### PR TITLE
Add cron job to prune `cache_field`

### DIFF
--- a/server/hedley/modules/custom/hedley_general/hedley_general.module
+++ b/server/hedley/modules/custom/hedley_general/hedley_general.module
@@ -545,6 +545,22 @@ function hedley_general_file_insert($file) {
 }
 
 /**
+ * Implements hook_cron().
+ *
+ * Prune cache_field entries older than 30 days to prevent unbounded growth.
+ */
+function hedley_general_cron() {
+  $threshold = REQUEST_TIME - 30 * 24 * 60 * 60;
+  $deleted = db_delete('cache_field')
+    ->condition('created', $threshold, '<')
+    ->execute();
+
+  if ($deleted) {
+    watchdog('hedley_general', 'Pruned @count old entries from cache_field.', ['@count' => $deleted]);
+  }
+}
+
+/**
  * Build Elm application for aggregated NCDA.
  *
  * @param string $page


### PR DESCRIPTION
Add hook_cron to hedley_general that deletes cache_field entries older than 30 days, preventing unbounded table growth.