### PR TITLE
Fix typo Error on the Diagnosis popup

### DIFF
--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -8734,7 +8734,7 @@ translationSet trans =
                     }
 
                 DiagnosisModerateAnemia ->
-                    { english = "Patient hshows signs of Mild to Moderate Anemia"
+                    { english = "Patient shows signs of Mild to Moderate Anemia"
                     , kinyarwanda = Nothing
                     }
 


### PR DESCRIPTION
[#265 Comment](https://github.com/TIP-Global-Health/eheza-app/issues/265#issuecomment-1180675250)