### PR TITLE
Add Case Management follow-up verification to E2E tests

### DIFF
--- a/client/e2e/acute-illness-encounter-chw.spec.ts
+++ b/client/e2e/acute-illness-encounter-chw.spec.ts
@@ -181,6 +181,17 @@ test.describe('CHW: Acute Illness Initial + Subsequent Encounter', () => {
     expect(initialNodes['acute_illness_vitals']).toBe(true);
     expect(initialNodes['malaria_testing']).toBe(true);
 
+    // --- Case Management verification ---
+    // After initial encounter, the follow-up should appear in CM.
+    // (Must verify before subsequent encounter, which concludes the illness.)
+    await navigateToCaseManagement(page);
+    await verifyCaseManagementEntry(
+      page,
+      'Acute Illness',
+      'Acute Illness Follow Up',
+      fullName,
+    );
+
     // === PART 2: CHW Subsequent Encounter ===
 
     // Backdate initial encounter to allow subsequent.
@@ -242,15 +253,5 @@ test.describe('CHW: Acute Illness Initial + Subsequent Encounter', () => {
 
     expect(subsequentNodes['acute_illness_danger_signs']).toBe(true);
     expect(subsequentNodes['treatment_ongoing']).toBe(true);
-
-    // --- Case Management verification ---
-    // The subsequent encounter created a follow-up. Verify it appears in CM.
-    await navigateToCaseManagement(page);
-    await verifyCaseManagementEntry(
-      page,
-      'Acute Illness',
-      'Acute Illness Follow Up',
-      fullName,
-    );
   });
 });

--- a/client/e2e/acute-illness-encounter-chw.spec.ts
+++ b/client/e2e/acute-illness-encounter-chw.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { setupDevice } from './helpers/auth';
+import {
+  navigateToCaseManagement,
+  verifyCaseManagementEntry,
+} from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import {
@@ -238,5 +242,15 @@ test.describe('CHW: Acute Illness Initial + Subsequent Encounter', () => {
 
     expect(subsequentNodes['acute_illness_danger_signs']).toBe(true);
     expect(subsequentNodes['treatment_ongoing']).toBe(true);
+
+    // --- Case Management verification ---
+    // The subsequent encounter created a follow-up. Verify it appears in CM.
+    await navigateToCaseManagement(page);
+    await verifyCaseManagementEntry(
+      page,
+      'Acute Illness',
+      'Acute Illness Follow Up',
+      fullName,
+    );
   });
 });

--- a/client/e2e/helpers/case-management.ts
+++ b/client/e2e/helpers/case-management.ts
@@ -26,9 +26,10 @@ export async function verifyCaseManagementEntry(
   paneHeadingText: string,
   patientName: string,
 ) {
-  // Click the filter button.
+  // Click the filter button. Escape filterText to avoid regex metacharacter issues.
+  const escaped = filterText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const filterBtn = page.locator('div.ui.segment.filters button', {
-    hasText: new RegExp(filterText, 'i'),
+    hasText: new RegExp(escaped, 'i'),
   });
   await click(filterBtn, page);
   await page.waitForTimeout(500);
@@ -39,8 +40,10 @@ export async function verifyCaseManagementEntry(
   });
   await expect(paneHeading).toBeVisible({ timeout: 5000 });
 
-  // Verify follow-up entry with patient name exists.
-  const entry = page.locator('div.follow-up-entry', {
+  // Scope entry search to the pane containing the heading to avoid
+  // false positives when multiple panes are visible.
+  const pane = page.locator('div.pane', { has: paneHeading });
+  const entry = pane.locator('div.follow-up-entry', {
     hasText: patientName,
   });
   await expect(entry).toBeVisible({ timeout: 5000 });
@@ -56,10 +59,11 @@ export async function verifyFollowUpDialog(
   page: Page,
   patientName: string,
 ) {
-  // Find the entry and click its forward icon.
+  // Find the first matching entry and click its forward icon.
   const entry = page.locator('div.follow-up-entry', {
     hasText: patientName,
-  });
+  }).first();
+  await expect(entry).toBeVisible({ timeout: 5000 });
   await click(entry.locator('.icon-forward'), page);
 
   // Verify dialog appears with patient name.

--- a/client/e2e/helpers/case-management.ts
+++ b/client/e2e/helpers/case-management.ts
@@ -1,0 +1,73 @@
+import { expect, Page } from '@playwright/test';
+import { click } from './auth';
+
+/**
+ * Navigate to Case Management from the main menu (PinCodePage when logged in).
+ * Works for all roles (nurse, CHW, lab tech).
+ */
+export async function navigateToCaseManagement(page: Page) {
+  await click(page.locator('.icon-task-case-management'), page);
+  await page.locator('.page-case-management').waitFor({ timeout: 10000 });
+  await page.waitForTimeout(500);
+}
+
+/**
+ * Verify that a Case Management pane is visible with the expected heading,
+ * and that a follow-up entry for the given patient name exists within it.
+ *
+ * @param filterText - Button text to click (e.g., "Home Visit", "Acute Illness").
+ *                     Case-insensitive match since CSS uppercases the text.
+ * @param paneHeadingText - Expected pane heading text (e.g., "Child Nutrition Follow Up").
+ * @param patientName - The patient's display name to look for in follow-up entries.
+ */
+export async function verifyCaseManagementEntry(
+  page: Page,
+  filterText: string,
+  paneHeadingText: string,
+  patientName: string,
+) {
+  // Click the filter button.
+  const filterBtn = page.locator('div.ui.segment.filters button', {
+    hasText: new RegExp(filterText, 'i'),
+  });
+  await click(filterBtn, page);
+  await page.waitForTimeout(500);
+
+  // Verify pane heading is visible.
+  const paneHeading = page.locator('div.pane-heading', {
+    hasText: paneHeadingText,
+  });
+  await expect(paneHeading).toBeVisible({ timeout: 5000 });
+
+  // Verify follow-up entry with patient name exists.
+  const entry = page.locator('div.follow-up-entry', {
+    hasText: patientName,
+  });
+  await expect(entry).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Verify that clicking the forward icon on a follow-up entry opens
+ * the follow-up encounter dialog with the patient's name, then dismiss it.
+ *
+ * @param patientName - The patient's display name to find in the entry.
+ */
+export async function verifyFollowUpDialog(
+  page: Page,
+  patientName: string,
+) {
+  // Find the entry and click its forward icon.
+  const entry = page.locator('div.follow-up-entry', {
+    hasText: patientName,
+  });
+  await click(entry.locator('.icon-forward'), page);
+
+  // Verify dialog appears with patient name.
+  const modal = page.locator('div.ui.active.modal');
+  await expect(modal).toBeVisible({ timeout: 5000 });
+  await expect(modal.locator('.person-name')).toHaveText(patientName);
+
+  // Dismiss by clicking "No".
+  await click(modal.locator('button', { hasText: 'No' }), page);
+  await modal.waitFor({ state: 'hidden', timeout: 5000 });
+}

--- a/client/e2e/hiv-encounter-chw.spec.ts
+++ b/client/e2e/hiv-encounter-chw.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { setupDevice } from './helpers/auth';
+import {
+  navigateToCaseManagement,
+  verifyCaseManagementEntry,
+} from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import {
@@ -78,6 +82,17 @@ test.describe('CHW: HIV Initial Encounter — Positive Diagnosis', () => {
     expect(nodes['hiv_referral']).toBe(false);
     // No symptom review in initial encounter.
     expect(nodes['hiv_symptom_review']).toBe(false);
+
+    // --- Case Management verification ---
+    // The HIV follow-up should appear in the HIV pane (feature-flag gated).
+    await navigateToCaseManagement(page);
+    const hivFilter = page.locator('div.ui.segment.filters button', {
+      hasText: /HIV/i,
+    });
+    // HIV filter is feature-flag dependent; only assert if visible.
+    if (await hivFilter.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await verifyCaseManagementEntry(page, 'HIV', 'HIV', fullName);
+    }
   });
 });
 

--- a/client/e2e/lab-tech-encounter.spec.ts
+++ b/client/e2e/lab-tech-encounter.spec.ts
@@ -92,6 +92,14 @@ test.describe('Lab Tech: Enter Lab Results via Case Management', () => {
     // Navigate to Case Management.
     await navigateToCaseManagement(page);
 
+    // Verify Lab Tech Case Management structure: only 2 filter buttons (All + ANC Labs).
+    const filterButtons = page.locator('div.ui.segment.filters button');
+    await expect(filterButtons).toHaveCount(2);
+    // Verify ANC Labs pane heading is visible.
+    await expect(
+      page.locator('div.pane-heading', { hasText: 'ANC Labs' }),
+    ).toBeVisible({ timeout: 5000 });
+
     // Find the patient in the Prenatal Labs pane.
     const entry = page.locator('.follow-up-entry', {
       has: page.locator('.name', { hasText: fullName }),

--- a/client/e2e/ncd-encounter-nurse.spec.ts
+++ b/client/e2e/ncd-encounter-nurse.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { setupDevice } from './helpers/auth';
+import { verifyCaseManagementEntry } from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import {
@@ -364,6 +365,9 @@ test.describe('Nurse: NCD Recurrent Encounter — Lab Results', () => {
 
     // Navigate to Case Management and find patient in NCD Labs pane.
     await navigateToCaseManagement(page);
+
+    // Verify Case Management: NCD Labs pane shows entry for this patient.
+    await verifyCaseManagementEntry(page, 'NCD Labs', 'NCD Labs', fullName);
 
     // Open the recurrent encounter.
     await openNCDRecurrentEncounterFromCaseManagement(page, fullName);

--- a/client/e2e/nutrition-encounter-chw.spec.ts
+++ b/client/e2e/nutrition-encounter-chw.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { click, setupDevice } from './helpers/auth';
+import {
+  navigateToCaseManagement,
+  verifyCaseManagementEntry,
+  verifyFollowUpDialog,
+} from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import {
@@ -126,5 +131,18 @@ test.describe('CHW: Individual Nutrition Encounter', () => {
     expect(nodes.healthEducation).toBe(true);
     expect(nodes.contributingFactors).toBe(true);
     expect(nodes.followUp).toBe(true);
+
+    // --- Case Management verification ---
+    // Navigate to Case Management and verify the nutrition follow-up entry appears.
+    await navigateToCaseManagement(page);
+    await verifyCaseManagementEntry(
+      page,
+      'Home Visit',
+      'Child Nutrition Follow Up',
+      fullName,
+    );
+
+    // Verify follow-up dialog: click forward icon, assert modal with name, dismiss.
+    await verifyFollowUpDialog(page, fullName);
   });
 });

--- a/client/e2e/prenatal-encounter-chw.spec.ts
+++ b/client/e2e/prenatal-encounter-chw.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { setupDevice } from './helpers/auth';
+import {
+  navigateToCaseManagement,
+  verifyCaseManagementEntry,
+} from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/nutrition';
@@ -64,6 +68,16 @@ test.describe('CHW: Prenatal First Encounter', () => {
     // and prenatal_follow_up should exist with no danger signs).
     expect(nodes['appointment_confirmation']).toBe(true);
     expect(nodes['prenatal_follow_up']).toBe(true);
+
+    // --- Case Management verification ---
+    // The prenatal follow-up should appear in the Antenatal Care pane.
+    await navigateToCaseManagement(page);
+    await verifyCaseManagementEntry(
+      page,
+      'Antenatal Care',
+      'Antenatal Care',
+      fullName,
+    );
   });
 });
 

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { setupDevice } from './helpers/auth';
+import { verifyCaseManagementEntry } from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/nutrition';
@@ -360,6 +361,9 @@ test.describe('Nurse: Prenatal Recurrent Encounter (BP Recheck)', () => {
 
     // Navigate to Case Management from the nurse menu.
     await navigateToCaseManagement(page);
+
+    // Verify Case Management: ANC Labs pane shows entry for this patient.
+    await verifyCaseManagementEntry(page, 'ANC Labs', 'ANC Labs', fullName);
 
     // Find the patient in the Prenatal Labs pane and open the recurrent encounter.
     await openRecurrentEncounterFromCaseManagement(page, fullName);

--- a/client/e2e/tuberculosis-encounter-chw.spec.ts
+++ b/client/e2e/tuberculosis-encounter-chw.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { setupDevice } from './helpers/auth';
+import {
+  navigateToCaseManagement,
+  verifyCaseManagementEntry,
+} from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import {
@@ -82,6 +86,22 @@ test.describe('CHW: Tuberculosis Initial Encounter — Positive Diagnosis', () =
     expect(nodes['tuberculosis_referral']).toBe(false);
     // No symptom review in initial encounter.
     expect(nodes['tuberculosis_symptom_review']).toBe(false);
+
+    // --- Case Management verification ---
+    // The TB follow-up should appear in the Tuberculosis pane (feature-flag gated).
+    await navigateToCaseManagement(page);
+    const tbFilter = page.locator('div.ui.segment.filters button', {
+      hasText: /Tuberculosis/i,
+    });
+    // TB filter is feature-flag dependent; only assert if visible.
+    if (await tbFilter.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await verifyCaseManagementEntry(
+        page,
+        'Tuberculosis',
+        'Tuberculosis',
+        fullName,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Extend 8 existing E2E tests to verify that follow-up entries appear correctly in the Global Case Management page after encounter sync
- Add shared `case-management.ts` helper with `navigateToCaseManagement()`, `verifyCaseManagementEntry()`, and `verifyFollowUpDialog()`
- Previously, tests only verified backend node creation but never checked that the frontend correctly computes and displays follow-up entries in Case Management

## What's verified

**Nurse (Tier 1 — assertions added to tests already navigating CM):**
- ✅ `prenatal-encounter-nurse` test 3: ANC Labs pane heading + entry with patient name
- ✅ `ncd-encounter-nurse` test 3: NCD Labs pane heading + entry with patient name
- ✅ `lab-tech-encounter`: filter bar has exactly 2 buttons (All + ANC Labs) + pane heading

**CHW (Tier 2 — CM navigation + assertions added after sync):**
- ✅ `nutrition-encounter-chw` test 2: Home Visit filter → "Child Nutrition Follow Up" pane + entry + **follow-up dialog click-through** (open modal, verify patient name, dismiss)
- ✅ `acute-illness-encounter-chw` test 2: Acute Illness filter → "Acute Illness Follow Up" pane + entry (verified after initial encounter, before subsequent concludes illness)
- ✅ `hiv-encounter-chw` test 1: HIV filter (feature-flag guarded) → HIV pane + entry
- ✅ `tuberculosis-encounter-chw` test 1: Tuberculosis filter (feature-flag guarded) → Tuberculosis pane + entry
- ✅ `prenatal-encounter-chw` test 1: Antenatal Care filter → "Antenatal Care" pane + entry

**Not covered (out of scope):**
- ❌ Contact Tracing (requires COVID diagnosis + contact form, currently unimplemented in E2E helpers)

## Test plan

- [x] All 8 modified tests pass locally (headless)
- [x] CI: `e2e_playwright_1` passes
- [x] CI: `e2e_playwright_2` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)