### PR TITLE
FHIR integration POC

### DIFF
--- a/server/composer.json
+++ b/server/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "consolidation/robo": "^2.0"
+        "consolidation/robo": "^2.0",
+        "firebase/php-jwt": "^6.2"
     }
 }

--- a/server/composer.lock
+++ b/server/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1b4430d80267dba6f4dfee4d184fb39",
+    "content-hash": "c7a36218155e4fac79b4205770ae319f",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -489,6 +489,64 @@
                 "notation"
             ],
             "time": "2017-01-20T21:14:22+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "d28e6df83830252650da4623c78aaaf98fb385f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d28e6df83830252650da4623c78aaaf98fb385f3",
+                "reference": "d28e6df83830252650da4623c78aaaf98fb385f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1||^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "phpspec/prophecy-phpunit": "^1.1",
+                "phpunit/phpunit": "^7.5||^9.5",
+                "psr/cache": "^1.0||^2.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "time": "2022-05-13T20:54:50+00:00"
         },
         {
             "name": "grasmash/expander",
@@ -1132,12 +1190,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1204,12 +1262,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1274,12 +1332,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]

--- a/server/hedley/hedley.install
+++ b/server/hedley/hedley.install
@@ -627,3 +627,10 @@ function hedley_update_7031() {
 function hedley_update_7032() {
   module_enable(['views_litepager']);
 }
+
+/**
+ * Enable the FHIR integration module.
+ */
+function hedley_update_7033() {
+  module_enable(['hedley_fhir']);
+}

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.info
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.info
@@ -1,0 +1,8 @@
+name = Hedley FHIR
+description = FHIR related code
+core = 7.x
+package = Hedley
+dependencies[] = entityreference
+dependencies[] = hedley_person
+dependencies[] = node
+dependencies[] = text

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -15,6 +15,13 @@ function hedley_fhir_node_insert($node) {
 }
 
 /**
+ * Implements hook_node_update().
+ */
+function hedley_fhir_node_update($node) {
+  hedley_fhir_upload_to_datastore($node);
+}
+
+/**
  * Upload measurements to OpenMRS.
  *
  * @param object $node

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -26,7 +26,7 @@ function hedley_fhir_node_update($node) {
 }
 
 /**
- * Upload measurements to OpenMRS.
+ * Upload measurements to FHIR datastore.
  *
  * @param object $node
  *   The saved node.

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -5,7 +5,11 @@
  * Code for the FHIR integration.
  */
 
+
+include '/var/www/html/server/www/sites/all/vendor/autoload.php';
+
 use Firebase\JWT\JWT;
+
 
 /**
  * Implements hook_node_insert().
@@ -80,7 +84,7 @@ function hedley_fhir_upload_to_datastore($node) {
   // Only for create we use `v1beta1`, so we can have condition PUt or add
   // `If-None-Exist` header. Otherwise, we'll use `v1`
   $api_service = 'v1beta1';
-  $url = 'https://healthcare.googleapis.com/' . $api_service . '/projects/e-heza/locations/us-central1/datasets/my-dataset/fhirStores/my-fhir-store/fhir/Patient';
+  $url = 'https://healthcare.googleapis.com/' . $api_service . '/projects/e-heza/locations/us-central1/datasets/my-dataset/fhirStores/my-fhir-store/fhir';
 
   $options = [
     'method' => 'POST',
@@ -88,10 +92,11 @@ function hedley_fhir_upload_to_datastore($node) {
       'Content-Type' => 'application/fhir+json',
       'Authorization' => 'Bearer ' . $jwt_access_token,
     ],
-    'data' => $data,
+    'data' => drupal_json_encode($data),
   ];
 
   $response = drupal_http_request($url, $options);
+
   return $response;
 }
 

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @file
+ * Code for the FHIR integration.
+ */
+
+use Firebase\JWT\JWT;
+
+/**
+ * Implements hook_node_insert().
+ */
+function hedley_fhir_node_insert($node) {
+  hedley_fhir_upload_to_datastore($node);
+}
+/**
+ * Upload measurements to OpenMRS.
+ *
+ * @param object $node
+ *   The saved node.
+ */
+function hedley_fhir_upload_to_datastore($node) {
+  $func = 'hedley_fhir_prepare_data__' . $node->type;
+  if (!function_exists($func)) {
+    // Not a node type we need to upload.
+    return;
+  }
+
+  $wrapper = entity_metadata_wrapper('node', $node);
+
+  // The FHIR bundle resource.
+  $bundle = [
+    'resourceType' => 'Bundle',
+    'type' => 'transaction',
+    'entry' => [],
+  ];
+
+  $bundle['entry'][] = hedley_fhir_prepare_data__person($wrapper);
+  $bundle['entry'][] = $func($wrapper);
+
+}
+
+/**
+ * Prepare a Bundle resource entry for Person.
+ *
+ * @param \EntityMetadataWrapper $wrapper
+ *   The wrapped node.
+ *
+ * @return array
+ *   Entry to be added to the FHIR bundle resource.
+ */
+function hedley_fhir_prepare_data__person(EntityMetadataWrapper $wrapper) {
+  $person_wrapper = $wrapper->field_person;
+
+  $uuid = $person_wrapper->field_uuid->value();
+
+  return [
+    'fullUrl' => 'urn:uuid:' . $uuid,
+    'resource' => [
+      'resourceType' => 'Patient',
+      'identifier' => [
+        0 => [
+          'use' => 'usual',
+          'system' => 'https://e-heza.example/Patient',
+          'value' => $uuid,
+        ],
+      ],
+      'name' => [
+        0 => [
+          'family' => $person_wrapper->field_first_name->value(),
+          'given' => [
+            0 => $person_wrapper->field_first_name->value(),
+          ],
+        ],
+      ],
+      'gender' => $person_wrapper->field_gender->value(),
+    ],
+    'request' => [
+      'method' => 'PUT',
+      'url' => 'Patient?identifier=' . $uuid,
+    ],
+  ];
+}
+
+/**
+ * Prepare a Bundle resource entry for Observation of type Height.
+ *
+ * @param \EntityMetadataWrapper $wrapper
+ *   The wrapped node.
+ *
+ * @return array
+ *   Entry to be added to the FHIR bundle resource.
+ */
+function hedley_fhir_prepare_data__height(EntityMetadataWrapper $wrapper) {
+  $person_wrapper = $wrapper->field_person;
+  $person_uuid = $person_wrapper->field_uuid->value();
+
+  $uuid = $wrapper->field_uuid->value();
+  $value = $wrapper->field_height->value();
+
+  return [
+    'fullUrl' => 'urn:uuid:' . $uuid,
+    'resource' => [
+      'resourceType' => 'Observation',
+      'identifier' => [
+        0 => [
+          'use' => 'usual',
+          'system' => 'https://e-heza.example/Height',
+          'value' => $uuid,
+        ],
+      ],
+      'meta' => [
+        'profile' => [
+          0 => 'http://hl7.org/fhir/StructureDefinition/vitalsigns',
+        ],
+      ],
+      'status' => 'final',
+      'category' => [
+        0 => [
+          'coding' => [
+            0 => [
+              'system' => 'http://terminology.hl7.org/CodeSystem/observation-category',
+              'code' => 'vital-signs',
+              'display' => 'Vital Signs',
+            ],
+          ],
+          'text' => 'Vital Signs',
+        ],
+      ],
+      'code' => [
+        'coding' => [
+          0 => [
+            'system' => 'http://loinc.org',
+            'code' => '8302-2',
+            'display' => 'Body height',
+          ],
+        ],
+        'text' => 'Body height',
+      ],
+      'subject' => [
+        'reference' => 'Patient/' . $person_uuid,
+      ],
+      'effectiveDateTime' => date('Y-m-d', $wrapper->value()->updated),
+      'valueQuantity' => [
+        'value' => $value,
+        'unit' => 'cm',
+        'system' => 'http://unitsofmeasure.org',
+        'code' => '[cm]',
+      ],
+    ],
+    'request' => [
+      'method' => 'PUT',
+      'url' => 'Observation?identifier=' . $uuid,
+    ],
+  ];
+}

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -95,9 +95,7 @@ function hedley_fhir_upload_to_datastore($node) {
     'data' => drupal_json_encode($data),
   ];
 
-  $response = drupal_http_request($url, $options);
-
-  return $response;
+  return drupal_http_request($url, $options);
 }
 
 /**
@@ -127,7 +125,7 @@ function hedley_fhir_prepare_data__person(EntityMetadataWrapper $wrapper) {
       ],
       'name' => [
         0 => [
-          'family' => $person_wrapper->field_first_name->value(),
+          'family' => $person_wrapper->field_second_name->value(),
           'given' => [
             0 => $person_wrapper->field_first_name->value(),
           ],

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -13,31 +13,79 @@ use Firebase\JWT\JWT;
 function hedley_fhir_node_insert($node) {
   hedley_fhir_upload_to_datastore($node);
 }
+
 /**
  * Upload measurements to OpenMRS.
  *
  * @param object $node
  *   The saved node.
+ *
+ * @return StdClass|NULL
+ *   The response object, or NULL if it could not be sent.
+ *
+ * @throws \Exception
  */
 function hedley_fhir_upload_to_datastore($node) {
   $func = 'hedley_fhir_prepare_data__' . $node->type;
   if (!function_exists($func)) {
     // Not a node type we need to upload.
-    return;
+    return NULL;
   }
 
   $wrapper = entity_metadata_wrapper('node', $node);
 
   // The FHIR bundle resource.
-  $bundle = [
+  $data = [
     'resourceType' => 'Bundle',
     'type' => 'transaction',
     'entry' => [],
   ];
 
-  $bundle['entry'][] = hedley_fhir_prepare_data__person($wrapper);
-  $bundle['entry'][] = $func($wrapper);
+  $data['entry'][] = hedley_fhir_prepare_data__person($wrapper);
+  $data['entry'][] = $func($wrapper);
 
+  $private_key = variable_get('hedley_fhir_private_key');
+  $service_account_email = variable_get('hedley_fhir_service_account_email');
+
+  $project_id = variable_get('hedley_fhir_project_id');
+  $location = variable_get('hedley_fhir_location');
+  $dataset_id = variable_get('hedley_fhir_dataset_id');
+  $fhir_store_id = variable_get('hedley_fhir_fhir_store_id');
+
+  if (empty($private_key) || empty($service_account_email)) {
+    throw new Exception('Private key or Service account email are missing. They should be present in settings.php or settings.ddev.php');
+  }
+
+  if (empty($project_id) || empty($location) || empty($dataset_id) || empty($fhir_store_id)) {
+    throw new Exception('Project info of the cloud is missing');
+  }
+
+  $payload = [
+    'iss' => $service_account_email,
+    'sub'=> $service_account_email,
+    'aud'=> "https://healthcare.googleapis.com/",
+    'iat' => time(),
+    'exp' => time() + 3600,
+  ];
+
+  $jwt_access_token = JWT::encode($payload, $private_key, 'RS256');
+
+  // Only for create we use `v1beta1`, so we can have condition PUt or add
+  // `If-None-Exist` header. Otherwise, we'll use `v1`
+  $api_service = 'v1beta1';
+  $url = 'https://healthcare.googleapis.com/' . $api_service . '/projects/e-heza/locations/us-central1/datasets/my-dataset/fhirStores/my-fhir-store/fhir/Patient';
+
+  $options = [
+    'method' => 'POST',
+    'headers' => [
+      'Content-Type' => 'application/fhir+json',
+      'Authorization' => 'Bearer ' . $jwt_access_token,
+    ],
+    'data' => $data,
+  ];
+
+  $response = drupal_http_request($url, $options);
+  return $response;
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
+++ b/server/hedley/modules/custom/hedley_fhir/hedley_fhir.module
@@ -195,7 +195,7 @@ function hedley_fhir_prepare_data__height(EntityMetadataWrapper $wrapper) {
       'subject' => [
         'reference' => 'Patient/' . $person_uuid,
       ],
-      'effectiveDateTime' => date('Y-m-d', $wrapper->value()->updated),
+      'effectiveDateTime' => date('Y-m-d', $wrapper->value()->changed),
       'valueQuantity' => [
         'value' => $value,
         'unit' => 'cm',


### PR DESCRIPTION
Added a FHIR integration module, that upon creation or update of data, it uploads it to a FHIR datastore.


1. A child's height is created or updated

![image](https://user-images.githubusercontent.com/125707/175922230-e41acf62-4576-4449-8619-c17b3cc28c5d.png)

2. An HTTP request sends the relevant info. No duplicates are created, so only a single patient or observation would be created.

![image](https://user-images.githubusercontent.com/125707/175923854-06fa2f95-35ff-4333-b84d-c5fd09a198b9.png)


3. `Observation `created on Google cloud. It references our `Patient`

![image](https://user-images.githubusercontent.com/125707/175922676-fe2f5556-831a-494c-bf40-d22f81e3edd8.png)


4. And we have the `Patient` as well

![image](https://user-images.githubusercontent.com/125707/175960071-a4f268e9-a004-49c6-b652-eadf0a38c1c6.png)


Current PR assumes running it locally with DDEV, so one would need to have the following info under `settings.ddev.php` (ping me to get the _real_ values, as the ones here are dummy, for security reasons):

```
$conf['hedley_fhir_private_key'] = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA...Ce3McVRrHyM=\n-----END PRIVATE KEY-----\n";
$conf['hedley_fhir_service_account_email'] = 'foo@bar.iam.gserviceaccount.com';
$conf['hedley_fhir_project_id'] = 'bar;
$conf['hedley_fhir_location'] = 'us-central1';
$conf['hedley_fhir_dataset_id'] = 'some-dataset';
$conf['hedley_fhir_fhir_store_id'] = 'some-fhir-store';
```