### PR TITLE
Refactor Dockerfile to be more robust - layer caching issue

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -1,8 +1,17 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-RUN apt-get update || true
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests inotify-tools build-essential mime-support
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      -o Dpkg::Options::="--force-confold" \
+      --no-install-recommends \
+      --no-install-suggests \
+      inotify-tools \
+      build-essential \
+      mime-support; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then \
       DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests autoconf autotools-dev automake; \


### PR DESCRIPTION
Fixes Docker build failures caused by outdated cached layers referencing non-existing package URLs.

## Changes
- Combine apt-get update and install into single RUN statement to prevent layer caching issues
- Remove `|| true` which masked errors
- Add `set -eux` for better error handling
- Add cleanup steps (`apt-get clean`, `rm -rf /var/lib/apt/lists/*`) to reduce image size
- Format package list for better readability

This ensures the Docker build remains stable even when intermediate layers are outdated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)