### PR TITLE
[Hotfix] Dashboards stats - hide Referred to hospital card on AI Covid page

### DIFF
--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -935,14 +935,18 @@ viewCovid19Page language isChw encounters managedCovid model =
 
     else
         let
-            sentToHospital =
-                -- @todo
-                0
+            -- Not viewd for now, as https://github.com/TIP-Global-Health/eheza-app/issues/959 is on hold.
+            hospitalReferralsCard =
+                let
+                    -- @todo: implement once issue is off hold.
+                    sentToHospital =
+                        0
+                in
+                chwCard language (Translate.Dashboard Translate.HospitalReferrals) (String.fromInt sentToHospital)
         in
         [ div [ class "ui grid" ]
-            [ div [ class "two column row" ]
-                [ chwCard language (Translate.Dashboard Translate.HospitalReferrals) (String.fromInt sentToHospital)
-                , chwCard language (Translate.Dashboard Translate.PatientsManagedAtHome) (String.fromInt managedAtHome)
+            [ div [ class "two column row center" ]
+                [ chwCard language (Translate.Dashboard Translate.PatientsManagedAtHome) (String.fromInt managedAtHome)
                 ]
             ]
         ]


### PR DESCRIPTION
We have delivered Dashboards, but don't have Acute Illness - Covid - Hospital referrals implemented for nurse, as it was put on hold per https://github.com/TIP-Global-Health/eheza-app/issues/959#issuecomment-1837629166 .
