### PR TITLE
Prune advancedqueue entries older than 6 months in cron

### DIFF
--- a/server/hedley/modules/custom/hedley_general/hedley_general.module
+++ b/server/hedley/modules/custom/hedley_general/hedley_general.module
@@ -547,7 +547,7 @@ function hedley_general_file_insert($file) {
 /**
  * Implements hook_cron().
  *
- * Prune cache_field entries older than 30 days to prevent unbounded growth.
+ * Prune old cache_field and advancedqueue entries to prevent unbounded growth.
  */
 function hedley_general_cron() {
   $threshold = REQUEST_TIME - 30 * 24 * 60 * 60;
@@ -557,6 +557,16 @@ function hedley_general_cron() {
 
   if ($deleted) {
     watchdog('hedley_general', 'Pruned @count old entries from cache_field.', ['@count' => $deleted]);
+  }
+
+  // Remove queue items older than 6 months.
+  $threshold = REQUEST_TIME - 6 * 30 * 24 * 60 * 60;
+  $deleted = db_delete('advancedqueue')
+    ->condition('created', $threshold, '<')
+    ->execute();
+
+  if ($deleted) {
+    watchdog('hedley_general', 'Pruned @count old entries from advancedqueue.', ['@count' => $deleted]);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add cleanup of `advancedqueue` table entries older than 6 months to the existing `hedley_general_cron()`, preventing unbounded queue growth.