### PR TITLE
Drop 'Discordant Couple'  HIV status

### DIFF
--- a/client/src/elm/Backend/Person/Decoder.elm
+++ b/client/src/elm/Backend/Person/Decoder.elm
@@ -60,9 +60,6 @@ decodeHivStatus =
                     "negative" ->
                         succeed Negative
 
-                    "negative-dc" ->
-                        succeed NegativeDiscordantCouple
-
                     "positive" ->
                         succeed Positive
 

--- a/client/src/elm/Backend/Person/Model.elm
+++ b/client/src/elm/Backend/Person/Model.elm
@@ -37,7 +37,6 @@ type alias Person =
 type HIVStatus
     = HIVExposedInfant
     | Negative
-    | NegativeDiscordantCouple
     | Positive
     | Unknown
 
@@ -46,7 +45,6 @@ allHivStatuses : List HIVStatus
 allHivStatuses =
     [ HIVExposedInfant
     , Negative
-    , NegativeDiscordantCouple
     , Positive
     , Unknown
     ]

--- a/client/src/elm/Backend/Person/Utils.elm
+++ b/client/src/elm/Backend/Person/Utils.elm
@@ -265,9 +265,6 @@ hivStatusToString status =
         Negative ->
             "negative"
 
-        NegativeDiscordantCouple ->
-            "negative-dc"
-
         Positive ->
             "positive"
 

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -6337,12 +6337,6 @@ translationSet trans =
                 Negative ->
                     translationSet NegativeLabel
 
-                NegativeDiscordantCouple ->
-                    { english = "Negative - discordant couple"
-                    , kinyarwanda = Just "Nta bwandu afite ariko abana n'ubufite"
-                    , kirundi = Just "Umugwayi ata mugera wa Sida afise ariko mugenziwe ayifise"
-                    }
-
                 Positive ->
                     { english = "Positive"
                     , kinyarwanda = Just "Afite ubwandu"

--- a/server/hedley/modules/custom/hedley_migrate/hedley_migrate.module
+++ b/server/hedley/modules/custom/hedley_migrate/hedley_migrate.module
@@ -557,7 +557,6 @@ function _hedley_migrate_preprocess_mother($node, Generator $faker) {
   $hiv_status = [
     'hiv-exposed-infant',
     'negative',
-    'negative-dc',
     'positive',
     'unknown',
   ];

--- a/server/hedley/modules/custom/hedley_migrate/scripts/export-patients.php
+++ b/server/hedley/modules/custom/hedley_migrate/scripts/export-patients.php
@@ -106,10 +106,6 @@ while ($processed < $total) {
         $hiv_status = 'negative';
         break;
 
-      case 'negative-dc':
-        $hiv_status = 'negative - discordant couple';
-        break;
-
       case 'positive':
         $hiv_status = 'positive';
         break;

--- a/server/hedley/modules/custom/hedley_person/hedley_person.features.field_base.inc
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.features.field_base.inc
@@ -241,7 +241,6 @@ function hedley_person_field_default_field_bases() {
       'allowed_values' => array(
         'hiv-exposed-infant' => 'HIV-exposed infant',
         'negative' => 'Negative',
-        'negative-dc' => 'Negative - discordant couple',
         'positive' => 'Positive',
         'unknown' => 'Unknown',
       ),

--- a/server/hedley/modules/custom/hedley_person/hedley_person.module
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.module
@@ -575,7 +575,6 @@ function hedley_person_validate_patient_fields($patient_type, array $values, arr
   $valid_values = [
     'hiv-exposed infant',
     'negative',
-    'negative - discordant couple',
     'positive',
     'unknown',
   ];
@@ -768,10 +767,6 @@ function hedley_person_import_patient($patient_type, array $values) {
 
       case 'negative':
         $wrapper->field_hiv_status->set('negative');
-        break;
-
-      case 'negative - discordant couple':
-        $wrapper->field_hiv_status->set('negative-dc');
         break;
 
       case 'positive':


### PR DESCRIPTION
#921

**Deployment note:** We need to understand what happens to existing patients that for 'Discordant Couple' HIV status set.
We'll need to edit those patients, so that `person` node is saved (to generate new revision). This way change will get synced to the devices. It will not happen if we run sql command at DB.

Only when this is implemented, we can deploy.