### PR TITLE
`admin/content` performance tweak

### DIFF
--- a/server/hedley/modules/custom/hedley_admin/admin_views_default/node.admin-content.inc
+++ b/server/hedley/modules/custom/hedley_admin/admin_views_default/node.admin-content.inc
@@ -46,7 +46,7 @@ $handler->display->display_options['style_options']['columns'] = array(
   'edit_node' => 'edit_node',
   'delete_node' => 'edit_node',
 );
-$handler->display->display_options['style_options']['default'] = 'changed';
+$handler->display->display_options['style_options']['default'] = '-1';
 $handler->display->display_options['style_options']['info'] = array(
   'views_bulk_operations' => array(
     'align' => '',

--- a/server/hedley/modules/custom/hedley_admin/hedley_admin.info
+++ b/server/hedley/modules/custom/hedley_admin/hedley_admin.info
@@ -6,6 +6,7 @@ dependencies[] = features
 dependencies[] = hedley_view_export
 dependencies[] = menu
 dependencies[] = views_data_export
+dependencies[] = views_litepager
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[menu_custom][] = main-menu

--- a/server/hedley/modules/custom/hedley_forms/hedley_forms.features.field_base.inc
+++ b/server/hedley/modules/custom/hedley_forms/hedley_forms.features.field_base.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * hedley_forms.features.field_base.inc

--- a/server/hedley/modules/custom/hedley_forms/hedley_forms.features.field_instance.inc
+++ b/server/hedley/modules/custom/hedley_forms/hedley_forms.features.field_instance.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * hedley_forms.features.field_instance.inc
@@ -20,6 +21,7 @@ function hedley_forms_field_default_field_instances() {
         'label' => 'above',
         'module' => 'date',
         'settings' => array(
+          'custom_date_format' => '',
           'format_type' => 'long',
           'fromto' => 'both',
           'multiple_from' => '',

--- a/server/hedley/modules/custom/hedley_forms/hedley_forms.features.inc
+++ b/server/hedley/modules/custom/hedley_forms/hedley_forms.features.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * hedley_forms.features.inc

--- a/server/hedley/modules/custom/hedley_forms/hedley_forms.features.user_permission.inc
+++ b/server/hedley/modules/custom/hedley_forms/hedley_forms.features.user_permission.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * hedley_forms.features.user_permission.inc

--- a/server/hedley/modules/custom/hedley_forms/hedley_forms.strongarm.inc
+++ b/server/hedley/modules/custom/hedley_forms/hedley_forms.strongarm.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * hedley_forms.strongarm.inc

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.features.field_base.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.features.field_base.inc
@@ -53,7 +53,11 @@ function hedley_patient_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_date_birth',
-    'indexes' => array(),
+    'indexes' => array(
+      'value' => array(
+        0 => 'value',
+      ),
+    ),
     'locked' => 0,
     'module' => 'date',
     'settings' => array(

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.features.field_instance.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.features.field_instance.inc
@@ -71,6 +71,7 @@ function hedley_patient_field_default_field_instances() {
         'label' => 'above',
         'module' => 'date',
         'settings' => array(
+          'custom_date_format' => '',
           'format_type' => 'long',
           'fromto' => 'both',
           'multiple_from' => '',
@@ -386,6 +387,7 @@ function hedley_patient_field_default_field_instances() {
         'label' => 'above',
         'module' => 'date',
         'settings' => array(
+          'custom_date_format' => '',
           'format_type' => 'long',
           'fromto' => 'both',
           'multiple_from' => '',

--- a/server/hedley/modules/custom/hedley_view_export/hedley_view_export.features.inc
+++ b/server/hedley/modules/custom/hedley_view_export/hedley_view_export.features.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * hedley_view_export.features.inc
+ */
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function hedley_view_export_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "strongarm" && $api == "strongarm") {
+    return array("version" => "1");
+  }
+}

--- a/server/hedley/modules/custom/hedley_view_export/hedley_view_export.module
+++ b/server/hedley/modules/custom/hedley_view_export/hedley_view_export.module
@@ -2,6 +2,13 @@
 
 /**
  * @file
+ * Code for the Hedley view export feature.
+ */
+
+include_once 'hedley_view_export.features.inc';
+
+/**
+ * @file
  * Export views with advanced queue.
  */
 


### PR DESCRIPTION
#2971

By default, no sorting is applied:
![image](https://user-images.githubusercontent.com/114076/185870001-7bbec252-3d9a-4e7c-a13b-1b22b7f7e571.png)
