### PR TITLE
Translate.elm: dedup duplicate translations + reorder case branches

### DIFF
--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -1057,6 +1057,7 @@ type TranslationId
     | NCDLabs
     | NoDiagnosis
     | OralPolioVaccineOPV
+    | OtherLabel
     | Paralysis
     | PatientDeclined
     | PatientShowsSignsOfHighRiskForPreclampsia
@@ -2877,11 +2878,7 @@ translationSet trans =
                     }
 
                 OutcomeOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
         AddChild ->
             { english = "Add Child"
@@ -3511,11 +3508,7 @@ translationSet trans =
                     translationSet Fatigue
 
                 AdverseEventOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoAdverseEvent ->
                     translationSet NoneOfTheAbove
@@ -3622,11 +3615,7 @@ translationSet trans =
                     }
 
                 AhezaDistributionReasonOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 AhezaDistributionReasonPregnant ->
                     { english = "Patient is pregnant"
@@ -3883,11 +3872,7 @@ translationSet trans =
                     }
 
                 AvoidingGuidanceHypertensionOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
         Azithromycin2g ->
             { english = "Azithromycin (2g)"
@@ -5465,11 +5450,7 @@ translationSet trans =
                     }
 
                 ComplicationOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoDeliveryComplications ->
                     translationSet NoneOfThese
@@ -5607,11 +5588,7 @@ translationSet trans =
                     translationSet None
 
                 Other ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 PreviousCSection ->
                     { english = "Previous c-section"
@@ -6070,11 +6047,7 @@ translationSet trans =
                     }
 
                 DistributedPartiallyOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Izindi mpamvu"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
         District ->
             { english = "District"
@@ -7240,6 +7213,13 @@ translationSet trans =
             , kinyarwanda = Just "Urukingo rw'imbasa rutangwa mu kanwa"
             , kirundi = Just "Urucanco rw'ubukangwe (amama)"
             , somali = Just "Tallaalka Afka ee Dabeysha (OPV)"
+            }
+
+        OtherLabel ->
+            { english = "Other"
+            , kinyarwanda = Just "Ibindi"
+            , kirundi = Just "Ibindi"
+            , somali = Just "Kale"
             }
 
         Paralysis ->
@@ -9173,11 +9153,7 @@ translationSet trans =
                     translationSet PatientRefused
 
                 HIVTreatmentNoMedicineOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 -- We do not require translation for other signs.
                 _ ->
@@ -12534,11 +12510,7 @@ translationSet trans =
                     }
 
                 MedicalConditionOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoMedicalConditions ->
                     { english = "None of the Above"
@@ -15124,11 +15096,7 @@ translationSet trans =
                     translationSet NotIndicated
 
                 ReasonForNonReferralOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoReasonForNonReferral ->
                     { english = "No Reason"
@@ -15166,11 +15134,7 @@ translationSet trans =
                     translationSet TooSick
 
                 NonAdministrationOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 AdministeredToday ->
                     { english = "Administered Today"
@@ -15208,11 +15172,7 @@ translationSet trans =
                     translationSet TooSick
 
                 NonAdministrationOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 -- Other options are not relevant for Immunisation.
                 _ ->
@@ -15244,11 +15204,7 @@ translationSet trans =
                     translationSet TooSick
 
                 NonAdministrationOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 -- Other options are not relevant for Immunisation.
                 _ ->
@@ -17594,11 +17550,7 @@ translationSet trans =
                     translationSet ModerateRiskOfPreeclampsia
 
                 DiagnosisOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 DiagnosisPostpartumAbdominalPain ->
                     translationSet AbdominalPainLabel
@@ -18515,11 +18467,7 @@ translationSet trans =
                     }
 
                 DiagnosisOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 -- Non Not Urgent diagnoses.
                 _ ->
@@ -20626,11 +20574,7 @@ translationSet trans =
                     }
 
                 NotBreastfeedingOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 _ ->
                     translationSet EmptyString
@@ -20659,11 +20603,7 @@ translationSet trans =
                     }
 
                 OtherReason ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ikindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 IsolationReasonNotApplicable ->
                     translationSet NotApplicable
@@ -20739,11 +20679,7 @@ translationSet trans =
                     }
 
                 NotTakingOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoReasonForNotTakingSign ->
                     translationSet EmptyString
@@ -20832,11 +20768,7 @@ translationSet trans =
                     }
 
                 OtherRecommendation114 ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoneNoAnswer ->
                     { english = "No answer"
@@ -20853,11 +20785,7 @@ translationSet trans =
                     }
 
                 NoneOtherRecommendation114 ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
         RecommendationSite recommendation ->
             case recommendation of
@@ -20876,11 +20804,7 @@ translationSet trans =
                     }
 
                 OtherRecommendationSite ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 NoneSentWithForm ->
                     { english = "No response. Sent patient with referral form."
@@ -20893,11 +20817,7 @@ translationSet trans =
                     translationSet PatientRefused
 
                 NoneOtherRecommendationSite ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
                 RecommendationSiteNotApplicable ->
                     translationSet NotApplicable
@@ -26184,11 +26104,7 @@ translationSet trans =
                     }
 
                 ReasonOther ->
-                    { english = "Other"
-                    , kinyarwanda = Just "Ibindi"
-                    , kirundi = Just "Ibindi"
-                    , somali = Just "Kale"
-                    }
+                    translationSet OtherLabel
 
         StockManagement ->
             { english = "Stock Management"

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -329,6 +329,7 @@ type Dashboard
 type TranslationId
     = Abdomen
     | AbdomenCPESign AbdomenCPESign
+    | AbdominalPainLabel
     | Abnormal
     | Abortions
     | Accept
@@ -412,10 +413,12 @@ type TranslationId
     | AgeSingleMonthWithoutDay Int
     | AgeSingleDayWithMonth Int Int
     | AgeSingleDayWithoutMonth Int
+    | AHEZA
     | AhezaActivityHelper
     | AhezaChild
     | AhezaDistributionReason AhezaDistributionReason
     | AhezaMother
+    | AlbendazoleLabel
     | AlertChwToFollowUp
     | AgeOneYearOld
     | AgeOneYearAndOneMonth
@@ -427,6 +430,7 @@ type TranslationId
     | AllowedValuesRangeHelper FloatInputConstraints
     | AlmostEveryday
     | AmbulanceArrivalPeriodQuestion
+    | Amlodipine5mg
     | ANCEncountersNotRecordedQuestion
     | ANCIndicateVisitsMonthsPhrase
     | ANCNewborn
@@ -444,6 +448,7 @@ type TranslationId
     | At
     | Attendance
     | AvoidingGuidanceReason AvoidingGuidanceReason
+    | Azithromycin2g
     | Baby
     | Back
     | BackendError
@@ -452,6 +457,7 @@ type TranslationId
     | BaselineWeight Float
     | BaselineWeightNotFound
     | BatchNumberAbbrev
+    | BloodGroup
     | BreastfeedingSignQuestion BreastfeedingSign
     | BeatsPerMinuteUnitLabel
     | BeginNewEncounter
@@ -488,9 +494,11 @@ type TranslationId
     | ByMouthDailyForXDays Int
     | ByMouthTwiceADayForXDays Int
     | ByMouthThreeTimesADayForXDays Int
+    | CalciumLabel
     | Call114
     | Called114Question
     | Cancel
+    | Candidiasis
     | CandidiasisRecommendedTreatmentHeader
     | CandidiasisRecommendedTreatmentHelper
     | CannotStartEncounterLabel
@@ -498,9 +506,11 @@ type TranslationId
     | CaregiverAccompanyQuestion
     | CaregiverMessage
     | Caring
+    | Carvedilol625mg
     | CaseManagement
     | CaseManagementFilterLabel CaseManagementFilter
     | CaseManagementPaneHeader CaseManagementFilter
+    | Ceftriaxone1g
     | Celsius
     | CelsiusAbbrev
     | Cell
@@ -523,6 +533,8 @@ type TranslationId
     | ChildScorecard
     | ChildWellness
     | ChooseOne
+    | ChronicHypertension
+    | CHW
     | CHWAction CHWAction
     | ChwActivity
     | Clear
@@ -543,6 +555,8 @@ type TranslationId
     | CompleteFacilityReferralForm ReferralFacility
     | CompletionDate
     | ConditionsDuringPreviousPregnancy
+    | Connecting
+    | ConstipationLabel
     | Contacted114
     | ContactedHC
     | ContactedHCQuestion
@@ -555,14 +569,33 @@ type TranslationId
     | ContactWithCOVID19SymptomsQuestion
     | Continued
     | ContributingFactor ContributingFactorsSign
+    | ContributingFactors
     | ContributingFactorsQuestion
     | ConvulsionsAndUnconsciousPreviousDelivery
+    | ConvulsionsLabel
     | ConvulsionsPreviousDelivery
+    | CorePhysicalExamLabel
+    | COVID19WithSignsOfPneumonia
+    | Creatinine
     | CSection
     | CSectionFor
     | CSectionScar CSectionScar
     | CurrentMedication
     | Dashboard Dashboard
+    | DepressionNotLikely
+    | DepressionPossible
+    | DiplomaProgram2YearsOfUniversity
+    | DiscordantPartnership
+    | DTPHepBHib
+    | EarlyMastitisOrEngorgement
+    | EnterTheAmountOfCSBFBFDistributedBelow
+    | Erythromycin500mg
+    | ExcessiveBleeding
+    | FairlyHighPossibilityOfDepression
+    | FeverOfUnknownOriginLabel
+    | GiveTheChildOneTabletByMouth
+    | Glipenclamide5mg
+    | Gonorrhea
     | Group
     | Groups
     | Close
@@ -761,7 +794,12 @@ type TranslationId
     | HandPallor
     | Hands
     | HandsCPESign HandsCPESign
+    | HardlyEver
+    | HaveYouCounseledPatientOnPositiveHIVTestMeaning
+    | HaveYouCounseledPatientOnSaferSexPractices
+    | HaveYouEncouragedThePatientsPartnerToGetTested
     | HbA1c
+    | HBA1C
     | HbA1cPercentage
     | HbA1cMostRecentTestResultInstruction
     | HCRecommendation HCRecommendation
@@ -781,6 +819,7 @@ type TranslationId
     | HealthTopics
     | HealthTopicsQuestion
     | Heart
+    | HeartburnLabel
     | HeartburnReliefMethod HeartburnReliefMethod
     | HeartburnRecommendedTreatmentHeader
     | HeartburnRecommendedTreatmentHelper
@@ -789,14 +828,18 @@ type TranslationId
     | HeartRate
     | HeartRateNotAudible
     | Height
+    | Hello
+    | HemoglobinTestHistory
     | High
     | HighRiskCase
     | HighRiskCaseHelper
     | HighRiskFactor HighRiskFactor
     | HighRiskFactors
+    | HighRiskOfPreeclampsia
     | HighSeverityAlert HighSeverityAlert
     | HighSeverityAlerts
     | History
+    | HistoryOfMentalHealthProblems
     | HistoryTask HistoryTask
     | HIV
     | HIVActivityTitle HIVActivity
@@ -805,6 +848,7 @@ type TranslationId
     | HIVMedicationTask Pages.HIV.Activity.Model.MedicationTask
     | HIVNextStepsTask Pages.HIV.Activity.Model.NextStepsTask
     | HIVPCRResult HIVPCRResult
+    | HIVPCRTestResult
     | HIVPositiveDateCorrectQuestion NominalDate
     | HIVPositiveDiagnosedQuestion
     | HIVPositiveTestDateQuestion
@@ -824,6 +868,7 @@ type TranslationId
     | HoursSinglePlural Int
     | HowManyPerWeek
     | Hygiene
+    | HyperemesisGravidum
     | Hypertension
     | HypertensionAndPregnantHeader
     | HypertensionBeforePregnancy
@@ -841,9 +886,14 @@ type TranslationId
     | IdleWaitingForSync
     | Ignore
     | IllnessSymptom IllnessSymptom
+    | IMDailyX10Days
+    | ImminentDeliveryLabel
     | Immunisation
     | ImmunizationFollowUpInstructions
     | ImmunizationHistory
+    | Immunizations
+    | IMX1
+    | Indeterminate
     | IndexPatient
     | IndividualEncounter
     | IndividualEncounterFirstVisit IndividualEncounterType
@@ -867,6 +917,8 @@ type TranslationId
     | IssuedTo
     | KilogramShorthand
     | KilogramsPerMonth
+    | KnownAllergy
+    | KnownAllergyOrReaction
     | KnownAsPositiveQuestion LaboratoryTask
     | KnownPositive
     | KnownPositiveHepatitisB
@@ -919,6 +971,7 @@ type TranslationId
     | LaboratoryASTLabel
     | LaboratoryPregnancyLabel
     | LaboratoryTest LaboratoryTest
+    | LaborDelivery
     | LabsEntryState Bool LabsEntryState
     | LabsHistoryCompletedQuestion
     | LaboratoryCreatinineCreatinineResult
@@ -939,11 +992,13 @@ type TranslationId
     | LabResultsHistoryModeLabel LabResultsHistoryMode
     | LabResultsNormalRange LabResultsHistoryMode
     | LabResultsPaneHeader LabResultsCurrentMode
+    | LabsResults
     | LastChecked
     | LastContacted
     | LastSuccessfulContactLabel
     | LeaveEncounter
     | Left
+    | LegCrampsLabel
     | LegCrampsReliefMethod LegCrampsReliefMethod
     | LegLeft
     | LegRight
@@ -953,8 +1008,10 @@ type TranslationId
     | LevelOfEducationLabel
     | LevelOfEducation EducationLevel
     | LevelOfEducationForResilience EducationLevel
+    | LevelOfStuntingUsingChildLengthMat
     | LipidPanel
     | LiveChildren
+    | LiverFunction
     | LmpDateConfirmationLabel
     | LmpDateConfirmationQuestion
     | LmpDateConfidentHeader
@@ -967,6 +1024,7 @@ type TranslationId
     | Location
     | LoginPhrase LoginPhrase
     | Low
+    | LowerBackPain
     | LowRiskCase
     | Lungs
     | LungsCPESign LungsCPESign
@@ -981,7 +1039,37 @@ type TranslationId
     | MalariaRapidDiagnosticTest
     | MalariaRecommendedTreatmentHeader
     | MalariaRecommendedTreatmentHelper
+    | MalariaWithAnemia
+    | MalariaWithAnemiaContinued
     | MalariaWithGIComplications
+    | MalariaWithoutComplications
+    | MalariaWithSevereAnemia
+    | MastersDegreeLabel
+    | Mastitis
+    | MaternalComplications
+    | Mebendazole
+    | Metformin500mg
+    | Methyldopa250mg
+    | MildToModeratePreeclampsia
+    | MissedECDMilestone
+    | MMSLabel
+    | ModerateRiskOfPreeclampsia
+    | NCDLabs
+    | NoDiagnosis
+    | OralPolioVaccineOPV
+    | Paralysis
+    | PatientDeclined
+    | PatientShowsSignsOfHighRiskForPreclampsia
+    | PatientShowsSignsOfMildToModeratePreeclampsia
+    | PatientShowsSignsOfSeverePreeclampsia
+    | PatientUnableToAfford
+    | PelvicPainLabel
+    | PerinealPainOrDischarge
+    | Postpartum
+    | PregnancyInducedHypertension
+    | PrimarySchoolLabel
+    | ProbableDepression
+    | RandomBloodSugarTestResult
     | RapidTestResult RapidTestResult
     | MalnutritionWithComplications
     | MaritalStatusLabel
@@ -1341,6 +1429,17 @@ type TranslationId
     | PrenatalSymptom PrenatalSymptom
     | PrenatalSymptomQuestion PrenatalSymptomQuestion
     | PrenatalSymptomQuestionsHeader
+    | Referral
+    | RememberMakeYourCoworkersYourWorkFamily
+    | Resolved
+    | SelectNutritionVisit
+    | SevereCOVID19
+    | SevereVomitingLabel
+    | SimpleCOVID19
+    | SpontaneousBleedingLabel
+    | StageOneHypertension
+    | SuicideRisk
+    | SyphilisWithComplications
     | TestExecutionNote TestExecutionNote
     | TestResult TestResult
     | PrenatalUltrasoundHeader
@@ -2039,10 +2138,13 @@ type TranslationId
     | TestResultsQuestion
     | TestVariantUrineDipstickQuestion
     | TestWillBePerformedTodayQuestion
+    | ThereAre
     | ThisGroupHasNoMothers
     | Time
     | To
+    | TooSick
     | Topics
+    | TotalCholesterol
     | TotalHighRiskPregnancies
     | ToThePatient
     | TransportationPlanQuestion
@@ -2067,6 +2169,7 @@ type TranslationId
     | TreatmentReviewWarningPopupMessage
     | TreatmentReviewWarningPopupInstructions
     | TreatmentTimeline
+    | TrichomonasOrBacterialVaginosis
     | TrySyncing
     | Tuberculosis
     | TuberculosisActivityTitle TuberculosisActivity
@@ -2102,9 +2205,12 @@ type TranslationId
     | UbudeheNumber Ubudehe
     | UltrasoundEDDQuestion
     | UltrasoundExecutionDateLabel
+    | UncomplicatedMalaria
     | Underweight
     | UndeterminedDiagnoses
     | UndeterminedDiagnosisMessage
+    | UndeterminedMoreEvaluationNeeded
+    | UNICEF
     | UnitCopiesPerMM3
     | UnitGramsPerDeciliter
     | UnitInternationalUnitsPerLiter
@@ -2139,6 +2245,9 @@ type TranslationId
     | View
     | ViewProgressReport
     | Village
+    | VisionChangesLabel
+    | VitalsRecheck
+    | VitaminA
     | VitaminAWarningPopupMessage
     | VomitingLabel
     | WaitForVitalsRecheckHelper
@@ -2146,6 +2255,7 @@ type TranslationId
     | WaitInstructions
     | Warning
     | WasFbfDistirbuted Activity
+    | WasThisTestPerformedBeforeAMeal
     | WeekSinglePlural Int
     | Weight
     | WeightGain
@@ -2170,6 +2280,7 @@ type TranslationId
     | WellChildNextStepsTask Bool Pages.WellChild.Activity.Types.NextStepsTask
     | WellChildSymptom WellChildSymptom
     | WellChildVaccineLabel Site WellChildVaccineType
+    | WellChildVisit
     | WhatDoYouWantToDo
     | WhatType
     | WhatWasTheirResponse
@@ -2181,6 +2292,7 @@ type TranslationId
     | Year
     | YearsOld Int
     | Yes
+    | YesSometimes
     | Zone
     | ZScoreHeadCircumferenceForAge
     | ZScoreHeightForAge
@@ -2252,6 +2364,13 @@ translationSet trans =
 
                 NormalAbdomen ->
                     translationSet Normal
+
+        AbdominalPainLabel ->
+            { english = "Abdominal Pain"
+            , kinyarwanda = Just "Kubabara mu nda"
+            , kirundi = Just "Ukubabara mu nda"
+            , somali = Just "Calool Xanuun"
+            }
 
         Abnormal ->
             { english = "Abnormal"
@@ -3584,6 +3703,13 @@ translationSet trans =
             , somali = Just <| String.fromInt days ++ " Maalin"
             }
 
+        AHEZA ->
+            { english = "AHEZA"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         AhezaActivityHelper ->
             { english = "Enter the amount of Aheza distributed below."
             , kinyarwanda = Just "Andika ingano ya Aheza yahawe hano."
@@ -3626,6 +3752,13 @@ translationSet trans =
             , kinyarwanda = Just "Aheza igenewe umubyeyi"
             , kirundi = Just "Aheza igenewe umuvyeyi"
             , somali = Just "Aheza Hooyo"
+            }
+
+        AlbendazoleLabel ->
+            { english = "Albendazole"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
             }
 
         AlertChwToFollowUp ->
@@ -3681,6 +3814,13 @@ translationSet trans =
                     , kirundi = Just "Igipimo c'ihuta ca Korona"
                     , somali = Just "Baaritaanka deg dega ah ee Covid"
                     }
+
+        Amlodipine5mg ->
+            { english = "Amlodipine (5mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
 
         And ->
             { english = "and"
@@ -3873,6 +4013,13 @@ translationSet trans =
                     , somali = Just "Kale"
                     }
 
+        Azithromycin2g ->
+            { english = "Azithromycin (2g)"
+            , kinyarwanda = Just "Azithromycine (2g)"
+            , kirundi = Just "azithromycine(2g)"
+            , somali = Nothing
+            }
+
         Baby ->
             { english = "Baby"
             , kinyarwanda = Just "Umwana"
@@ -3926,6 +4073,13 @@ translationSet trans =
             { english = "Batch #"
             , kinyarwanda = Just "Nomero #"
             , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        BloodGroup ->
+            { english = "Blood Group"
+            , kinyarwanda = Just "Ubwoko bw'Amaraso"
+            , kirundi = Just "Umurwi wa'amaraso"
             , somali = Nothing
             }
 
@@ -4411,6 +4565,13 @@ translationSet trans =
             , somali = Just <| "afka 3 jeer maalinki x " ++ String.fromInt days ++ " maalin"
             }
 
+        CalciumLabel ->
+            { english = "Calcium"
+            , kinyarwanda = Just "Kalisiyumu"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         Call114 ->
             { english = "Call 114"
             , kinyarwanda = Just "Hamagara 114"
@@ -4430,6 +4591,13 @@ translationSet trans =
             , kinyarwanda = Just "Guhagarika"
             , kirundi = Just "Guhagarika"
             , somali = Just "Tirtir"
+            }
+
+        Candidiasis ->
+            { english = "Candidiasis"
+            , kinyarwanda = Just "Kandidoze"
+            , kirundi = Just "Candidose"
+            , somali = Nothing
             }
 
         CandidiasisRecommendedTreatmentHeader ->
@@ -4479,6 +4647,20 @@ translationSet trans =
             , kinyarwanda = Just "Kwita ku mwana"
             , kirundi = Just "Ukwita ku mwana"
             , somali = Just "Daryeelaya"
+            }
+
+        Carvedilol625mg ->
+            { english = "Carvedilol (6.25mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Ceftriaxone1g ->
+            { english = "Ceftriaxone (1g)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
             }
 
         Cell ->
@@ -4755,6 +4937,20 @@ translationSet trans =
             , somali = Just "Mid dooro"
             }
 
+        ChronicHypertension ->
+            { english = "Chronic Hypertension"
+            , kinyarwanda = Just "Indwara y'Umuvuduko w'Amaraso Imaze Igihe Kirekire"
+            , kirundi = Just "Umuvuduko ukabije w'amaraso wamaho"
+            , somali = Nothing
+            }
+
+        CHW ->
+            { english = "CHW"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         CHWAction value ->
             case value of
                 ActionPregnancyDating ->
@@ -4886,6 +5082,55 @@ translationSet trans =
             , kinyarwanda = Just "Amakuru y’ubuvuzi"
             , kirundi = Just "Ivyo kwa muganga"
             , somali = Just "Daaweyn"
+            }
+
+        Connecting ->
+            { english = "Connecting"
+            , kinyarwanda = Just "Gusabana"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ConstipationLabel ->
+            { english = "Constipation"
+            , kinyarwanda = Just "Kwituma impatwe"
+            , kirundi = Just "Ukuzura inda"
+            , somali = Just "Calool istaag"
+            }
+
+        ContributingFactors ->
+            { english = "Contributing Factors"
+            , kinyarwanda = Just "Impamvu zateye uburwayi"
+            , kirundi = Just "Ivyatumye arwara"
+            , somali = Just "Waxyaabaha Keeni kara"
+            }
+
+        ConvulsionsLabel ->
+            { english = "Convulsions"
+            , kinyarwanda = Just "Kugagara"
+            , kirundi = Just "Ibisahuzi"
+            , somali = Just "Gariir"
+            }
+
+        CorePhysicalExamLabel ->
+            { english = "Core Physical Exam"
+            , kinyarwanda = Just "Isuzuma ryimbitse"
+            , kirundi = Just "Igipimo c'umubiri c'intango"
+            , somali = Nothing
+            }
+
+        COVID19WithSignsOfPneumonia ->
+            { english = "COVID-19 with signs of Pneumonia"
+            , kinyarwanda = Just "Uburwayi bwa Covid-19 hamwe n'ibimenyetso by'Umusonga"
+            , kirundi = Just "Virisi ya Korona - 19 n'ibimenyetso vy'umusonga"
+            , somali = Just "COVID-19 oo leh calaamadaha Oof wareenka"
+            }
+
+        Creatinine ->
+            { english = "Creatinine"
+            , kinyarwanda = Just "Keleyatinine"
+            , kirundi = Just "Créatinine"
+            , somali = Nothing
             }
 
         Dashboard dashboard ->
@@ -5198,6 +5443,104 @@ translationSet trans =
             { english = "Current Medication"
             , kinyarwanda = Nothing
             , kirundi = Just "Umuti ariko afata"
+            , somali = Nothing
+            }
+
+        DepressionNotLikely ->
+            { english = "Depression not Likely"
+            , kinyarwanda = Just "Birashoboka ko adafite indwara y'agahinda gakabije"
+            , kirundi = Just "Kwihebura ntibishoboka"
+            , somali = Nothing
+            }
+
+        DepressionPossible ->
+            { english = "Depression Possible"
+            , kinyarwanda = Just "Birashoboka ko yagira indwara y'agahinda gakabije"
+            , kirundi = Just "Kwihebura birashoboka"
+            , somali = Nothing
+            }
+
+        DiplomaProgram2YearsOfUniversity ->
+            { english = "Diploma Program (2 years of University)"
+            , kinyarwanda = Just "Amashuri 2 ya Kaminuza"
+            , kirundi = Just "Umugambi wo kuronka urupapuro rw'umutsindo (Imyaka Ibiri (2) kuri Kaminuza)"
+            , somali = Just "Barnaamijka Dibloomada (2 sano oo Jaamacad ah)"
+            }
+
+        DiscordantPartnership ->
+            { english = "Discordant Partnership"
+            , kinyarwanda = Just "Umwe mubo babana afite ubwandu"
+            , kirundi = Just "Umwe afise umugera wa SIDA kandi uwundi atawafise"
+            , somali = Nothing
+            }
+
+        DTPHepBHib ->
+            { english = "DTP - HepB - Hib"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        EarlyMastitisOrEngorgement ->
+            { english = "Early Mastitis or Engorgement"
+            , kinyarwanda = Just "Uburwayi bwo kubyimba amabere bwaje kare cyane"
+            , kirundi = Just "Iyuzura ry'amaberebere (Mastite précoce)"
+            , somali = Nothing
+            }
+
+        EnterTheAmountOfCSBFBFDistributedBelow ->
+            { english = "Enter the amount of CSB++ (FBF) distributed below."
+            , kinyarwanda = Just "Andika ingano ya  CSB++ (FBF) yahawe hano."
+            , kirundi = Just "Injiza/andika igitigiri ca CSB++ hamwe na FBF catanzwe aha hepfo."
+            , somali = Nothing
+            }
+
+        Erythromycin500mg ->
+            { english = "Erythromycin (500mg)"
+            , kinyarwanda = Just "Erythromicine (500mg)"
+            , kirundi = Just "Erythromycine (500 mg)"
+            , somali = Nothing
+            }
+
+        ExcessiveBleeding ->
+            { english = "Excessive Bleeding"
+            , kinyarwanda = Just "Kuva cyane"
+            , kirundi = Just "Kuva amaraso cane"
+            , somali = Just "Dhiigbax aad u daran"
+            }
+
+        FairlyHighPossibilityOfDepression ->
+            { english = "Fairly High Possibility of Depression"
+            , kinyarwanda = Just "Birashoboka cyane ko afite indwara y'agahinda gakabije"
+            , kirundi = Just "Birashoboka cane kwihebura"
+            , somali = Nothing
+            }
+
+        FeverOfUnknownOriginLabel ->
+            { english = "Fever of Unknown Origin"
+            , kinyarwanda = Just "Umuriro utazi icyawuteye"
+            , kirundi = Just "Ubushuhe bitazwi iyo bwazananye"
+            , somali = Just "Qandho aan asalkeeda la garanayn"
+            }
+
+        GiveTheChildOneTabletByMouth ->
+            { english = "Give the child one tablet by mouth"
+            , kinyarwanda = Just "Ha umwana ikinini kimwe akinywe"
+            , kirundi = Just "Ha umwana ikinini 1 co kumira"
+            , somali = Just "Sii canuga hal kaniini oo afka ah"
+            }
+
+        Glipenclamide5mg ->
+            { english = "Glipenclamide (5mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Gonorrhea ->
+            { english = "Gonorrhea"
+            , kinyarwanda = Just "Indwara y'umutezi"
+            , kirundi = Just "Ingwara yo mu bihimba vy'irondoka"
             , somali = Nothing
             }
 
@@ -6746,11 +7089,459 @@ translationSet trans =
                     , somali = Just "La xaliyay"
                     }
 
+        HardlyEver ->
+            { english = "Hardly ever"
+            , kinyarwanda = Just "Gake gashoboka"
+            , kirundi = Just "Biragoye bukebuke"
+            , somali = Just "Marnaba aan dhicin"
+            }
+
+        HaveYouCounseledPatientOnPositiveHIVTestMeaning ->
+            { english = "Have you counseled patient on positive HIV test meaning"
+            , kinyarwanda = Just "Waba wasobanuriye umurwayi (umubyeyi) icyo bisibanuye kugira ibisubizo biri positifu ku bwandu bw'agakoko gatera SIDA"
+            , kirundi = Just "Mbega warahanuye wongera urabwira umugwayi iciza c'igipimo c'umugera wa SIDA"
+            , somali = Just "Ma kala talisay bukaanka macnaha baaritaanka togan ee HIV"
+            }
+
+        HaveYouCounseledPatientOnSaferSexPractices ->
+            { english = "Have you counseled patient on safer sex practices"
+            , kinyarwanda = Just "Wagiriye inama umubyeyi ku bijyanye no gukora imibonano mpuzabitsina ikingiye"
+            , kirundi = Just "Mbega warahanuye  umugwayi kuvyerekeye iciza co kwikingira mu gihe c'imibonano mpuza ibitsina"
+            , somali = Just "Ma kala talisay bukaanka galmada badqabka leh"
+            }
+
+        HaveYouEncouragedThePatientsPartnerToGetTested ->
+            { english = "Have you encouraged the patient’s partner to get tested"
+            , kinyarwanda = Just "Waba washishikarije umubyueyi kubwira uwo babana kwipimisha"
+            , kirundi = Just "Mbega wateye inguvu umufasha w'umugwayi kugira yipimishe"
+            , somali = Nothing
+            }
+
+        HBA1C ->
+            { english = "HBA1C"
+            , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
+            , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
+            , somali = Nothing
+            }
+
+        HeartburnLabel ->
+            { english = "Heartburn"
+            , kinyarwanda = Just "Ikirungurira"
+            , kirundi = Just "Ugusha k'umutima"
+            , somali = Nothing
+            }
+
+        Hello ->
+            { english = "Hello "
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        HemoglobinTestHistory ->
+            { english = "Hemoglobin Test History"
+            , kinyarwanda = Just "Amakuru ku kizamini cy'ingano y'amaraso"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        HighRiskOfPreeclampsia ->
+            { english = "High Risk of Preeclampsia"
+            , kinyarwanda = Just "Afite ibyago byinshi byo kugira Preklampusi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        HistoryOfMentalHealthProblems ->
+            { english = "History of Mental Health Problems"
+            , kinyarwanda = Just "Niba yaragize uburwayi bwo mumutwe"
+            , kirundi = Just "Akahise k'ingorane y'ingwara yo mu mutwe"
+            , somali = Nothing
+            }
+
+        HIVPCRTestResult ->
+            { english = "HIV PCR Test Result"
+            , kinyarwanda = Just "Ibisubizo by'ikizamini cya PCR gipima Virusi itera SIDA"
+            , kirundi = Just "Inyishu y'igipimo ca PCR ya VIH"
+            , somali = Nothing
+            }
+
+        HyperemesisGravidum ->
+            { english = "Hyperemesis Gravidum"
+            , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
+            , kirundi = Just "Hyperémèse gravidique"
+            , somali = Nothing
+            }
+
+        IMDailyX10Days ->
+            { english = "IM daily x 10 days"
+            , kinyarwanda = Just "IM buri munsi mu minsi 10"
+            , kirundi = Just "IM buri munsi mu kiringo c'iminsi 10"
+            , somali = Nothing
+            }
+
+        ImminentDeliveryLabel ->
+            { english = "Imminent Delivery"
+            , kinyarwanda = Just "Kubyara biri hafi"
+            , kirundi = Just "Gutanga bigaragara/"
+            , somali = Nothing
+            }
+
+        Immunizations ->
+            { english = "Immunizations"
+            , kinyarwanda = Just "Ikingira"
+            , kirundi = Just "Incanco"
+            , somali = Just "Tallaalada"
+            }
+
+        IMX1 ->
+            { english = "IM x 1"
+            , kinyarwanda = Just "IM inshuro 1"
+            , kirundi = Just "IM Gucisha umuti mu mutsi incuro 1 gusa"
+            , somali = Nothing
+            }
+
+        Indeterminate ->
+            { english = "Indeterminate"
+            , kinyarwanda = Just "Ntibisobanutse"
+            , kirundi = Just "Ntibizwi neza"
+            , somali = Just "Aan horay laga ogaan karin"
+            }
+
+        KnownAllergy ->
+            { english = "Known Allergy"
+            , kinyarwanda = Just "Uyu muti usanzwe umutera ifurutwa"
+            , kirundi = Just "Ihindagurika ry'umuiri rizwi"
+            , somali = Just "Lagu yaqaano xasaasiyad"
+            }
+
+        KnownAllergyOrReaction ->
+            { english = "Known Allergy or Reaction"
+            , kinyarwanda = Just "Agira ingaruka zizwi kubera uru rukingo/umuti"
+            , kirundi = Just "Ihindagurika ry'umuiri rizwi"
+            , somali = Nothing
+            }
+
+        LaborDelivery ->
+            { english = "Labor + Delivery"
+            , kinyarwanda = Just "Kujya ku nda + Kubyara"
+            , kirundi = Just "Ibise + Kuvyara"
+            , somali = Just "Fool + Dhalmo"
+            }
+
+        LabsResults ->
+            { english = "Labs Results"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Inyishu z'ibipimo vy'ingwara"
+            , somali = Nothing
+            }
+
+        LegCrampsLabel ->
+            { english = "Leg Cramps"
+            , kinyarwanda = Just "Ibinya mu maguru"
+            , kirundi = Just "Ibinyanya vy'amaguru"
+            , somali = Just "Kabaabyo Lugaha ah"
+            }
+
+        LevelOfStuntingUsingChildLengthMat ->
+            { english = "Level of stunting using child length mat"
+            , kinyarwanda = Just "Ikigero cyo kugwingira hakoreshejwe agasambi"
+            , kirundi = Nothing
+            , somali = Just "Heerka nafaqo darrda ayadoo la isticmaalayo xariga cabirka"
+            }
+
+        LiverFunction ->
+            { english = "Liver Function"
+            , kinyarwanda = Just "Imikorere y'Umwijima"
+            , kirundi = Just "Ugukora kw'Igitigu"
+            , somali = Nothing
+            }
+
+        LowerBackPain ->
+            { english = "Lower Back Pain"
+            , kinyarwanda = Just "Kubabara umugongo wo hasi"
+            , kirundi = Just "Ububabare bw'umugongo wo hasi"
+            , somali = Just "Xanuun Dhinca dambe ah"
+            }
+
+        MalariaWithAnemia ->
+            { english = "Malaria with Anemia"
+            , kinyarwanda = Just "Malariya n'Amaraso Macye"
+            , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri"
+            , somali = Nothing
+            }
+
+        MalariaWithAnemiaContinued ->
+            { english = "Malaria with Anemia Continued"
+            , kinyarwanda = Just "Malariya n'Amaraso Macye bikigaragara"
+            , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri birabandanya"
+            , somali = Nothing
+            }
+
+        MalariaWithoutComplications ->
+            { english = "Malaria Without Complications"
+            , kinyarwanda = Just "Afite Malariya yoroheje"
+            , kirundi = Just "Malariya itagira ingorane zikomeye"
+            , somali = Just "Duumo aan Lahayn Waxyeello"
+            }
+
+        MalariaWithSevereAnemia ->
+            { english = "Malaria with Severe Anemia"
+            , kinyarwanda = Just "Malariya n'Amaraso Macye Cyane"
+            , kirundi = Just "Malariya kumwe n'igabanuka ry'amaraso m'umubiri ridasanzwe"
+            , somali = Just "Duumo leh Dhiig la`aan Daran"
+            }
+
+        MastersDegreeLabel ->
+            { english = "Masters Degree"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Urupapuro rw'umutsindo rw'igice ca 3 mashule (Maîtrise)"
+            , somali = Nothing
+            }
+
+        Mastitis ->
+            { english = "Mastitis"
+            , kinyarwanda = Just "Uburwayi bw'amabere"
+            , kirundi = Just "Ingwara y'imoko ituma amaberebere adasohoka"
+            , somali = Nothing
+            }
+
+        MaternalComplications ->
+            { english = "Maternal Complications"
+            , kinyarwanda = Just "Ibibazo bishobora kwibasira umugore utwite"
+            , kirundi = Just "Ingorane z'abavyeyi"
+            , somali = Nothing
+            }
+
+        Mebendazole ->
+            { english = "Mebendazole"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         MemoryQuota quota ->
             { english = "Memory used " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " MB of available " ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024)) ++ " MB"
             , kinyarwanda = Just <| "Hamaze gukoreshwa umwanya wa memori (ushobora kubika amakuru igihe gito) ungana na MB" ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " kuri MB" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
             , kirundi = Just <| "Memoire imaze gukoreshwa ungana na MO(Mégaoctets) " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " kuri MO(Mégaoctets)" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
             , somali = Just <| "Xasuus keydka la adeegsaday " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " MB banaan" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
+            }
+
+        Metformin500mg ->
+            { english = "Metformin (500mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Methyldopa250mg ->
+            { english = "Methyldopa (250mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        MildToModeratePreeclampsia ->
+            { english = "Mild to Moderate Preeclampsia"
+            , kinyarwanda = Just "Preklampusi Yoroheje"
+            , kirundi = Just "Umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
+            , somali = Just "Dhiig karka Uurka u dhaxeeya mid hoose iyo mid dhexe"
+            }
+
+        MissedECDMilestone ->
+            { english = "Missed ECD Milestone"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        MMSLabel ->
+            { english = "MMS"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ModerateRiskOfPreeclampsia ->
+            { english = "Moderate Risk of Preeclampsia"
+            , kinyarwanda = Just "Afite ibyago biringaniye byo kugira Preklampusi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        NCDLabs ->
+            { english = "NCD Labs"
+            , kinyarwanda = Just "Ibizamini bikorerwa ufite indwara zitandura"
+            , kirundi = Just "Ibipimo vy'ingwara zitandukira"
+            , somali = Nothing
+            }
+
+        NoDiagnosis ->
+            { english = "No Diagnosis"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Nta Gupima/gusuzuma"
+            , somali = Just "Ma jiro Baaritaan"
+            }
+
+        OralPolioVaccineOPV ->
+            { english = "Oral Polio Vaccine (OPV)"
+            , kinyarwanda = Just "Urukingo rw'imbasa rutangwa mu kanwa"
+            , kirundi = Just "Urucanco rw'ubukangwe (amama)"
+            , somali = Just "Tallaalka Afka ee Dabeysha (OPV)"
+            }
+
+        Paralysis ->
+            { english = "Paralysis"
+            , kinyarwanda = Just "Igice cy'umubiri kidakora"
+            , kirundi = Just "Ubumuga"
+            , somali = Just "Curyaan"
+            }
+
+        PatientDeclined ->
+            { english = "Patient Declined"
+            , kinyarwanda = Just "Umurwayi yanze"
+            , kirundi = Just "Umurwayi yaranse"
+            , somali = Just "Bukaanka ayaa Diiday"
+            }
+
+        PatientShowsSignsOfHighRiskForPreclampsia ->
+            { english = "Patient shows signs of High Risk for Preclampsia"
+            , kinyarwanda = Just "Umubyeyi agaragaza ibimenyetso biri hejuru byo kugira Preklampusi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        PatientShowsSignsOfMildToModeratePreeclampsia ->
+            { english = "Patient shows signs of Mild to Moderate Preeclampsia"
+            , kinyarwanda = Just "Agaragaza ibimenyetso byoroheje bya Preklampusi"
+            , kirundi = Just "Yerekana ibimenyetso vy'umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
+            , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Dhiig karka Uurka u dhaxeeya mid Hoose iyo mid Dhexe"
+            }
+
+        PatientShowsSignsOfSeverePreeclampsia ->
+            { english = "Patient shows signs of Severe Preeclampsia"
+            , kinyarwanda = Just "Agaragaza ibimenyetso bikabije bya Preklampusi"
+            , kirundi = Just "Yerekana ibimenyetso vy'Umuvuduko w'amaraso mu gihe c'imbanyi ukaze"
+            , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Daran ee Dhiig karka Uurka"
+            }
+
+        PatientUnableToAfford ->
+            { english = "Patient Unable to Afford"
+            , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
+            , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
+            , somali = Just "Bukaanka ma Awoodo Qarashka"
+            }
+
+        PelvicPainLabel ->
+            { english = "Pelvic Pain"
+            , kinyarwanda = Just "Kubabara mu kiziba cy'inda"
+            , kirundi = Just "Ububabare bwo mu nda yo hepfo"
+            , somali = Just "Dhabar Xanuun"
+            }
+
+        PerinealPainOrDischarge ->
+            { english = "Perineal Pain or Discharge"
+            , kinyarwanda = Just "Arababara perine cg aratakaza ibintu budasanzwe"
+            , kirundi = Just "Ububabare bw'umugongo hepfo"
+            , somali = Just "Xanuun qaska ah ama Dheecaan"
+            }
+
+        Postpartum ->
+            { english = "Postpartum"
+            , kinyarwanda = Just "Igihe cya nyuma cyo kubyara"
+            , kirundi = Just "Inyuma yo kwibaruka"
+            , somali = Just "Dhalmada kadib"
+            }
+
+        PregnancyInducedHypertension ->
+            { english = "Pregnancy-Induced Hypertension"
+            , kinyarwanda = Just "Umuvuduko w'amaraso watewe no gutwita"
+            , kirundi = Just "Umuvuduko w'amaraso utewe n'imbanyi"
+            , somali = Nothing
+            }
+
+        PrimarySchoolLabel ->
+            { english = "Primary School"
+            , kinyarwanda = Just "Abanza"
+            , kirundi = Just "Amashule matoya"
+            , somali = Just "Dugsi Hoose"
+            }
+
+        ProbableDepression ->
+            { english = "Probable Depression"
+            , kinyarwanda = Just "Birashoboka ko afite indwara y'agahinda gakabije"
+            , kirundi = Just "Ukwihebura gushoboka"
+            , somali = Just "U eg Niyad Jab"
+            }
+
+        RandomBloodSugarTestResult ->
+            { english = "Random Blood Sugar Test Result"
+            , kinyarwanda = Just "Igisubizo ku kizamini gipima ingano y'isukari mu maraso"
+            , kirundi = Just "Inyishu y'igipimo c'Isukari mu Maraso umwanya uwariwo wose"
+            , somali = Nothing
+            }
+
+        Referral ->
+            { english = "Referral"
+            , kinyarwanda = Just "Kohereza"
+            , kirundi = Just "Kurungika"
+            , somali = Just "Gudbin"
+            }
+
+        RememberMakeYourCoworkersYourWorkFamily ->
+            { english = "Remember: Make your co-workers your work family."
+            , kinyarwanda = Just ""
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Resolved ->
+            { english = "Resolved"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Cakemutse"
+            , somali = Just "La xaliyay"
+            }
+
+        SelectNutritionVisit ->
+            { english = "Select Nutrition Visit"
+            , kinyarwanda = Just "Hitamo isuzuma ry’imirire"
+            , kirundi = Just "Hitamo isuzumwa ry'ingaburo"
+            , somali = Just "Dooro Booqasho Nafaqo"
+            }
+
+        SevereCOVID19 ->
+            { english = "Severe COVID-19"
+            , kinyarwanda = Just "Uburwayi bwa Covid-19 bukabije"
+            , kirundi = Just "COVID-19 ikaze"
+            , somali = Just "COVID-19 aad u daran"
+            }
+
+        SevereVomitingLabel ->
+            { english = "Severe Vomiting"
+            , kinyarwanda = Just "Kuruka bikabije"
+            , kirundi = Just "Ukudahwa gukaze"
+            , somali = Nothing
+            }
+
+        SimpleCOVID19 ->
+            { english = "Simple COVID-19"
+            , kinyarwanda = Just "Uburwayi bwa Covid-19 bworoheje"
+            , kirundi = Just "Korona (COVID-19) isanzwe"
+            , somali = Just "COVID-19 Fudud"
+            }
+
+        SpontaneousBleedingLabel ->
+            { english = "Spontaneous Bleeding"
+            , kinyarwanda = Just "Kuva amaraso bitunguranye"
+            , kirundi = Just "Ukuva amaraso aho nyene"
+            , somali = Just "Dhiigbax aan waqti lahayn"
+            }
+
+        StageOneHypertension ->
+            { english = "Stage One Hypertension"
+            , kinyarwanda = Just "Umuvuduko w'amaraso uri ku rwego rwa mbere"
+            , kirundi = Just "Umuvuduko w'amaraso uri mu c'iciro/mu gice ca mbere"
+            , somali = Nothing
             }
 
         StorageQuota quota ->
@@ -20088,6 +20879,20 @@ translationSet trans =
             , somali = Just "Bukaanka wuxuu muujiyay calaamado u baahan su`aalo ka war qab ah."
             }
 
+        SuicideRisk ->
+            { english = "Suicide Risk"
+            , kinyarwanda = Just "Afite ibyago byo kwiyahura"
+            , kirundi = Just "Ingorane zimutuma ashobora kwiyahura"
+            , somali = Nothing
+            }
+
+        SyphilisWithComplications ->
+            { english = "Syphilis with Complications"
+            , kinyarwanda = Just "Mburugu n'ibibazo bishamikiyeho"
+            , kirundi = Just "Syphilis hamwe n'ingorane"
+            , somali = Nothing
+            }
+
         TestExecutionNote note ->
             case note of
                 TestNoteRunToday ->
@@ -27171,6 +27976,13 @@ translationSet trans =
             , somali = Just "Tirada Uurka Bilo Dhameystay (Ku Dhashay Nolol)"
             }
 
+        ThereAre ->
+            { english = "There are "
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         ThisGroupHasNoMothers ->
             { english = "This Group has no mothers assigned to it."
             , kinyarwanda = Just "Iki cyiciro nta mubyeyi cyagenewe."
@@ -27192,11 +28004,25 @@ translationSet trans =
             , somali = Just "Ku"
             }
 
+        TooSick ->
+            { english = "Too Sick"
+            , kinyarwanda = Just "Ararembye"
+            , kirundi = Just "Ararwaye cane"
+            , somali = Nothing
+            }
+
         Topics ->
             { english = "Topics"
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing
+            }
+
+        TotalCholesterol ->
+            { english = "Total Cholesterol"
+            , kinyarwanda = Just "Igipimo cy'ibinure byose mu maraso (Total cholesterol)"
+            , kirundi = Just "Icegeranyo c'amavuta m'umubiri"
+            , somali = Just "Wadarta Kolesteroolka"
             }
 
         TotalHighRiskPregnancies ->
@@ -27515,6 +28341,13 @@ translationSet trans =
             , kinyarwanda = Nothing
             , kirundi = Just "Amezi agezeko mugufata umuti"
             , somali = Nothing
+            }
+
+        TrichomonasOrBacterialVaginosis ->
+            { english = "Trichomonas or Bacterial Vaginosis"
+            , kinyarwanda = Just "Tirikomonasi cyangwa Mikorobe zo mu nda ibyara"
+            , kirundi = Just "Ingwara yo mu bihimba vy'irondoka igaragazwa kenshi no kuhiyagaza"
+            , somali = Just "Trichomonas ama Bakteeriyada Makaanka"
             }
 
         TrySyncing ->
@@ -27971,6 +28804,13 @@ translationSet trans =
             , somali = Just "Taariikhda baaritaanka uurka lagu sameeyay"
             }
 
+        UncomplicatedMalaria ->
+            { english = "Uncomplicated Malaria"
+            , kinyarwanda = Just "Malariya yoroheje"
+            , kirundi = Just "Malariya yoroshe/isanzwe"
+            , somali = Just "Duumo aan Waxyeello lahayn"
+            }
+
         Underweight ->
             { english = "Underweight"
             , kinyarwanda = Just "Ibiro bidahagije"
@@ -27989,6 +28829,20 @@ translationSet trans =
             { english = "undetermined diagnosis - followed Post-Partum Protocols"
             , kinyarwanda = Just "Uburwayi ntibusobanutse - hakurikijwe mabwiriza yo kwita ku mubyeyi wabyaye"
             , kirundi = Just "Isuzuma ritamenyekana - Kurikiza inyandikondongozi zerekeye inyuma y'ivyara"
+            , somali = Nothing
+            }
+
+        UndeterminedMoreEvaluationNeeded ->
+            { english = "Undetermined - More Evaluation Needed"
+            , kinyarwanda = Just "Ntibisobanutse - Hakenewe Isuzuma Ryimbitse"
+            , kirundi = Just "Ntibimenyekana - Isuzuma ryinshi rirakenewe"
+            , somali = Just "Aan la xaqiijinin - U baahan Qiimeyn dheeraad ah"
+            }
+
+        UNICEF ->
+            { english = "UNICEF"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
             , somali = Nothing
             }
 
@@ -28352,6 +29206,27 @@ translationSet trans =
             , somali = Just "Xaafad"
             }
 
+        VisionChangesLabel ->
+            { english = "Vision Changes"
+            , kinyarwanda = Just "Uko areba byahindutse"
+            , kirundi = Just "Impinduka y'icerekezo"
+            , somali = Nothing
+            }
+
+        VitalsRecheck ->
+            { english = "Vitals Recheck"
+            , kinyarwanda = Just "Gusubiramo ibipimo by'ubuzima"
+            , kirundi = Just "Ugusubiramwo ivyangombwa"
+            , somali = Nothing
+            }
+
+        VitaminA ->
+            { english = "Vitamin A"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         VitaminAWarningPopupMessage ->
             { english = "Patient did not recieve Vitamin A"
             , kinyarwanda = Nothing
@@ -28409,6 +29284,13 @@ translationSet trans =
                     , kirundi = Just "Nimba igipimo catanzwe kidahuye n'intumbero zanditse zico gikorwa, hitamwo impamvu"
                     , somali = Just "Haddii tirada la qeybiyay aysan waafaqsaneyn hab-raaca, qor sababta"
                     }
+
+        WasThisTestPerformedBeforeAMeal ->
+            { english = "Was this test performed before a meal"
+            , kinyarwanda = Just "Umurwayi yafatiwe iki kizamini mbere yo kurya"
+            , kirundi = Just "Mbega iki gipimo cabaye imbere yo gufungura"
+            , somali = Nothing
+            }
 
         WeekSinglePlural value ->
             if value == 1 then
@@ -29262,6 +30144,13 @@ translationSet trans =
                     , somali = Nothing
                     }
 
+        WellChildVisit ->
+            { english = "Well Child Visit"
+            , kinyarwanda = Just "Isura ku buzima bwiza bw'umwana"
+            , kirundi = Just "Kugendera urugo rufise umwana"
+            , somali = Just "Booqashada Canuga Fayow"
+            }
+
         WhatDoYouWantToDo ->
             { english = "What do you want to do?"
             , kinyarwanda = Just "Urashaka gukora iki?"
@@ -29337,6 +30226,13 @@ translationSet trans =
             , kinyarwanda = Just "Yego"
             , kirundi = Just "Ego"
             , somali = Just "Haa"
+            }
+
+        YesSometimes ->
+            { english = "Yes, sometimes"
+            , kinyarwanda = Just "Yego, rimwe na rimwe"
+            , kirundi = Just "Ego, rimwe na rimwe"
+            , somali = Just "Haa, Mararka qaar"
             }
 
         Zone ->

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -2579,11 +2579,7 @@ translationSet trans =
                     translationSet VomitingLabel
 
                 DangerSignConvulsions ->
-                    { english = "Convulsions"
-                    , kinyarwanda = Just "Kugagara"
-                    , kirundi = Just "Ibisahuzi"
-                    , somali = Just "Gariir"
-                    }
+                    translationSet ConvulsionsLabel
 
                 DangerSignLethargyUnconsciousness ->
                     { english = "Lethargy or Unconsciousness"
@@ -2600,11 +2596,7 @@ translationSet trans =
                     }
 
                 DangerSignSpontaneousBleeding ->
-                    { english = "Spontaneous Bleeding"
-                    , kinyarwanda = Just "Kuva amaraso bitunguranye"
-                    , kirundi = Just "Ukuva amaraso aho nyene"
-                    , somali = Just "Dhiigbax aan waqti lahayn"
-                    }
+                    translationSet SpontaneousBleedingLabel
 
                 DangerSignBloodyDiarrhea ->
                     { english = "Bloody Diarrhea"
@@ -2633,25 +2625,13 @@ translationSet trans =
                     }
 
                 DiagnosisSevereCovid19 ->
-                    { english = "Severe COVID-19"
-                    , kinyarwanda = Just "Uburwayi bwa Covid-19 bukabije"
-                    , kirundi = Just "COVID-19 ikaze"
-                    , somali = Just "COVID-19 aad u daran"
-                    }
+                    translationSet SevereCOVID19
 
                 DiagnosisPneuminialCovid19 ->
-                    { english = "COVID-19 with signs of Pneumonia"
-                    , kinyarwanda = Just "Uburwayi bwa Covid-19 hamwe n'ibimenyetso by'Umusonga"
-                    , kirundi = Just "Virisi ya Korona - 19 n'ibimenyetso vy'umusonga"
-                    , somali = Just "COVID-19 oo leh calaamadaha Oof wareenka"
-                    }
+                    translationSet COVID19WithSignsOfPneumonia
 
                 DiagnosisLowRiskCovid19 ->
-                    { english = "Simple COVID-19"
-                    , kinyarwanda = Just "Uburwayi bwa Covid-19 bworoheje"
-                    , kirundi = Just "Korona (COVID-19) isanzwe"
-                    , somali = Just "COVID-19 Fudud"
-                    }
+                    translationSet SimpleCOVID19
 
                 DiagnosisMalariaComplicated ->
                     { english = "Complicated Malaria"
@@ -2661,18 +2641,10 @@ translationSet trans =
                     }
 
                 DiagnosisMalariaUncomplicated ->
-                    { english = "Uncomplicated Malaria"
-                    , kinyarwanda = Just "Malariya yoroheje"
-                    , kirundi = Just "Malariya yoroshe/isanzwe"
-                    , somali = Just "Duumo aan Waxyeello lahayn"
-                    }
+                    translationSet UncomplicatedMalaria
 
                 DiagnosisMalariaUncomplicatedAndPregnant ->
-                    { english = "Uncomplicated Malaria"
-                    , kinyarwanda = Just "Malariya yoroheje"
-                    , kirundi = Just "Malariya yoroshe/isanzwe"
-                    , somali = Just "Duumo aan Waxyeello lahayn"
-                    }
+                    translationSet UncomplicatedMalaria
 
                 DiagnosisGastrointestinalInfectionComplicated ->
                     { english = "Gastrointestinal Infection with Complications"
@@ -2710,28 +2682,16 @@ translationSet trans =
                     }
 
                 DiagnosisFeverOfUnknownOrigin ->
-                    { english = "Fever of Unknown Origin"
-                    , kinyarwanda = Just "Umuriro utazi icyawuteye"
-                    , kirundi = Just "Ubushuhe bitazwi iyo bwazananye"
-                    , somali = Just "Qandho aan asalkeeda la garanayn"
-                    }
+                    translationSet FeverOfUnknownOriginLabel
 
                 DiagnosisUndeterminedMoreEvaluationNeeded ->
-                    { english = "Undetermined - More Evaluation Needed"
-                    , kinyarwanda = Just "Ntibisobanutse - Hakenewe Isuzuma Ryimbitse"
-                    , kirundi = Just "Ntibimenyekana - Isuzuma ryinshi rirakenewe"
-                    , somali = Just "Aan la xaqiijinin - U baahan Qiimeyn dheeraad ah"
-                    }
+                    translationSet UndeterminedMoreEvaluationNeeded
 
                 DiagnosisTuberculosisSuspect ->
                     translationSet TuberculosisSuspect
 
                 NoAcuteIllnessDiagnosis ->
-                    { english = "No Diagnosis"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Nta Gupima/gusuzuma"
-                    , somali = Just "Ma jiro Baaritaan"
-                    }
+                    translationSet NoDiagnosis
 
         AcuteIllnessDiagnosisWarning diagnosis ->
             case diagnosis of
@@ -2743,25 +2703,13 @@ translationSet trans =
                     }
 
                 DiagnosisSevereCovid19 ->
-                    { english = "Severe COVID-19"
-                    , kinyarwanda = Just "Uburwayi bwa Covid-19 bukabije"
-                    , kirundi = Just "COVID-19 ikaze"
-                    , somali = Just "COVID-19 aad u daran"
-                    }
+                    translationSet SevereCOVID19
 
                 DiagnosisPneuminialCovid19 ->
-                    { english = "COVID-19 with signs of Pneumonia"
-                    , kinyarwanda = Just "Uburwayi bwa Covid-19 hamwe n'ibimenyetso by'Umusonga"
-                    , kirundi = Just "Virisi ya Korona - 19 n'ibimenyetso vy'umusonga"
-                    , somali = Just "COVID-19 oo leh calaamadaha Oof wareenka"
-                    }
+                    translationSet COVID19WithSignsOfPneumonia
 
                 DiagnosisLowRiskCovid19 ->
-                    { english = "Simple COVID-19"
-                    , kinyarwanda = Just "Uburwayi bwa Covid-19 bworoheje"
-                    , kirundi = Just "Korona (COVID-19) isanzwe"
-                    , somali = Just "COVID-19 Fudud"
-                    }
+                    translationSet SimpleCOVID19
 
                 DiagnosisMalariaComplicated ->
                     { english = "Malaria with Complications"
@@ -2771,18 +2719,10 @@ translationSet trans =
                     }
 
                 DiagnosisMalariaUncomplicated ->
-                    { english = "Malaria Without Complications"
-                    , kinyarwanda = Just "Afite Malariya yoroheje"
-                    , kirundi = Just "Malariya itagira ingorane zikomeye"
-                    , somali = Just "Duumo aan Lahayn Waxyeello"
-                    }
+                    translationSet MalariaWithoutComplications
 
                 DiagnosisMalariaUncomplicatedAndPregnant ->
-                    { english = "Malaria Without Complications"
-                    , kinyarwanda = Just "Afite Malariya yoroheje"
-                    , kirundi = Just "Malariya itagira ingorane zikomeye"
-                    , somali = Just "Duumo aan Lahayn Waxyeello"
-                    }
+                    translationSet MalariaWithoutComplications
 
                 DiagnosisGastrointestinalInfectionComplicated ->
                     { english = "Suspected Gastrointestinal Infection (with Complications)"
@@ -2820,28 +2760,16 @@ translationSet trans =
                     }
 
                 DiagnosisFeverOfUnknownOrigin ->
-                    { english = "Fever of Unknown Origin"
-                    , kinyarwanda = Just "Umuriro utazi icyawuteye"
-                    , kirundi = Just "Ubushuhe bitazwi iyo bwazananye"
-                    , somali = Just "Qandho aan asalkeeda la garanayn"
-                    }
+                    translationSet FeverOfUnknownOriginLabel
 
                 DiagnosisUndeterminedMoreEvaluationNeeded ->
-                    { english = "Undetermined - More Evaluation Needed"
-                    , kinyarwanda = Just "Ntibisobanutse - Hakenewe Isuzuma Ryimbitse"
-                    , kirundi = Just "Ntibimenyekana - Isuzuma ryinshi rirakenewe"
-                    , somali = Just "Aan la xaqiijinin - U baahan Qiimeyn dheeraad ah"
-                    }
+                    translationSet UndeterminedMoreEvaluationNeeded
 
                 DiagnosisTuberculosisSuspect ->
                     translationSet TuberculosisSuspect
 
                 NoAcuteIllnessDiagnosis ->
-                    { english = "No Diagnosis"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Nta Gupima/gusuzuma"
-                    , somali = Just "Ma jiro Baaritaan"
-                    }
+                    translationSet NoDiagnosis
 
         AcuteIllnessExisting ->
             { english = "Existing Acute Illness"
@@ -2895,11 +2823,7 @@ translationSet trans =
                     }
 
                 AcuteIllnessResolved ->
-                    { english = "Resolved"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Cakemutse"
-                    , somali = Just "La xaliyay"
-                    }
+                    translationSet Resolved
 
         AcuteMalnutrition ->
             { english = "Acute Malnutrition"
@@ -3023,11 +2947,7 @@ translationSet trans =
             }
 
         AdministerAlbendazoleHelper ->
-            { english = "Give the child one tablet by mouth"
-            , kinyarwanda = Just "Ha umwana ikinini kimwe akinywe"
-            , kirundi = Just "Ha umwana ikinini 1 co kumira"
-            , somali = Just "Sii canuga hal kaniini oo afka ah"
-            }
+            translationSet GiveTheChildOneTabletByMouth
 
         AdministerAspirinHelper ->
             { english = "1 tablet 150 mg by mouth daily"
@@ -3082,11 +3002,7 @@ translationSet trans =
             }
 
         AdministerMebendezoleHelper ->
-            { english = "Give the child one tablet by mouth"
-            , kinyarwanda = Just "Ha umwana ikinini kimwe akinywe"
-            , kirundi = Just "Ha umwana ikinini 1 co kumira"
-            , somali = Just "Sii canuga hal kaniini oo afka ah"
-            }
+            translationSet GiveTheChildOneTabletByMouth
 
         AdministerMetronidazoleHelper ->
             { english = "By mouth twice a day for 7 days"
@@ -3271,11 +3187,7 @@ translationSet trans =
                     }
 
                 ChildActivity Activity.Model.ContributingFactors ->
-                    { english = "Contributing Factors"
-                    , kinyarwanda = Just "Impamvu zateye uburwayi"
-                    , kirundi = Just "Ivyatumye arwara"
-                    , somali = Just "Waxyaabaha Keeni kara"
-                    }
+                    translationSet ContributingFactors
 
                 ChildActivity Activity.Model.FollowUp ->
                     translationSet FollowUp
@@ -3302,11 +3214,7 @@ translationSet trans =
                     translationSet EmptyString
 
                 MotherActivity MotherFbf ->
-                    { english = "Enter the amount of CSB++ (FBF) distributed below."
-                    , kinyarwanda = Just "Andika ingano ya  CSB++ (FBF) yahawe hano."
-                    , kirundi = Just "Injiza/andika igitigiri ca CSB++ hamwe na FBF catanzwe aha hepfo."
-                    , somali = Nothing
-                    }
+                    translationSet EnterTheAmountOfCSBFBFDistributedBelow
 
                 MotherActivity ParticipantConsent ->
                     { english = "Forms:"
@@ -3321,11 +3229,7 @@ translationSet trans =
                    , kirundi = Nothing }
                 -}
                 ChildActivity ChildFbf ->
-                    { english = "Enter the amount of CSB++ (FBF) distributed below."
-                    , kinyarwanda = Just "Andika ingano ya  CSB++ (FBF) yahawe hano."
-                    , kirundi = Just "Injiza/andika igitigiri ca CSB++ hamwe na FBF catanzwe aha hepfo."
-                    , somali = Nothing
-                    }
+                    translationSet EnterTheAmountOfCSBFBFDistributedBelow
 
                 ChildActivity Activity.Model.Height ->
                     { english = "Height:"
@@ -3440,11 +3344,7 @@ translationSet trans =
                     }
 
                 ChildActivity Activity.Model.Height ->
-                    { english = "Height"
-                    , kinyarwanda = Just "Uburebure"
-                    , kirundi = Just "Uburebure"
-                    , somali = Just "Dhirika"
-                    }
+                    translationSet Height
 
                 ChildActivity Activity.Model.Muac ->
                     translationSet MUAC
@@ -3453,25 +3353,13 @@ translationSet trans =
                     translationSet Nutrition
 
                 ChildActivity Activity.Model.ChildPicture ->
-                    { english = "Photo"
-                    , kinyarwanda = Just "Ifoto"
-                    , kirundi = Just "Ifoto"
-                    , somali = Just "Sawir"
-                    }
+                    translationSet Photo
 
                 ChildActivity Activity.Model.Weight ->
-                    { english = "Weight"
-                    , kinyarwanda = Just "Ibiro"
-                    , kirundi = Just "Uburemere"
-                    , somali = Just "Miisaan"
-                    }
+                    translationSet Weight
 
                 ChildActivity Activity.Model.ContributingFactors ->
-                    { english = "Contributing Factors"
-                    , kinyarwanda = Just "Impamvu zateye uburwayi"
-                    , kirundi = Just "Ivyatumye arwara"
-                    , somali = Just "Waxyaabaha Keeni kara"
-                    }
+                    translationSet ContributingFactors
 
                 ChildActivity Activity.Model.FollowUp ->
                     translationSet FollowUp
@@ -3979,25 +3867,13 @@ translationSet trans =
                     }
 
                 AvoidingGuidanceHypertensionKnownAllergy ->
-                    { english = "Known Allergy"
-                    , kinyarwanda = Just "Uyu muti usanzwe umutera ifurutwa"
-                    , kirundi = Just "Ihindagurika ry'umuiri rizwi"
-                    , somali = Just "Lagu yaqaano xasaasiyad"
-                    }
+                    translationSet KnownAllergy
 
                 AvoidingGuidanceHypertensionPatientDeclined ->
-                    { english = "Patient Declined"
-                    , kinyarwanda = Just "Umurwayi yanze"
-                    , kirundi = Just "Umurwayi yaranse"
-                    , somali = Just "Bukaanka ayaa Diiday"
-                    }
+                    translationSet PatientDeclined
 
                 AvoidingGuidanceHypertensionPatientUnableToAfford ->
-                    { english = "Patient Unable to Afford"
-                    , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
-                    , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
-                    , somali = Just "Bukaanka ma Awoodo Qarashka"
-                    }
+                    translationSet PatientUnableToAfford
 
                 AvoidingGuidanceHypertensionReinforceAdherence ->
                     { english = "Reinforce adherence of existing dosage"
@@ -4703,11 +4579,7 @@ translationSet trans =
                     }
 
                 FilterNCDLabs ->
-                    { english = "NCD Labs"
-                    , kinyarwanda = Just "Ibizamini bikorerwa ufite indwara zitandura"
-                    , kirundi = Just "Ibipimo vy'ingwara zitandukira"
-                    , somali = Nothing
-                    }
+                    translationSet NCDLabs
 
                 FilterImmunization ->
                     translationSet Immunisation
@@ -4752,11 +4624,7 @@ translationSet trans =
                     }
 
                 FilterNCDLabs ->
-                    { english = "NCD Labs"
-                    , kinyarwanda = Just "Ibizamini bikorerwa ufite indwara zitandura"
-                    , kirundi = Just "Ibipimo vy'ingwara zitandukira"
-                    , somali = Nothing
-                    }
+                    translationSet NCDLabs
 
                 FilterImmunization ->
                     translationSet Immunisation
@@ -4903,11 +4771,7 @@ translationSet trans =
         ChildScoreboardActivityTitle activity ->
             case activity of
                 ChildScoreboardNCDA ->
-                    { english = "Child Scorecard"
-                    , kinyarwanda = Just "Ifishi y’Imikurire y’Umwana"
-                    , kirundi = Just "Ikarata y'ikurikiranwa ry'umwana"
-                    , somali = Just "Jaantuska Canuga"
-                    }
+                    translationSet ChildScorecard
 
                 ChildScoreboardVaccinationHistory ->
                     { english = "Vaccination History"
@@ -5050,11 +4914,7 @@ translationSet trans =
                     }
 
                 Chw ->
-                    { english = "CHW"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet CHW
 
                 Fbf ->
                     { english = "Fbf"
@@ -5840,11 +5700,7 @@ translationSet trans =
                     }
 
                 Convulsions ->
-                    { english = "Convulsions"
-                    , kinyarwanda = Just "Kugagara"
-                    , kirundi = Just "Ibisahuzi"
-                    , somali = Just "Gariir"
-                    }
+                    translationSet ConvulsionsLabel
 
                 AbdominalPain ->
                     translationSet SevereAbdominalPainLabel
@@ -7083,11 +6939,7 @@ translationSet trans =
                     }
 
                 StatusResolved ->
-                    { english = "Resolved"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Cakemutse"
-                    , somali = Just "La xaliyay"
-                    }
+                    translationSet Resolved
 
         HardlyEver ->
             { english = "Hardly ever"
@@ -7620,11 +7472,7 @@ translationSet trans =
                     translationSet NutritionAssessmentLabel
 
                 CorePhysicalExam ->
-                    { english = "Core Physical Exam"
-                    , kinyarwanda = Just "Isuzuma ryimbitse"
-                    , kirundi = Just "Igipimo c'umubiri c'intango"
-                    , somali = Nothing
-                    }
+                    translationSet CorePhysicalExamLabel
 
                 ObstetricalExam ->
                     { english = "Obstetrical Exam"
@@ -8920,25 +8768,13 @@ translationSet trans =
         HIVHealthEducationQuestion sign ->
             case sign of
                 EducationPositiveResult ->
-                    { english = "Have you counseled patient on positive HIV test meaning"
-                    , kinyarwanda = Just "Waba wasobanuriye umurwayi (umubyeyi) icyo bisibanuye kugira ibisubizo biri positifu ku bwandu bw'agakoko gatera SIDA"
-                    , kirundi = Just "Mbega warahanuye wongera urabwira umugwayi iciza c'igipimo c'umugera wa SIDA"
-                    , somali = Just "Ma kala talisay bukaanka macnaha baaritaanka togan ee HIV"
-                    }
+                    translationSet HaveYouCounseledPatientOnPositiveHIVTestMeaning
 
                 EducationSaferSexPractices ->
-                    { english = "Have you counseled patient on safer sex practices"
-                    , kinyarwanda = Just "Wagiriye inama umubyeyi ku bijyanye no gukora imibonano mpuzabitsina ikingiye"
-                    , kirundi = Just "Mbega warahanuye  umugwayi kuvyerekeye iciza co kwikingira mu gihe c'imibonano mpuza ibitsina"
-                    , somali = Just "Ma kala talisay bukaanka galmada badqabka leh"
-                    }
+                    translationSet HaveYouCounseledPatientOnSaferSexPractices
 
                 EducationEncouragedPartnerTesting ->
-                    { english = "Have you encouraged the patient’s partner to get tested"
-                    , kinyarwanda = Just "Waba washishikarije umubyueyi kubwira uwo babana kwipimisha"
-                    , kirundi = Just "Mbega wateye inguvu umufasha w'umugwayi kugira yipimishe"
-                    , somali = Nothing
-                    }
+                    translationSet HaveYouEncouragedThePatientsPartnerToGetTested
 
                 EducationFamilyPlanningOptions ->
                     { english = "Have you counseled the patient on family planning options"
@@ -9611,11 +9447,7 @@ translationSet trans =
                     translationSet HeadacheLabel
 
                 IllnessSymptomVisionChanges ->
-                    { english = "Vision Changes"
-                    , kinyarwanda = Just "Uko areba byahindutse"
-                    , kirundi = Just "Impinduka y'icerekezo"
-                    , somali = Nothing
-                    }
+                    translationSet VisionChangesLabel
 
                 IllnessSymptomRash ->
                     { english = "Rash on body, feet or hands"
@@ -10323,11 +10155,7 @@ translationSet trans =
             }
 
         LaboratoryBloodGroupLabel ->
-            { english = "Blood Group"
-            , kinyarwanda = Just "Ubwoko bw'Amaraso"
-            , kirundi = Just "Umurwi wa'amaraso"
-            , somali = Nothing
-            }
+            translationSet BloodGroup
 
         LaboratoryBloodGroupTestResult ->
             { english = "Blood Group Test Result"
@@ -10867,18 +10695,10 @@ translationSet trans =
             }
 
         LaboratoryRandomBloodSugarTestResult ->
-            { english = "Random Blood Sugar Test Result"
-            , kinyarwanda = Just "Igisubizo ku kizamini gipima ingano y'isukari mu maraso"
-            , kirundi = Just "Inyishu y'igipimo c'Isukari mu Maraso umwanya uwariwo wose"
-            , somali = Nothing
-            }
+            translationSet RandomBloodSugarTestResult
 
         LaboratoryHIVPCRTestResult ->
-            { english = "HIV PCR Test Result"
-            , kinyarwanda = Just "Ibisubizo by'ikizamini cya PCR gipima Virusi itera SIDA"
-            , kirundi = Just "Inyishu y'igipimo ca PCR ya VIH"
-            , somali = Nothing
-            }
+            translationSet HIVPCRTestResult
 
         LaboratoryHIVPCRViralLoadStatusQuestion ->
             { english = "Are there less than 20 copies/mm3"
@@ -10888,11 +10708,7 @@ translationSet trans =
             }
 
         LaboratoryCreatinineLabel ->
-            { english = "Creatinine"
-            , kinyarwanda = Just "Keleyatinine"
-            , kirundi = Just "Créatinine"
-            , somali = Nothing
-            }
+            translationSet Creatinine
 
         LaboratoryBUNLabel ->
             { english = "BUN"
@@ -10934,11 +10750,7 @@ translationSet trans =
                     translationSet Malaria
 
                 TestBloodGpRs ->
-                    { english = "Blood Group"
-                    , kinyarwanda = Just "Ubwoko bw'Amaraso"
-                    , kirundi = Just "Umurwi wa'amaraso"
-                    , somali = Nothing
-                    }
+                    translationSet BloodGroup
 
                 TestHemoglobin ->
                     { english = "Hemoglobin"
@@ -10972,11 +10784,7 @@ translationSet trans =
                     }
 
                 TestVitalsRecheck ->
-                    { english = "Vitals Recheck"
-                    , kinyarwanda = Just "Gusubiramo ibipimo by'ubuzima"
-                    , kirundi = Just "Ugusubiramwo ivyangombwa"
-                    , somali = Nothing
-                    }
+                    translationSet VitalsRecheck
 
                 TestHIVPCR ->
                     { english = "HIV PCR"
@@ -10986,18 +10794,10 @@ translationSet trans =
                     }
 
                 TestCreatinine ->
-                    { english = "Creatinine"
-                    , kinyarwanda = Just "Keleyatinine"
-                    , kirundi = Just "Créatinine"
-                    , somali = Nothing
-                    }
+                    translationSet Creatinine
 
                 TestLiverFunction ->
-                    { english = "Liver Function"
-                    , kinyarwanda = Just "Imikorere y'Umwijima"
-                    , kirundi = Just "Ugukora kw'Igitigu"
-                    , somali = Nothing
-                    }
+                    translationSet LiverFunction
 
                 TestLipidPanel ->
                     translationSet LipidPanel
@@ -11010,20 +10810,12 @@ translationSet trans =
             }
 
         PrenatalLabsCaseManagementEntryTypeVitals ->
-            { english = "Vitals Recheck"
-            , kinyarwanda = Just "Gusubiramo ibipimo by'ubuzima"
-            , kirundi = Just "Ugusubiramwo ivyangombwa"
-            , somali = Nothing
-            }
+            translationSet VitalsRecheck
 
         PrenatalMedicationTask task ->
             case task of
                 TaskCalcium ->
-                    { english = "Calcium"
-                    , kinyarwanda = Just "Kalisiyumu"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet CalciumLabel
 
                 TaskFefol ->
                     { english = "Fefol"
@@ -11047,18 +10839,10 @@ translationSet trans =
                     }
 
                 TaskMMS ->
-                    { english = "MMS"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet MMSLabel
 
                 TaskMebendazole ->
-                    { english = "Mebendazole"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Mebendazole
 
         LabsEntryState isLabTech state ->
             case state of
@@ -11119,11 +10903,7 @@ translationSet trans =
             }
 
         LaboratoryLipidPanelTotalCholesterolLabel ->
-            { english = "Total Cholesterol"
-            , kinyarwanda = Just "Igipimo cy'ibinure byose mu maraso (Total cholesterol)"
-            , kirundi = Just "Icegeranyo c'amavuta m'umubiri"
-            , somali = Just "Wadarta Kolesteroolka"
-            }
+            translationSet TotalCholesterol
 
         LaboratoryLipidPanelLDLCholesterolLabel ->
             { english = "LDL"
@@ -11183,11 +10963,7 @@ translationSet trans =
                     translationSet Malaria
 
                 TaskBloodGpRsTest ->
-                    { english = "Blood Group"
-                    , kinyarwanda = Just "Ubwoko bw'Amaraso"
-                    , kirundi = Just "Umurwi wa'amaraso"
-                    , somali = Nothing
-                    }
+                    translationSet BloodGroup
 
                 TaskUrineDipstickTest ->
                     { english = "Urine Dipstick"
@@ -11225,28 +11001,16 @@ translationSet trans =
                     }
 
                 TaskCreatinineTest ->
-                    { english = "Creatinine"
-                    , kinyarwanda = Just "Keleyatinine"
-                    , kirundi = Just "Créatinine"
-                    , somali = Nothing
-                    }
+                    translationSet Creatinine
 
                 TaskLiverFunctionTest ->
-                    { english = "Liver Function"
-                    , kinyarwanda = Just "Imikorere y'Umwijima"
-                    , kirundi = Just "Ugukora kw'Igitigu"
-                    , somali = Nothing
-                    }
+                    translationSet LiverFunction
 
                 TaskLipidPanelTest ->
                     translationSet LipidPanel
 
                 TaskHbA1cTest ->
-                    { english = "HBA1C"
-                    , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
-                    , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
-                    , somali = Nothing
-                    }
+                    translationSet HBA1C
 
                 TaskPartnerHIVTest ->
                     translationSet PartnerHIV
@@ -11319,28 +11083,16 @@ translationSet trans =
                     }
 
                 TaskCreatinineTest ->
-                    { english = "Creatinine"
-                    , kinyarwanda = Just "Keleyatinine"
-                    , kirundi = Just "Créatinine"
-                    , somali = Nothing
-                    }
+                    translationSet Creatinine
 
                 TaskLiverFunctionTest ->
-                    { english = "Liver Function"
-                    , kinyarwanda = Just "Imikorere y'Umwijima"
-                    , kirundi = Just "Ugukora kw'Igitigu"
-                    , somali = Nothing
-                    }
+                    translationSet LiverFunction
 
                 TaskLipidPanelTest ->
                     translationSet LipidPanel
 
                 TaskHbA1cTest ->
-                    { english = "HBA1C"
-                    , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
-                    , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
-                    , somali = Nothing
-                    }
+                    translationSet HBA1C
 
                 TaskPartnerHIVTest ->
                     translationSet PartnerHIV
@@ -11512,18 +11264,10 @@ translationSet trans =
                     }
 
                 TaskRandomBloodSugarTest ->
-                    { english = "Random Blood Sugar Test Result"
-                    , kinyarwanda = Just "Igisubizo ku kizamini gipima ingano y'isukari mu maraso"
-                    , kirundi = Just "Inyishu y'igipimo c'Isukari mu Maraso umwanya uwariwo wose"
-                    , somali = Nothing
-                    }
+                    translationSet RandomBloodSugarTestResult
 
                 TaskHIVPCRTest ->
-                    { english = "HIV PCR Test Result"
-                    , kinyarwanda = Just "Ibisubizo by'ikizamini cya PCR gipima Virusi itera SIDA"
-                    , kirundi = Just "Inyishu y'igipimo ca PCR ya VIH"
-                    , somali = Nothing
-                    }
+                    translationSet HIVPCRTestResult
 
                 TaskPregnancyTest ->
                     { english = "Pregnancy Test Result"
@@ -11679,11 +11423,7 @@ translationSet trans =
                     }
 
                 LabResultsHistoryHaemoglobin _ ->
-                    { english = "Hemoglobin Test History"
-                    , kinyarwanda = Just "Amakuru ku kizamini cy'ingano y'amaraso"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet HemoglobinTestHistory
 
                 LabResultsHistoryKetone _ ->
                     { english = "Ketone Test History"
@@ -11707,11 +11447,7 @@ translationSet trans =
                     }
 
                 LabResultsHistoryHemoglobin _ ->
-                    { english = "Hemoglobin Test History"
-                    , kinyarwanda = Just "Amakuru ku kizamini cy'ingano y'amaraso"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet HemoglobinTestHistory
 
                 LabResultsHistoryBloodGroup _ ->
                     { english = "Blood Group Test History"
@@ -11763,18 +11499,10 @@ translationSet trans =
                     }
 
                 LabResultsHistoryHbA1c _ ->
-                    { english = "HBA1C"
-                    , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
-                    , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
-                    , somali = Nothing
-                    }
+                    translationSet HBA1C
 
                 LabResultsHistoryTotalCholesterol _ ->
-                    { english = "Total Cholesterol"
-                    , kinyarwanda = Just "Igipimo cy'ibinure byose mu maraso (Total cholesterol)"
-                    , kirundi = Just "Icegeranyo c'amavuta m'umubiri"
-                    , somali = Just "Wadarta Kolesteroolka"
-                    }
+                    translationSet TotalCholesterol
 
                 LabResultsHistoryLDLCholesterol _ ->
                     { english = "LDL Cholesterol"
@@ -11964,11 +11692,7 @@ translationSet trans =
         LabResultsPaneHeader mode ->
             case mode of
                 LabResultsCurrentMain ->
-                    { english = "Lab Results"
-                    , kinyarwanda = Just "Ibisubizo by'Ibizamini Byafashwe"
-                    , kirundi = Just "Inyishu y'igipimo c'ingwara"
-                    , somali = Just "Natiijada baaritaanada"
-                    }
+                    translationSet LabResults
 
                 LabResultsCurrentDipstickShort ->
                     { english = "Short Dipstick Lab Results"
@@ -12126,11 +11850,7 @@ translationSet trans =
                     }
 
                 PrimarySchool ->
-                    { english = "Primary School"
-                    , kinyarwanda = Just "Abanza"
-                    , kirundi = Just "Amashule matoya"
-                    , somali = Just "Dugsi Hoose"
-                    }
+                    translationSet PrimarySchoolLabel
 
                 VocationalTrainingSchool ->
                     { english = "Vocational Training School"
@@ -12147,11 +11867,7 @@ translationSet trans =
                     }
 
                 DiplomaProgram ->
-                    { english = "Diploma Program (2 years of University)"
-                    , kinyarwanda = Just "Amashuri 2 ya Kaminuza"
-                    , kirundi = Just "Umugambi wo kuronka urupapuro rw'umutsindo (Imyaka Ibiri (2) kuri Kaminuza)"
-                    , somali = Just "Barnaamijka Dibloomada (2 sano oo Jaamacad ah)"
-                    }
+                    translationSet DiplomaProgram2YearsOfUniversity
 
                 HigherEducation ->
                     { english = "Higher Education (University)"
@@ -12169,11 +11885,7 @@ translationSet trans =
 
                 -- Not in use.
                 MastersDegree ->
-                    { english = "Masters Degree"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Urupapuro rw'umutsindo rw'igice ca 3 mashule (Maîtrise)"
-                    , somali = Nothing
-                    }
+                    translationSet MastersDegreeLabel
 
         LevelOfEducationForResilience educationLevel ->
             case educationLevel of
@@ -12185,11 +11897,7 @@ translationSet trans =
                     }
 
                 PrimarySchool ->
-                    { english = "Primary School"
-                    , kinyarwanda = Just "Abanza"
-                    , kirundi = Just "Amashule matoya"
-                    , somali = Just "Dugsi Hoose"
-                    }
+                    translationSet PrimarySchoolLabel
 
                 VocationalTrainingSchool ->
                     { english = "Vocational School"
@@ -12207,11 +11915,7 @@ translationSet trans =
 
                 -- Not it use.
                 DiplomaProgram ->
-                    { english = "Diploma Program (2 years of University)"
-                    , kinyarwanda = Just "Amashuri 2 ya Kaminuza"
-                    , kirundi = Just "Umugambi wo kuronka urupapuro rw'umutsindo (Imyaka Ibiri (2) kuri Kaminuza)"
-                    , somali = Just "Barnaamijka Dibloomada (2 sano oo Jaamacad ah)"
-                    }
+                    translationSet DiplomaProgram2YearsOfUniversity
 
                 AdvancedDiploma ->
                     { english = "Advanced Diploma (A1)"
@@ -12228,11 +11932,7 @@ translationSet trans =
                     }
 
                 MastersDegree ->
-                    { english = "Masters Degree"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Urupapuro rw'umutsindo rw'igice ca 3 mashule (Maîtrise)"
-                    , somali = Nothing
-                    }
+                    translationSet MastersDegreeLabel
 
         LipidPanel ->
             { english = "Lipid Panel"
@@ -12452,18 +12152,10 @@ translationSet trans =
                     translationSet DeviceStatus
 
                 MenuWellbeing ->
-                    { english = "Wellbeing"
-                    , kinyarwanda = Just "Gubwa neza"
-                    , kirundi = Just "Imibereho myiza"
-                    , somali = Just "Fayoobid"
-                    }
+                    translationSet Wellbeing
 
                 MenuStockManagement ->
-                    { english = "Stock Management"
-                    , kinyarwanda = Just "Ububiko bw'imiti"
-                    , kirundi = Just "Ugucunga ububiko"
-                    , somali = Nothing
-                    }
+                    translationSet StockManagement
 
         MainWaterSource source ->
             case source of
@@ -12611,11 +12303,7 @@ translationSet trans =
                     }
 
                 RapidTestIndeterminate ->
-                    { english = "Indeterminate"
-                    , kinyarwanda = Just "Ntibisobanutse"
-                    , kirundi = Just "Ntibizwi neza"
-                    , somali = Just "Aan horay laga ogaan karin"
-                    }
+                    translationSet Indeterminate
 
                 RapidTestUnableToRun ->
                     { english = "Unable to run"
@@ -13005,11 +12693,7 @@ translationSet trans =
                     translationSet CardiacDisease
 
                 DiagnosisRenalDisease ->
-                    { english = "Renal Disease"
-                    , kinyarwanda = Just "Indwara z'impyiko"
-                    , kirundi = Just "Ingwara yo mu mafyigo"
-                    , somali = Nothing
-                    }
+                    translationSet RenalDisease
 
                 DiagnosisHypertensionBeforePregnancy ->
                     translationSet Hypertension
@@ -13031,11 +12715,7 @@ translationSet trans =
                     translationSet HIV
 
                 DiagnosisMentalHealthHistory ->
-                    { english = "History of Mental Health Problems"
-                    , kinyarwanda = Just "Niba yaragize uburwayi bwo mumutwe"
-                    , kirundi = Just "Akahise k'ingorane y'ingwara yo mu mutwe"
-                    , somali = Nothing
-                    }
+                    translationSet HistoryOfMentalHealthProblems
 
         MedicalHistory ->
             { english = "Medical History"
@@ -13216,11 +12896,7 @@ translationSet trans =
             }
 
         MedicationDistributionHelperPreeclampsiaRiskHigh ->
-            { english = "Patient shows signs of High Risk for Preclampsia"
-            , kinyarwanda = Just "Umubyeyi agaragaza ibimenyetso biri hejuru byo kugira Preklampusi"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
+            translationSet PatientShowsSignsOfHighRiskForPreclampsia
 
         MedicationDistributionHelperPreeclampsiaRiskModerate ->
             { english = "Patient shows signs of Moderate Risk for Preclampsia"
@@ -13424,18 +13100,10 @@ translationSet trans =
                     }
 
                 Calcium ->
-                    { english = "Calcium"
-                    , kinyarwanda = Just "Kalisiyumu"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet CalciumLabel
 
                 MMS ->
-                    { english = "MMS"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet MMSLabel
 
                 Fefol ->
                     { english = "Fefol"
@@ -13597,11 +13265,7 @@ translationSet trans =
             }
 
         MentalHealthHistory ->
-            { english = "History of Mental Health Problems"
-            , kinyarwanda = Just "Niba yaragize uburwayi bwo mumutwe"
-            , kirundi = Just "Akahise k'ingorane y'ingwara yo mu mutwe"
-            , somali = Nothing
-            }
+            translationSet HistoryOfMentalHealthProblems
 
         MentalHealthIssues ->
             { english = "Mental health issues"
@@ -13630,11 +13294,7 @@ translationSet trans =
                     }
 
                 TabConnecting ->
-                    { english = "Connecting"
-                    , kinyarwanda = Just "Gusabana"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Connecting
 
                 TabSelfcare ->
                     { english = "Selfcare"
@@ -14527,18 +14187,10 @@ translationSet trans =
         NCDAFillTheBlanksItemLabel item ->
             case item of
                 HeightToAge ->
-                    { english = "Level of stunting using child length mat"
-                    , kinyarwanda = Just "Ikigero cyo kugwingira hakoreshejwe agasambi"
-                    , kirundi = Nothing
-                    , somali = Just "Heerka nafaqo darrda ayadoo la isticmaalayo xariga cabirka"
-                    }
+                    translationSet LevelOfStuntingUsingChildLengthMat
 
                 WeightToAge ->
-                    { english = "Weight"
-                    , kinyarwanda = Just "Ibiro"
-                    , kirundi = Just "Uburemere"
-                    , somali = Just "Miisaan"
-                    }
+                    translationSet Weight
 
                 MuacValue ->
                     translationSet MUAC
@@ -14604,11 +14256,7 @@ translationSet trans =
                     }
 
                 VisionChanges ->
-                    { english = "Vision Changes"
-                    , kinyarwanda = Just "Uko areba byahindutse"
-                    , kirundi = Just "Impinduka y'icerekezo"
-                    , somali = Nothing
-                    }
+                    translationSet VisionChangesLabel
 
                 ChestPain ->
                     { english = "Chest Pain"
@@ -14731,11 +14379,7 @@ translationSet trans =
         NCDExaminationTask task ->
             case task of
                 TaskCoreExam ->
-                    { english = "Core Physical Exam"
-                    , kinyarwanda = Just "Isuzuma ryimbitse"
-                    , kirundi = Just "Igipimo c'umubiri c'intango"
-                    , somali = Nothing
-                    }
+                    translationSet CorePhysicalExamLabel
 
                 TaskVitals ->
                     { english = "Vitals"
@@ -14783,11 +14427,7 @@ translationSet trans =
                     translationSet EmptyString
 
         NCDHealthEducationHeader ->
-            { english = "Stage One Hypertension"
-            , kinyarwanda = Just "Umuvuduko w'amaraso uri ku rwego rwa mbere"
-            , kirundi = Just "Umuvuduko w'amaraso uri mu c'iciro/mu gice ca mbere"
-            , somali = Nothing
-            }
+            translationSet StageOneHypertension
 
         NCDHealthEducationInstructions ->
             { english = "Counsel patient on lifestyle changes and the root causes of hypertension"
@@ -15036,11 +14676,7 @@ translationSet trans =
                     }
 
                 PainNeck ->
-                    { english = "Neck"
-                    , kinyarwanda = Just "Ijosi"
-                    , kirundi = Just "Izosi"
-                    , somali = Just "Qoorta"
-                    }
+                    translationSet Neck
 
                 PainAbdomen ->
                     { english = "Abdomen"
@@ -15511,25 +15147,13 @@ translationSet trans =
                     }
 
                 NonAdministrationKnownAllergy ->
-                    { english = "Known Allergy"
-                    , kinyarwanda = Just "Uyu muti usanzwe umutera ifurutwa"
-                    , kirundi = Just "Ihindagurika ry'umuiri rizwi"
-                    , somali = Just "Lagu yaqaano xasaasiyad"
-                    }
+                    translationSet KnownAllergy
 
                 NonAdministrationPatientDeclined ->
-                    { english = "Patient Declined"
-                    , kinyarwanda = Just "Umurwayi yanze"
-                    , kirundi = Just "Umurwayi yaranse"
-                    , somali = Just "Bukaanka ayaa Diiday"
-                    }
+                    translationSet PatientDeclined
 
                 NonAdministrationPatientUnableToAfford ->
-                    { english = "Patient Unable to Afford"
-                    , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
-                    , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
-                    , somali = Just "Bukaanka ma Awoodo Qarashka"
-                    }
+                    translationSet PatientUnableToAfford
 
                 NonAdministrationHomeBirth ->
                     { english = "Home Birth"
@@ -15539,11 +15163,7 @@ translationSet trans =
                     }
 
                 NonAdministrationTooIll ->
-                    { english = "Too Sick"
-                    , kinyarwanda = Just "Ararembye"
-                    , kirundi = Just "Ararwaye cane"
-                    , somali = Nothing
-                    }
+                    translationSet TooSick
 
                 NonAdministrationOther ->
                     { english = "Other"
@@ -15576,32 +15196,16 @@ translationSet trans =
                     }
 
                 NonAdministrationKnownAllergy ->
-                    { english = "Known Allergy or Reaction"
-                    , kinyarwanda = Just "Agira ingaruka zizwi kubera uru rukingo/umuti"
-                    , kirundi = Just "Ihindagurika ry'umuiri rizwi"
-                    , somali = Nothing
-                    }
+                    translationSet KnownAllergyOrReaction
 
                 NonAdministrationPatientDeclined ->
-                    { english = "Patient Declined"
-                    , kinyarwanda = Just "Umurwayi yanze"
-                    , kirundi = Just "Umurwayi yaranse"
-                    , somali = Just "Bukaanka ayaa Diiday"
-                    }
+                    translationSet PatientDeclined
 
                 NonAdministrationPatientUnableToAfford ->
-                    { english = "Patient Unable to Afford"
-                    , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
-                    , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
-                    , somali = Just "Bukaanka ma Awoodo Qarashka"
-                    }
+                    translationSet PatientUnableToAfford
 
                 NonAdministrationTooIll ->
-                    { english = "Too Sick"
-                    , kinyarwanda = Just "Ararembye"
-                    , kirundi = Just "Ararwaye cane"
-                    , somali = Nothing
-                    }
+                    translationSet TooSick
 
                 NonAdministrationOther ->
                     { english = "Other"
@@ -15624,11 +15228,7 @@ translationSet trans =
                     }
 
                 NonAdministrationKnownAllergy ->
-                    { english = "Known Allergy or Reaction"
-                    , kinyarwanda = Just "Agira ingaruka zizwi kubera uru rukingo/umuti"
-                    , kirundi = Just "Ihindagurika ry'umuiri rizwi"
-                    , somali = Nothing
-                    }
+                    translationSet KnownAllergyOrReaction
 
                 NonAdministrationPatientDeclined ->
                     { english = "Mother / Caregiver Declined"
@@ -15638,18 +15238,10 @@ translationSet trans =
                     }
 
                 NonAdministrationPatientUnableToAfford ->
-                    { english = "Patient Unable to Afford"
-                    , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
-                    , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
-                    , somali = Just "Bukaanka ma Awoodo Qarashka"
-                    }
+                    translationSet PatientUnableToAfford
 
                 NonAdministrationTooIll ->
-                    { english = "Too Sick"
-                    , kinyarwanda = Just "Ararembye"
-                    , kirundi = Just "Ararwaye cane"
-                    , somali = Nothing
-                    }
+                    translationSet TooSick
 
                 NonAdministrationOther ->
                     { english = "Other"
@@ -15979,11 +15571,7 @@ translationSet trans =
         NutritionAssessmentTask task ->
             case task of
                 TaskHeight ->
-                    { english = "Height"
-                    , kinyarwanda = Just "Uburebure"
-                    , kirundi = Just "Uburebure"
-                    , somali = Just "Dhirika"
-                    }
+                    translationSet Height
 
                 TaskHeadCircumference ->
                     { english = "Head Circumference"
@@ -15999,11 +15587,7 @@ translationSet trans =
                     translationSet Nutrition
 
                 TaskWeight ->
-                    { english = "Weight"
-                    , kinyarwanda = Just "Ibiro"
-                    , kirundi = Just "Uburemere"
-                    , somali = Just "Miisaan"
-                    }
+                    translationSet Weight
 
         NutritionBehavior ->
             { english = "Nutrition Behavior"
@@ -16185,11 +15769,7 @@ translationSet trans =
                     translationSet HealthEducation
 
                 NextStepContributingFactors ->
-                    { english = "Contributing Factors"
-                    , kinyarwanda = Just "Impamvu zateye uburwayi"
-                    , kirundi = Just "Ivyatumye arwara"
-                    , somali = Just "Waxyaabaha Keeni kara"
-                    }
+                    translationSet ContributingFactors
 
                 NextStepFollowUp ->
                     translationSet FollowUp
@@ -16228,11 +15808,7 @@ translationSet trans =
                     translationSet None
 
         NitritionSigns ->
-            { english = "Nutrition Signs"
-            , kinyarwanda = Just "Ibimenyetso by'imirire"
-            , kirundi = Just "Ibimenyetso vyo gufungura"
-            , somali = Just "Calaamadaha Nafaqada"
-            }
+            translationSet NutritionSigns
 
         Observations ->
             { english = "Observations"
@@ -17184,11 +16760,7 @@ translationSet trans =
                     }
 
                 PostpartumChildParalysis ->
-                    { english = "Paralysis"
-                    , kinyarwanda = Just "Igice cy'umubiri kidakora"
-                    , kirundi = Just "Ubumuga"
-                    , somali = Just "Curyaan"
-                    }
+                    translationSet Paralysis
 
                 PostpartumChildLabouredBreathing ->
                     { english = "Laboured or Rapid Breathing"
@@ -17245,11 +16817,7 @@ translationSet trans =
                     }
 
                 PostpartumMotherParalysis ->
-                    { english = "Paralysis"
-                    , kinyarwanda = Just "Igice cy'umubiri kidakora"
-                    , kirundi = Just "Ubumuga"
-                    , somali = Just "Curyaan"
-                    }
+                    translationSet Paralysis
 
                 PostpartumMotherAcuteAbdominalPain ->
                     { english = "Acute Abdominal Pain"
@@ -17435,11 +17003,7 @@ translationSet trans =
                     }
 
                 PregnancyTestIndeterminate ->
-                    { english = "Indeterminate"
-                    , kinyarwanda = Just "Ntibisobanutse"
-                    , kirundi = Just "Ntibizwi neza"
-                    , somali = Just "Aan horay laga ogaan karin"
-                    }
+                    translationSet Indeterminate
 
                 PregnancyTestUnableToConduct ->
                     { english = "Unable to conduct test"
@@ -17517,11 +17081,7 @@ translationSet trans =
                     }
 
                 PrenatalPhoto ->
-                    { english = "Photo"
-                    , kinyarwanda = Just "Ifoto"
-                    , kirundi = Just "Ifoto"
-                    , somali = Just "Sawir"
-                    }
+                    translationSet Photo
 
                 Backend.PrenatalActivity.Model.Laboratory ->
                     { english = "Laboratory"
@@ -17574,11 +17134,7 @@ translationSet trans =
                     }
 
                 PrenatalImmunisation ->
-                    { english = "Immunizations"
-                    , kinyarwanda = Just "Ikingira"
-                    , kirundi = Just "Incanco"
-                    , somali = Just "Tallaalada"
-                    }
+                    translationSet Immunizations
 
                 Backend.PrenatalActivity.Model.Breastfeeding ->
                     { english = "Breastfeeding"
@@ -17656,31 +17212,19 @@ translationSet trans =
         PrenatalDiagnosis diagnosis ->
             case diagnosis of
                 DiagnosisChronicHypertensionImmediate ->
-                    { english = "Chronic Hypertension"
-                    , kinyarwanda = Just "Indwara y'Umuvuduko w'Amaraso Imaze Igihe Kirekire"
-                    , kirundi = Just "Umuvuduko ukabije w'amaraso wamaho"
-                    , somali = Nothing
-                    }
+                    translationSet ChronicHypertension
 
                 DiagnosisChronicHypertensionAfterRecheck ->
                     translationSet <| PrenatalDiagnosis DiagnosisChronicHypertensionImmediate
 
                 DiagnosisGestationalHypertensionImmediate ->
-                    { english = "Pregnancy-Induced Hypertension"
-                    , kinyarwanda = Just "Umuvuduko w'amaraso watewe no gutwita"
-                    , kirundi = Just "Umuvuduko w'amaraso utewe n'imbanyi"
-                    , somali = Nothing
-                    }
+                    translationSet PregnancyInducedHypertension
 
                 DiagnosisGestationalHypertensionAfterRecheck ->
                     translationSet <| PrenatalDiagnosis DiagnosisGestationalHypertensionImmediate
 
                 DiagnosisModeratePreeclampsiaInitialPhase ->
-                    { english = "Mild to Moderate Preeclampsia"
-                    , kinyarwanda = Just "Preklampusi Yoroheje"
-                    , kirundi = Just "Umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
-                    , somali = Just "Dhiig karka Uurka u dhaxeeya mid hoose iyo mid dhexe"
-                    }
+                    translationSet MildToModeratePreeclampsia
 
                 DiagnosisModeratePreeclampsiaInitialPhaseEGA37Plus ->
                     translationSet <| PrenatalDiagnosis DiagnosisModeratePreeclampsiaInitialPhase
@@ -17727,11 +17271,7 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosis DiagnosisHIVDetectableViralLoadInitialPhase
 
                 DiagnosisDiscordantPartnershipInitialPhase ->
-                    { english = "Discordant Partnership"
-                    , kinyarwanda = Just "Umwe mubo babana afite ubwandu"
-                    , kirundi = Just "Umwe afise umugera wa SIDA kandi uwundi atawafise"
-                    , somali = Nothing
-                    }
+                    translationSet DiscordantPartnership
 
                 DiagnosisDiscordantPartnershipRecurrentPhase ->
                     translationSet <| PrenatalDiagnosis DiagnosisDiscordantPartnershipInitialPhase
@@ -17743,11 +17283,7 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosis DiagnosisSyphilisInitialPhase
 
                 DiagnosisSyphilisWithComplicationsInitialPhase ->
-                    { english = "Syphilis with Complications"
-                    , kinyarwanda = Just "Mburugu n'ibibazo bishamikiyeho"
-                    , kirundi = Just "Syphilis hamwe n'ingorane"
-                    , somali = Nothing
-                    }
+                    translationSet SyphilisWithComplications
 
                 DiagnosisSyphilisWithComplicationsRecurrentPhase ->
                     translationSet <| PrenatalDiagnosis DiagnosisSyphilisWithComplicationsInitialPhase
@@ -17789,31 +17325,19 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosis DiagnosisMalariaMedicatedContinuedInitialPhase
 
                 DiagnosisMalariaWithAnemiaInitialPhase ->
-                    { english = "Malaria with Anemia"
-                    , kinyarwanda = Just "Malariya n'Amaraso Macye"
-                    , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri"
-                    , somali = Nothing
-                    }
+                    translationSet MalariaWithAnemia
 
                 DiagnosisMalariaWithAnemiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosis DiagnosisMalariaWithAnemiaInitialPhase
 
                 DiagnosisMalariaWithAnemiaMedicatedContinuedInitialPhase ->
-                    { english = "Malaria with Anemia Continued"
-                    , kinyarwanda = Just "Malariya n'Amaraso Macye bikigaragara"
-                    , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri birabandanya"
-                    , somali = Nothing
-                    }
+                    translationSet MalariaWithAnemiaContinued
 
                 DiagnosisMalariaWithAnemiaMedicatedContinuedRecurrentPhase ->
                     translationSet <| PrenatalDiagnosis DiagnosisMalariaWithAnemiaMedicatedContinuedInitialPhase
 
                 DiagnosisMalariaWithSevereAnemiaInitialPhase ->
-                    { english = "Malaria with Severe Anemia"
-                    , kinyarwanda = Just "Malariya n'Amaraso Macye Cyane"
-                    , kirundi = Just "Malariya kumwe n'igabanuka ry'amaraso m'umubiri ridasanzwe"
-                    , somali = Just "Duumo leh Dhiig la`aan Daran"
-                    }
+                    translationSet MalariaWithSevereAnemia
 
                 DiagnosisMalariaWithSevereAnemiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosis DiagnosisMalariaWithSevereAnemiaInitialPhase
@@ -17911,39 +17435,19 @@ translationSet trans =
                     }
 
                 DiagnosisHyperemesisGravidum ->
-                    { english = "Hyperemesis Gravidum"
-                    , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
-                    , kirundi = Just "Hyperémèse gravidique"
-                    , somali = Nothing
-                    }
+                    translationSet HyperemesisGravidum
 
                 DiagnosisHyperemesisGravidumBySymptoms ->
-                    { english = "Hyperemesis Gravidum"
-                    , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
-                    , kirundi = Just "Hyperémèse gravidique"
-                    , somali = Nothing
-                    }
+                    translationSet HyperemesisGravidum
 
                 DiagnosisSevereVomiting ->
-                    { english = "Severe Vomiting"
-                    , kinyarwanda = Just "Kuruka bikabije"
-                    , kirundi = Just "Ukudahwa gukaze"
-                    , somali = Nothing
-                    }
+                    translationSet SevereVomitingLabel
 
                 DiagnosisSevereVomitingBySymptoms ->
-                    { english = "Severe Vomiting"
-                    , kinyarwanda = Just "Kuruka bikabije"
-                    , kirundi = Just "Ukudahwa gukaze"
-                    , somali = Nothing
-                    }
+                    translationSet SevereVomitingLabel
 
                 DiagnosisMaternalComplications ->
-                    { english = "Maternal Complications"
-                    , kinyarwanda = Just "Ibibazo bishobora kwibasira umugore utwite"
-                    , kirundi = Just "Ingorane z'abavyeyi"
-                    , somali = Nothing
-                    }
+                    translationSet MaternalComplications
 
                 DiagnosisInfection ->
                     { english = "Infection"
@@ -17953,25 +17457,13 @@ translationSet trans =
                     }
 
                 DiagnosisImminentDelivery ->
-                    { english = "Imminent Delivery"
-                    , kinyarwanda = Just "Kubyara biri hafi"
-                    , kirundi = Just "Gutanga bigaragara/"
-                    , somali = Nothing
-                    }
+                    translationSet ImminentDeliveryLabel
 
                 DiagnosisLaborAndDelivery ->
-                    { english = "Labor + Delivery"
-                    , kinyarwanda = Just "Kujya ku nda + Kubyara"
-                    , kirundi = Just "Ibise + Kuvyara"
-                    , somali = Just "Fool + Dhalmo"
-                    }
+                    translationSet LaborDelivery
 
                 DiagnosisHeartburn ->
-                    { english = "Heartburn"
-                    , kinyarwanda = Just "Ikirungurira"
-                    , kirundi = Just "Ugusha k'umutima"
-                    , somali = Nothing
-                    }
+                    translationSet HeartburnLabel
 
                 DiagnosisHeartburnPersistent ->
                     { english = "Persistent Heartburn"
@@ -18023,11 +17515,7 @@ translationSet trans =
                     }
 
                 DiagnosisCandidiasis ->
-                    { english = "Candidiasis"
-                    , kinyarwanda = Just "Kandidoze"
-                    , kirundi = Just "Candidose"
-                    , somali = Nothing
-                    }
+                    translationSet Candidiasis
 
                 DiagnosisCandidiasisContinued ->
                     { english = "Candidiasis Continued"
@@ -18037,11 +17525,7 @@ translationSet trans =
                     }
 
                 DiagnosisGonorrhea ->
-                    { english = "Gonorrhea"
-                    , kinyarwanda = Just "Indwara y'umutezi"
-                    , kirundi = Just "Ingwara yo mu bihimba vy'irondoka"
-                    , somali = Nothing
-                    }
+                    translationSet Gonorrhea
 
                 DiagnosisGonorrheaContinued ->
                     { english = "Gonorrhea Continued"
@@ -18051,11 +17535,7 @@ translationSet trans =
                     }
 
                 DiagnosisTrichomonasOrBacterialVaginosis ->
-                    { english = "Trichomonas or Bacterial Vaginosis"
-                    , kinyarwanda = Just "Tirikomonasi cyangwa Mikorobe zo mu nda ibyara"
-                    , kirundi = Just "Ingwara yo mu bihimba vy'irondoka igaragazwa kenshi no kuhiyagaza"
-                    , somali = Just "Trichomonas ama Bakteeriyada Makaanka"
-                    }
+                    translationSet TrichomonasOrBacterialVaginosis
 
                 DiagnosisTrichomonasOrBacterialVaginosisContinued ->
                     { english = "Trichomonas or Bacterial Vaginosis Continued"
@@ -18090,56 +17570,28 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosis DiagnosisRhesusNegativeInitialPhase
 
                 DiagnosisDepressionNotLikely ->
-                    { english = "Depression not Likely"
-                    , kinyarwanda = Just "Birashoboka ko adafite indwara y'agahinda gakabije"
-                    , kirundi = Just "Kwihebura ntibishoboka"
-                    , somali = Nothing
-                    }
+                    translationSet DepressionNotLikely
 
                 DiagnosisDepressionPossible ->
-                    { english = "Depression Possible"
-                    , kinyarwanda = Just "Birashoboka ko yagira indwara y'agahinda gakabije"
-                    , kirundi = Just "Kwihebura birashoboka"
-                    , somali = Nothing
-                    }
+                    translationSet DepressionPossible
 
                 DiagnosisDepressionHighlyPossible ->
-                    { english = "Fairly High Possibility of Depression"
-                    , kinyarwanda = Just "Birashoboka cyane ko afite indwara y'agahinda gakabije"
-                    , kirundi = Just "Birashoboka cane kwihebura"
-                    , somali = Nothing
-                    }
+                    translationSet FairlyHighPossibilityOfDepression
 
                 DiagnosisDepressionProbable ->
-                    { english = "Probable Depression"
-                    , kinyarwanda = Just "Birashoboka ko afite indwara y'agahinda gakabije"
-                    , kirundi = Just "Ukwihebura gushoboka"
-                    , somali = Just "U eg Niyad Jab"
-                    }
+                    translationSet ProbableDepression
 
                 DiagnosisSuicideRisk ->
-                    { english = "Suicide Risk"
-                    , kinyarwanda = Just "Afite ibyago byo kwiyahura"
-                    , kirundi = Just "Ingorane zimutuma ashobora kwiyahura"
-                    , somali = Nothing
-                    }
+                    translationSet SuicideRisk
 
                 DiagnosisHighRiskOfPreeclampsiaInitialPhase ->
-                    { english = "High Risk of Preeclampsia"
-                    , kinyarwanda = Just "Afite ibyago byinshi byo kugira Preklampusi"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet HighRiskOfPreeclampsia
 
                 DiagnosisHighRiskOfPreeclampsiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosis DiagnosisHighRiskOfPreeclampsiaInitialPhase
 
                 DiagnosisModerateRiskOfPreeclampsia ->
-                    { english = "Moderate Risk of Preeclampsia"
-                    , kinyarwanda = Just "Afite ibyago biringaniye byo kugira Preklampusi"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet ModerateRiskOfPreeclampsia
 
                 DiagnosisOther ->
                     { english = "Other"
@@ -18149,11 +17601,7 @@ translationSet trans =
                     }
 
                 DiagnosisPostpartumAbdominalPain ->
-                    { english = "Abdominal Pain"
-                    , kinyarwanda = Just "Kubabara mu nda"
-                    , kirundi = Just "Ukubabara mu nda"
-                    , somali = Just "Calool Xanuun"
-                    }
+                    translationSet AbdominalPainLabel
 
                 DiagnosisPostpartumUrinaryIncontinence ->
                     { english = "Urinary Incontinence"
@@ -18172,11 +17620,7 @@ translationSet trans =
                     translationSet Fever
 
                 DiagnosisPostpartumPerinealPainOrDischarge ->
-                    { english = "Perineal Pain or Discharge"
-                    , kinyarwanda = Just "Arababara perine cg aratakaza ibintu budasanzwe"
-                    , kirundi = Just "Ububabare bw'umugongo hepfo"
-                    , somali = Just "Xanuun qaska ah ama Dheecaan"
-                    }
+                    translationSet PerinealPainOrDischarge
 
                 DiagnosisPostpartumInfection ->
                     { english = "Infection"
@@ -18186,25 +17630,13 @@ translationSet trans =
                     }
 
                 DiagnosisPostpartumExcessiveBleeding ->
-                    { english = "Excessive Bleeding"
-                    , kinyarwanda = Just "Kuva cyane"
-                    , kirundi = Just "Kuva amaraso cane"
-                    , somali = Just "Dhiigbax aad u daran"
-                    }
+                    translationSet ExcessiveBleeding
 
                 DiagnosisPostpartumEarlyMastitisOrEngorgment ->
-                    { english = "Early Mastitis or Engorgement"
-                    , kinyarwanda = Just "Uburwayi bwo kubyimba amabere bwaje kare cyane"
-                    , kirundi = Just "Iyuzura ry'amaberebere (Mastite précoce)"
-                    , somali = Nothing
-                    }
+                    translationSet EarlyMastitisOrEngorgement
 
                 DiagnosisPostpartumMastitis ->
-                    { english = "Mastitis"
-                    , kinyarwanda = Just "Uburwayi bw'amabere"
-                    , kirundi = Just "Ingwara y'imoko ituma amaberebere adasohoka"
-                    , somali = Nothing
-                    }
+                    translationSet Mastitis
 
                 NoPrenatalDiagnosis ->
                     translationSet None
@@ -18212,31 +17644,19 @@ translationSet trans =
         PrenatalDiagnosisForProgressReport diagnosis ->
             case diagnosis of
                 DiagnosisChronicHypertensionImmediate ->
-                    { english = "Chronic Hypertension"
-                    , kinyarwanda = Just "Indwara y'Umuvuduko w'Amaraso Imaze Igihe Kirekire"
-                    , kirundi = Just "Umuvuduko ukabije w'amaraso wamaho"
-                    , somali = Nothing
-                    }
+                    translationSet ChronicHypertension
 
                 DiagnosisChronicHypertensionAfterRecheck ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisChronicHypertensionImmediate
 
                 DiagnosisGestationalHypertensionImmediate ->
-                    { english = "Pregnancy-Induced Hypertension"
-                    , kinyarwanda = Just "Umuvuduko w'amaraso watewe no gutwita"
-                    , kirundi = Just "Umuvuduko w'amaraso utewe n'imbanyi"
-                    , somali = Nothing
-                    }
+                    translationSet PregnancyInducedHypertension
 
                 DiagnosisGestationalHypertensionAfterRecheck ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisGestationalHypertensionImmediate
 
                 DiagnosisModeratePreeclampsiaInitialPhase ->
-                    { english = "Mild to Moderate Preeclampsia"
-                    , kinyarwanda = Just "Preklampusi Yoroheje"
-                    , kirundi = Just "Umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
-                    , somali = Just "Dhiig karka Uurka u dhaxeeya mid hoose iyo mid dhexe"
-                    }
+                    translationSet MildToModeratePreeclampsia
 
                 DiagnosisModeratePreeclampsiaInitialPhaseEGA37Plus ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisModeratePreeclampsiaInitialPhase
@@ -18264,11 +17684,7 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisSeverePreeclampsiaInitialPhase
 
                 DiagnosisEclampsia ->
-                    { english = "Eclampsia"
-                    , kinyarwanda = Just "Ekalampusi"
-                    , kirundi = Just "Éclampsie"
-                    , somali = Just "Ekalaamsiyo"
-                    }
+                    translationSet Eclampsia
 
                 DiagnosisHIVInitialPhase ->
                     translationSet HIV
@@ -18287,11 +17703,7 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisHIVDetectableViralLoadInitialPhase
 
                 DiagnosisDiscordantPartnershipInitialPhase ->
-                    { english = "Discordant Partnership"
-                    , kinyarwanda = Just "Umwe mubo babana afite ubwandu"
-                    , kirundi = Just "Umwe afise umugera wa SIDA kandi uwundi atawafise"
-                    , somali = Nothing
-                    }
+                    translationSet DiscordantPartnership
 
                 DiagnosisDiscordantPartnershipRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisDiscordantPartnershipInitialPhase
@@ -18303,11 +17715,7 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisSyphilisInitialPhase
 
                 DiagnosisSyphilisWithComplicationsInitialPhase ->
-                    { english = "Syphilis with Complications"
-                    , kinyarwanda = Just "Mburugu n'ibibazo bishamikiyeho"
-                    , kirundi = Just "Syphilis hamwe n'ingorane"
-                    , somali = Nothing
-                    }
+                    translationSet SyphilisWithComplications
 
                 DiagnosisSyphilisWithComplicationsRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisSyphilisWithComplicationsInitialPhase
@@ -18349,31 +17757,19 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisMalariaMedicatedContinuedInitialPhase
 
                 DiagnosisMalariaWithAnemiaInitialPhase ->
-                    { english = "Malaria with Anemia"
-                    , kinyarwanda = Just "Malariya n'Amaraso Macye"
-                    , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri"
-                    , somali = Nothing
-                    }
+                    translationSet MalariaWithAnemia
 
                 DiagnosisMalariaWithAnemiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisMalariaWithAnemiaInitialPhase
 
                 DiagnosisMalariaWithAnemiaMedicatedContinuedInitialPhase ->
-                    { english = "Malaria with Anemia Continued"
-                    , kinyarwanda = Just "Malariya n'Amaraso Macye bikigaragara"
-                    , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri birabandanya"
-                    , somali = Nothing
-                    }
+                    translationSet MalariaWithAnemiaContinued
 
                 DiagnosisMalariaWithAnemiaMedicatedContinuedRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisMalariaWithAnemiaMedicatedContinuedInitialPhase
 
                 DiagnosisMalariaWithSevereAnemiaInitialPhase ->
-                    { english = "Malaria with Severe Anemia"
-                    , kinyarwanda = Just "Malariya n'Amaraso Macye Cyane"
-                    , kirundi = Just "Malariya kumwe n'igabanuka ry'amaraso m'umubiri ridasanzwe"
-                    , somali = Just "Duumo leh Dhiig la`aan Daran"
-                    }
+                    translationSet MalariaWithSevereAnemia
 
                 DiagnosisMalariaWithSevereAnemiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisMalariaWithSevereAnemiaInitialPhase
@@ -18479,39 +17875,19 @@ translationSet trans =
                     }
 
                 DiagnosisHyperemesisGravidum ->
-                    { english = "Hyperemesis Gravidum"
-                    , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
-                    , kirundi = Just "Hyperémèse gravidique"
-                    , somali = Nothing
-                    }
+                    translationSet HyperemesisGravidum
 
                 DiagnosisHyperemesisGravidumBySymptoms ->
-                    { english = "Hyperemesis Gravidum"
-                    , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
-                    , kirundi = Just "Hyperémèse gravidique"
-                    , somali = Nothing
-                    }
+                    translationSet HyperemesisGravidum
 
                 DiagnosisSevereVomiting ->
-                    { english = "Severe Vomiting"
-                    , kinyarwanda = Just "Kuruka bikabije"
-                    , kirundi = Just "Ukudahwa gukaze"
-                    , somali = Nothing
-                    }
+                    translationSet SevereVomitingLabel
 
                 DiagnosisSevereVomitingBySymptoms ->
-                    { english = "Severe Vomiting"
-                    , kinyarwanda = Just "Kuruka bikabije"
-                    , kirundi = Just "Ukudahwa gukaze"
-                    , somali = Nothing
-                    }
+                    translationSet SevereVomitingLabel
 
                 DiagnosisMaternalComplications ->
-                    { english = "Maternal Complications"
-                    , kinyarwanda = Just "Ibibazo bishobora kwibasira umugore utwite"
-                    , kirundi = Just "Ingorane z'abavyeyi"
-                    , somali = Nothing
-                    }
+                    translationSet MaternalComplications
 
                 DiagnosisInfection ->
                     { english = "Infection"
@@ -18521,18 +17897,10 @@ translationSet trans =
                     }
 
                 DiagnosisImminentDelivery ->
-                    { english = "Imminent Delivery"
-                    , kinyarwanda = Just "Kubyara biri hafi"
-                    , kirundi = Just "Gutanga bigaragara/"
-                    , somali = Nothing
-                    }
+                    translationSet ImminentDeliveryLabel
 
                 DiagnosisLaborAndDelivery ->
-                    { english = "Labor + Delivery"
-                    , kinyarwanda = Just "Kujya ku nda + Kubyara"
-                    , kirundi = Just "Ibise + Kuvyara"
-                    , somali = Just "Fool + Dhalmo"
-                    }
+                    translationSet LaborDelivery
 
                 DiagnosisHeartburn ->
                     { english = "Heartburn in pregnancy"
@@ -18591,11 +17959,7 @@ translationSet trans =
                     }
 
                 DiagnosisCandidiasis ->
-                    { english = "Candidiasis"
-                    , kinyarwanda = Just "Kandidoze"
-                    , kirundi = Just "Candidose"
-                    , somali = Nothing
-                    }
+                    translationSet Candidiasis
 
                 DiagnosisCandidiasisContinued ->
                     { english = "Candidiasis (continued)"
@@ -18605,11 +17969,7 @@ translationSet trans =
                     }
 
                 DiagnosisGonorrhea ->
-                    { english = "Gonorrhea"
-                    , kinyarwanda = Just "Indwara y'umutezi"
-                    , kirundi = Just "Ingwara yo mu bihimba vy'irondoka"
-                    , somali = Nothing
-                    }
+                    translationSet Gonorrhea
 
                 DiagnosisGonorrheaContinued ->
                     { english = "Gonorrhea (continued)"
@@ -18619,11 +17979,7 @@ translationSet trans =
                     }
 
                 DiagnosisTrichomonasOrBacterialVaginosis ->
-                    { english = "Trichomonas or Bacterial Vaginosis"
-                    , kinyarwanda = Just "Tirikomonasi cyangwa Mikorobe zo mu nda ibyara"
-                    , kirundi = Just "Ingwara yo mu bihimba vy'irondoka igaragazwa kenshi no kuhiyagaza"
-                    , somali = Just "Trichomonas ama Bakteeriyada Makaanka"
-                    }
+                    translationSet TrichomonasOrBacterialVaginosis
 
                 DiagnosisTrichomonasOrBacterialVaginosisContinued ->
                     { english = "Trichomonas or Bacterial Vaginosis (continued)"
@@ -18658,56 +18014,28 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisRhesusNegativeInitialPhase
 
                 DiagnosisDepressionNotLikely ->
-                    { english = "Depression not Likely"
-                    , kinyarwanda = Just "Birashoboka ko adafite indwara y'agahinda gakabije"
-                    , kirundi = Just "Kwihebura ntibishoboka"
-                    , somali = Nothing
-                    }
+                    translationSet DepressionNotLikely
 
                 DiagnosisDepressionPossible ->
-                    { english = "Depression Possible"
-                    , kinyarwanda = Just "Birashoboka ko yagira indwara y'agahinda gakabije"
-                    , kirundi = Just "Kwihebura birashoboka"
-                    , somali = Nothing
-                    }
+                    translationSet DepressionPossible
 
                 DiagnosisDepressionHighlyPossible ->
-                    { english = "Fairly High Possibility of Depression"
-                    , kinyarwanda = Just "Birashoboka cyane ko afite indwara y'agahinda gakabije"
-                    , kirundi = Just "Birashoboka cane kwihebura"
-                    , somali = Nothing
-                    }
+                    translationSet FairlyHighPossibilityOfDepression
 
                 DiagnosisDepressionProbable ->
-                    { english = "Probable Depression"
-                    , kinyarwanda = Just "Birashoboka ko afite indwara y'agahinda gakabije"
-                    , kirundi = Just "Ukwihebura gushoboka"
-                    , somali = Just "U eg Niyad Jab"
-                    }
+                    translationSet ProbableDepression
 
                 DiagnosisSuicideRisk ->
-                    { english = "Suicide Risk"
-                    , kinyarwanda = Just "Afite ibyago byo kwiyahura"
-                    , kirundi = Just "Ingorane zimutuma ashobora kwiyahura"
-                    , somali = Nothing
-                    }
+                    translationSet SuicideRisk
 
                 DiagnosisHighRiskOfPreeclampsiaInitialPhase ->
-                    { english = "High Risk of Preeclampsia"
-                    , kinyarwanda = Just "Afite ibyago byinshi byo kugira Preklampusi"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet HighRiskOfPreeclampsia
 
                 DiagnosisHighRiskOfPreeclampsiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisForProgressReport DiagnosisHighRiskOfPreeclampsiaInitialPhase
 
                 DiagnosisModerateRiskOfPreeclampsia ->
-                    { english = "Moderate Risk of Preeclampsia"
-                    , kinyarwanda = Just "Afite ibyago biringaniye byo kugira Preklampusi"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet ModerateRiskOfPreeclampsia
 
                 DiagnosisOther ->
                     { english = "Received a diagnosis from a different health care facility - please follow up with patient"
@@ -18717,11 +18045,7 @@ translationSet trans =
                     }
 
                 DiagnosisPostpartumAbdominalPain ->
-                    { english = "Abdominal Pain"
-                    , kinyarwanda = Just "Kubabara mu nda"
-                    , kirundi = Just "Ukubabara mu nda"
-                    , somali = Just "Calool Xanuun"
-                    }
+                    translationSet AbdominalPainLabel
 
                 DiagnosisPostpartumUrinaryIncontinence ->
                     { english = "Urinary Incontinence"
@@ -18740,11 +18064,7 @@ translationSet trans =
                     translationSet Fever
 
                 DiagnosisPostpartumPerinealPainOrDischarge ->
-                    { english = "Perineal Pain or Discharge"
-                    , kinyarwanda = Just "Arababara perine cg aratakaza ibintu budasanzwe"
-                    , kirundi = Just "Ububabare bw'umugongo hepfo"
-                    , somali = Just "Xanuun qaska ah ama Dheecaan"
-                    }
+                    translationSet PerinealPainOrDischarge
 
                 DiagnosisPostpartumInfection ->
                     { english = "Infection"
@@ -18754,25 +18074,13 @@ translationSet trans =
                     }
 
                 DiagnosisPostpartumExcessiveBleeding ->
-                    { english = "Excessive Bleeding"
-                    , kinyarwanda = Just "Kuva cyane"
-                    , kirundi = Just "Kuva amaraso cane"
-                    , somali = Just "Dhiigbax aad u daran"
-                    }
+                    translationSet ExcessiveBleeding
 
                 DiagnosisPostpartumEarlyMastitisOrEngorgment ->
-                    { english = "Early Mastitis or Engorgement"
-                    , kinyarwanda = Just "Uburwayi bwo kubyimba amabere bwaje kare cyane"
-                    , kirundi = Just "Iyuzura ry'amaberebere (Mastite précoce)"
-                    , somali = Nothing
-                    }
+                    translationSet EarlyMastitisOrEngorgement
 
                 DiagnosisPostpartumMastitis ->
-                    { english = "Mastitis"
-                    , kinyarwanda = Just "Uburwayi bw'amabere"
-                    , kirundi = Just "Ingwara y'imoko ituma amaberebere adasohoka"
-                    , somali = Nothing
-                    }
+                    translationSet Mastitis
 
                 NoPrenatalDiagnosis ->
                     translationSet None
@@ -18787,11 +18095,7 @@ translationSet trans =
                     }
 
                 DiagnosisHighRiskOfPreeclampsiaInitialPhase ->
-                    { english = "Patient shows signs of High Risk for Preclampsia"
-                    , kinyarwanda = Just "Umubyeyi agaragaza ibimenyetso biri hejuru byo kugira Preklampusi"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet PatientShowsSignsOfHighRiskForPreclampsia
 
                 DiagnosisHighRiskOfPreeclampsiaRecurrentPhase ->
                     translationSet <| PrenatalDiagnosisNonUrgentMessage DiagnosisHighRiskOfPreeclampsiaInitialPhase
@@ -18967,32 +18271,16 @@ translationSet trans =
                     translationSet <| PrenatalDiagnosisNonUrgentMessage DiagnosisGestationalHypertensionImmediate
 
                 DiagnosisModeratePreeclampsiaInitialPhase ->
-                    { english = "Patient shows signs of Mild to Moderate Preeclampsia"
-                    , kinyarwanda = Just "Agaragaza ibimenyetso byoroheje bya Preklampusi"
-                    , kirundi = Just "Yerekana ibimenyetso vy'umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
-                    , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Dhiig karka Uurka u dhaxeeya mid Hoose iyo mid Dhexe"
-                    }
+                    translationSet PatientShowsSignsOfMildToModeratePreeclampsia
 
                 DiagnosisModeratePreeclampsiaRecurrentPhase ->
-                    { english = "Patient shows signs of Mild to Moderate Preeclampsia"
-                    , kinyarwanda = Just "Agaragaza ibimenyetso byoroheje bya Preklampusi"
-                    , kirundi = Just "Yerekana ibimenyetso vy'umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
-                    , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Dhiig karka Uurka u dhaxeeya mid Hoose iyo mid Dhexe"
-                    }
+                    translationSet PatientShowsSignsOfMildToModeratePreeclampsia
 
                 DiagnosisSeverePreeclampsiaInitialPhase ->
-                    { english = "Patient shows signs of Severe Preeclampsia"
-                    , kinyarwanda = Just "Agaragaza ibimenyetso bikabije bya Preklampusi"
-                    , kirundi = Just "Yerekana ibimenyetso vy'Umuvuduko w'amaraso mu gihe c'imbanyi ukaze"
-                    , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Daran ee Dhiig karka Uurka"
-                    }
+                    translationSet PatientShowsSignsOfSeverePreeclampsia
 
                 DiagnosisSeverePreeclampsiaRecurrentPhase ->
-                    { english = "Patient shows signs of Severe Preeclampsia"
-                    , kinyarwanda = Just "Agaragaza ibimenyetso bikabije bya Preklampusi"
-                    , kirundi = Just "Yerekana ibimenyetso vy'Umuvuduko w'amaraso mu gihe c'imbanyi ukaze"
-                    , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Daran ee Dhiig karka Uurka"
-                    }
+                    translationSet PatientShowsSignsOfSeverePreeclampsia
 
                 DiagnosisHeartburn ->
                     { english = "Patient shows signs of Persistent Heartburn"
@@ -19146,11 +18434,7 @@ translationSet trans =
                     }
 
                 DiagnosisDepressionNotLikely ->
-                    { english = "Depression not Likely"
-                    , kinyarwanda = Just "Birashoboka ko adafite indwara y'agahinda gakabije"
-                    , kirundi = Just "Kwihebura ntibishoboka"
-                    , somali = Nothing
-                    }
+                    translationSet DepressionNotLikely
 
                 DiagnosisDepressionPossible ->
                     { english = "Patient shows signs of possible depression"
@@ -19181,11 +18465,7 @@ translationSet trans =
                     }
 
                 DiagnosisPostpartumAbdominalPain ->
-                    { english = "Abdominal Pain"
-                    , kinyarwanda = Just "Kubabara mu nda"
-                    , kirundi = Just "Ukubabara mu nda"
-                    , somali = Just "Calool Xanuun"
-                    }
+                    translationSet AbdominalPainLabel
 
                 DiagnosisPostpartumUrinaryIncontinence ->
                     { english = "Patient shows signs of Urinary Incontinence"
@@ -19204,11 +18484,7 @@ translationSet trans =
                     translationSet Fever
 
                 DiagnosisPostpartumPerinealPainOrDischarge ->
-                    { english = "Perineal Pain or Discharge"
-                    , kinyarwanda = Just "Arababara perine cg aratakaza ibintu budasanzwe"
-                    , kirundi = Just "Ububabare bw'umugongo hepfo"
-                    , somali = Just "Xanuun qaska ah ama Dheecaan"
-                    }
+                    translationSet PerinealPainOrDischarge
 
                 DiagnosisPostpartumInfection ->
                     { english = "Patient shows signs of Infection"
@@ -19255,11 +18531,7 @@ translationSet trans =
                     translationSet EmptyString
 
                 NursePostpartumEncounter ->
-                    { english = "Postpartum"
-                    , kinyarwanda = Just "Igihe cya nyuma cyo kubyara"
-                    , kirundi = Just "Inyuma yo kwibaruka"
-                    , somali = Just "Dhalmada kadib"
-                    }
+                    translationSet Postpartum
 
                 ChwFirstEncounter ->
                     { english = "First Antenatal Visit"
@@ -19283,11 +18555,7 @@ translationSet trans =
                     }
 
                 ChwPostpartumEncounter ->
-                    { english = "Postpartum"
-                    , kinyarwanda = Just "Igihe cya nyuma cyo kubyara"
-                    , kirundi = Just "Inyuma yo kwibaruka"
-                    , somali = Just "Dhalmada kadib"
-                    }
+                    translationSet Postpartum
 
         PrenatalFlankPainSign sign ->
             case sign of
@@ -19436,32 +18704,16 @@ translationSet trans =
                     }
 
                 EducationLegCramps ->
-                    { english = "Leg Cramps"
-                    , kinyarwanda = Just "Ibinya mu maguru"
-                    , kirundi = Just "Ibinyanya vy'amaguru"
-                    , somali = Just "Kabaabyo Lugaha ah"
-                    }
+                    translationSet LegCrampsLabel
 
                 EducationLowBackPain ->
-                    { english = "Lower Back Pain"
-                    , kinyarwanda = Just "Kubabara umugongo wo hasi"
-                    , kirundi = Just "Ububabare bw'umugongo wo hasi"
-                    , somali = Just "Xanuun Dhinca dambe ah"
-                    }
+                    translationSet LowerBackPain
 
                 EducationConstipation ->
-                    { english = "Constipation"
-                    , kinyarwanda = Just "Kwituma impatwe"
-                    , kirundi = Just "Ukuzura inda"
-                    , somali = Just "Calool istaag"
-                    }
+                    translationSet ConstipationLabel
 
                 EducationHeartburn ->
-                    { english = "Heartburn"
-                    , kinyarwanda = Just "Ikirungurira"
-                    , kirundi = Just "Ugusha k'umutima"
-                    , somali = Nothing
-                    }
+                    translationSet HeartburnLabel
 
                 EducationVaricoseVeins ->
                     { english = "Varicose Veins"
@@ -19478,11 +18730,7 @@ translationSet trans =
                     }
 
                 EducationPelvicPain ->
-                    { english = "Pelvic Pain"
-                    , kinyarwanda = Just "Kubabara mu kiziba cy'inda"
-                    , kirundi = Just "Ububabare bwo mu nda yo hepfo"
-                    , somali = Just "Dhabar Xanuun"
-                    }
+                    translationSet PelvicPainLabel
 
                 EducationSaferSex ->
                     { english = "Safer Sex Practices"
@@ -19499,18 +18747,10 @@ translationSet trans =
                     }
 
                 EducationEarlyMastitisOrEngorgment ->
-                    { english = "Early Mastitis or Engorgement"
-                    , kinyarwanda = Just "Uburwayi bwo kubyimba amabere bwaje kare cyane"
-                    , kirundi = Just "Iyuzura ry'amaberebere (Mastite précoce)"
-                    , somali = Nothing
-                    }
+                    translationSet EarlyMastitisOrEngorgement
 
                 EducationMastitis ->
-                    { english = "Mastitis"
-                    , kinyarwanda = Just "Uburwayi bw'amabere"
-                    , kirundi = Just "Ingwara y'imoko ituma amaberebere adasohoka"
-                    , somali = Nothing
-                    }
+                    translationSet Mastitis
 
                 EducationGrief ->
                     { english = "Grief"
@@ -19603,25 +18843,13 @@ translationSet trans =
                     }
 
                 EducationPositiveHIV ->
-                    { english = "Have you counseled patient on positive HIV test meaning"
-                    , kinyarwanda = Just "Waba wasobanuriye umurwayi (umubyeyi) icyo bisibanuye kugira ibisubizo biri positifu ku bwandu bw'agakoko gatera SIDA"
-                    , kirundi = Just "Mbega warahanuye wongera urabwira umugwayi iciza c'igipimo c'umugera wa SIDA"
-                    , somali = Just "Ma kala talisay bukaanka macnaha baaritaanka togan ee HIV"
-                    }
+                    translationSet HaveYouCounseledPatientOnPositiveHIVTestMeaning
 
                 EducationSaferSexHIV ->
-                    { english = "Have you counseled patient on safer sex practices"
-                    , kinyarwanda = Just "Wagiriye inama umubyeyi ku bijyanye no gukora imibonano mpuzabitsina ikingiye"
-                    , kirundi = Just "Mbega warahanuye  umugwayi kuvyerekeye iciza co kwikingira mu gihe c'imibonano mpuza ibitsina"
-                    , somali = Just "Ma kala talisay bukaanka galmada badqabka leh"
-                    }
+                    translationSet HaveYouCounseledPatientOnSaferSexPractices
 
                 EducationPartnerTesting ->
-                    { english = "Have you encouraged the patient’s partner to get tested"
-                    , kinyarwanda = Just "Waba washishikarije umubyueyi kubwira uwo babana kwipimisha"
-                    , kirundi = Just "Mbega wateye inguvu umufasha w'umugwayi kugira yipimishe"
-                    , somali = Nothing
-                    }
+                    translationSet HaveYouEncouragedThePatientsPartnerToGetTested
 
                 EducationGrief ->
                     { english = "Have you provided grief counseling to the patient"
@@ -20119,18 +19347,10 @@ translationSet trans =
                             }
 
                         MentalHealthQuestionOption1 ->
-                            { english = "Hardly ever"
-                            , kinyarwanda = Just "Gake gashoboka"
-                            , kirundi = Just "Biragoye bukebuke"
-                            , somali = Just "Marnaba aan dhicin"
-                            }
+                            translationSet HardlyEver
 
                         MentalHealthQuestionOption2 ->
-                            { english = "Yes, sometimes"
-                            , kinyarwanda = Just "Yego, rimwe na rimwe"
-                            , kirundi = Just "Ego, rimwe na rimwe"
-                            , somali = Just "Haa, Mararka qaar"
-                            }
+                            translationSet YesSometimes
 
                         MentalHealthQuestionOption3 ->
                             { english = "Yes, very often"
@@ -20156,11 +19376,7 @@ translationSet trans =
                             }
 
                         MentalHealthQuestionOption2 ->
-                            { english = "Yes, sometimes"
-                            , kinyarwanda = Just "Yego, rimwe na rimwe"
-                            , kirundi = Just "Ego, rimwe na rimwe"
-                            , somali = Just "Haa, Mararka qaar"
-                            }
+                            translationSet YesSometimes
 
                         MentalHealthQuestionOption3 ->
                             { english = "Yes, quite a lot"
@@ -20216,11 +19432,7 @@ translationSet trans =
                             }
 
                         MentalHealthQuestionOption2 ->
-                            { english = "Yes, sometimes"
-                            , kinyarwanda = Just "Yego, rimwe na rimwe"
-                            , kirundi = Just "Ego, rimwe na rimwe"
-                            , somali = Just "Haa, Mararka qaar"
-                            }
+                            translationSet YesSometimes
 
                         MentalHealthQuestionOption3 ->
                             { english = "Yes, most of the time"
@@ -20299,11 +19511,7 @@ translationSet trans =
                             }
 
                         MentalHealthQuestionOption1 ->
-                            { english = "Hardly ever"
-                            , kinyarwanda = Just "Gake gashoboka"
-                            , kirundi = Just "Biragoye bukebuke"
-                            , somali = Just "Marnaba aan dhicin"
-                            }
+                            translationSet HardlyEver
 
                         MentalHealthQuestionOption2 ->
                             { english = "Sometimes"
@@ -20398,11 +19606,7 @@ translationSet trans =
                     }
 
                 OutsideCareMedicationPenecilin1 ->
-                    { english = "IM x 1"
-                    , kinyarwanda = Just "IM inshuro 1"
-                    , kirundi = Just "IM Gucisha umuti mu mutsi incuro 1 gusa"
-                    , somali = Nothing
-                    }
+                    translationSet IMX1
 
                 OutsideCareMedicationPenecilin3 ->
                     { english = "IM 1x a week for 3 weeks"
@@ -20426,11 +19630,7 @@ translationSet trans =
                     }
 
                 OutsideCareMedicationCeftriaxon ->
-                    { english = "IM daily x 10 days"
-                    , kinyarwanda = Just "IM buri munsi mu minsi 10"
-                    , kirundi = Just "IM buri munsi mu kiringo c'iminsi 10"
-                    , somali = Nothing
-                    }
+                    translationSet IMDailyX10Days
 
                 OutsideCareMedicationMethyldopa2 ->
                     { english = "1 tablet by mouth twice a day"
@@ -20540,63 +19740,31 @@ translationSet trans =
                     }
 
                 OutsideCareMedicationErythromycin ->
-                    { english = "Erythromycin (500mg)"
-                    , kinyarwanda = Just "Erythromicine (500mg)"
-                    , kirundi = Just "Erythromycine (500 mg)"
-                    , somali = Nothing
-                    }
+                    translationSet Erythromycin500mg
 
                 OutsideCareMedicationAzithromycin ->
-                    { english = "Azithromycin (2g)"
-                    , kinyarwanda = Just "Azithromycine (2g)"
-                    , kirundi = Just "azithromycine(2g)"
-                    , somali = Nothing
-                    }
+                    translationSet Azithromycin2g
 
                 OutsideCareMedicationCeftriaxon ->
-                    { english = "Ceftriaxone (1g)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Ceftriaxone1g
 
                 NoOutsideCareMedicationForSyphilis ->
                     translationSet NoneOfThese
 
                 OutsideCareMedicationMethyldopa2 ->
-                    { english = "Methyldopa (250mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Methyldopa250mg
 
                 OutsideCareMedicationMethyldopa3 ->
-                    { english = "Methyldopa (250mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Methyldopa250mg
 
                 OutsideCareMedicationMethyldopa4 ->
-                    { english = "Methyldopa (250mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Methyldopa250mg
 
                 OutsideCareMedicationCarvedilol ->
-                    { english = "Carvedilol (6.25mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Carvedilol625mg
 
                 OutsideCareMedicationAmlodipine ->
-                    { english = "Amlodipine (5mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Amlodipine5mg
 
                 NoOutsideCareMedicationForHypertension ->
                     translationSet NoneOfThese
@@ -20676,25 +19844,13 @@ translationSet trans =
                     }
 
                 Heartburn ->
-                    { english = "Heartburn"
-                    , kinyarwanda = Just "Ikirungurira"
-                    , kirundi = Just "Ugusha k'umutima"
-                    , somali = Nothing
-                    }
+                    translationSet HeartburnLabel
 
                 LegCramps ->
-                    { english = "Leg Cramps"
-                    , kinyarwanda = Just "Ibinya mu maguru"
-                    , kirundi = Just "Ibinyanya vy'amaguru"
-                    , somali = Just "Kabaabyo Lugaha ah"
-                    }
+                    translationSet LegCrampsLabel
 
                 LowBackPain ->
-                    { english = "Lower Back Pain"
-                    , kinyarwanda = Just "Kubabara umugongo wo hasi"
-                    , kirundi = Just "Ububabare bw'umugongo wo hasi"
-                    , somali = Just "Xanuun Dhinca dambe ah"
-                    }
+                    translationSet LowerBackPain
 
                 CoughContinuous ->
                     { english = "Cough for >2 weeks"
@@ -20704,18 +19860,10 @@ translationSet trans =
                     }
 
                 PelvicPain ->
-                    { english = "Pelvic Pain"
-                    , kinyarwanda = Just "Kubabara mu kiziba cy'inda"
-                    , kirundi = Just "Ububabare bwo mu nda yo hepfo"
-                    , somali = Just "Dhabar Xanuun"
-                    }
+                    translationSet PelvicPainLabel
 
                 Constipation ->
-                    { english = "Constipation"
-                    , kinyarwanda = Just "Kwituma impatwe"
-                    , kirundi = Just "Ukuzura inda"
-                    , somali = Just "Calool istaag"
-                    }
+                    translationSet ConstipationLabel
 
                 VaricoseVeins ->
                     { english = "Varicose Veins"
@@ -20732,11 +19880,7 @@ translationSet trans =
                     }
 
                 PostpartumAbdominalPain ->
-                    { english = "Abdominal Pain"
-                    , kinyarwanda = Just "Kubabara mu nda"
-                    , kirundi = Just "Ukubabara mu nda"
-                    , somali = Just "Calool Xanuun"
-                    }
+                    translationSet AbdominalPainLabel
 
                 PostpartumUrinaryIncontinence ->
                     { english = "Urinary Incontinence"
@@ -20977,11 +20121,7 @@ translationSet trans =
                     translationSet NegativeLabel
 
                 TestIndeterminate ->
-                    { english = "Indeterminate"
-                    , kinyarwanda = Just "Ntibisobanutse"
-                    , kirundi = Just "Ntibizwi neza"
-                    , somali = Just "Aan horay laga ogaan karin"
-                    }
+                    translationSet Indeterminate
 
         PrenatalVaccineLabel value ->
             case value of
@@ -21256,11 +20396,7 @@ translationSet trans =
         TestPrerequisiteQuestion value ->
             case value of
                 PrerequisiteFastFor12h ->
-                    { english = "Was this test performed before a meal"
-                    , kinyarwanda = Just "Umurwayi yafatiwe iki kizamini mbere yo kurya"
-                    , kirundi = Just "Mbega iki gipimo cabaye imbere yo gufungura"
-                    , somali = Nothing
-                    }
+                    translationSet WasThisTestPerformedBeforeAMeal
 
                 PrerequisiteImmediateResult ->
                     { english = "Where was this test performed"
@@ -21275,11 +20411,7 @@ translationSet trans =
         TestUniversalPrerequisiteQuestion value ->
             case value of
                 PrerequisiteFastFor12h ->
-                    { english = "Was this test performed before a meal"
-                    , kinyarwanda = Just "Umurwayi yafatiwe iki kizamini mbere yo kurya"
-                    , kirundi = Just "Mbega iki gipimo cabaye imbere yo gufungura"
-                    , somali = Nothing
-                    }
+                    translationSet WasThisTestPerformedBeforeAMeal
 
                 PrerequisiteImmediateResult ->
                     { english = "Where will this test be"
@@ -21794,11 +20926,7 @@ translationSet trans =
         RecommendedTreatmentSignDosage sign ->
             case sign of
                 TreatmentPenecilin1 ->
-                    { english = "IM x 1"
-                    , kinyarwanda = Just "IM inshuro 1"
-                    , kirundi = Just "IM Gucisha umuti mu mutsi incuro 1 gusa"
-                    , somali = Nothing
-                    }
+                    translationSet IMX1
 
                 TreatmentPenecilin3 ->
                     { english = "IM 1x a week for 3 weeks"
@@ -21822,11 +20950,7 @@ translationSet trans =
                     }
 
                 TreatmentCeftriaxon ->
-                    { english = "IM daily x 10 days"
-                    , kinyarwanda = Just "IM buri munsi mu minsi 10"
-                    , kirundi = Just "IM buri munsi mu kiringo c'iminsi 10"
-                    , somali = Nothing
-                    }
+                    translationSet IMDailyX10Days
 
                 TreatmentAluminiumHydroxide ->
                     { english = "1 tablet by mouth 3x a day for 7 days"
@@ -22110,39 +21234,19 @@ translationSet trans =
                     }
 
                 TreatmentMethyldopa2 ->
-                    { english = "Methyldopa (250mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Methyldopa250mg
 
                 TreatmentMethyldopa3 ->
-                    { english = "Methyldopa (250mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Methyldopa250mg
 
                 TreatmentMethyldopa4 ->
-                    { english = "Methyldopa (250mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Methyldopa250mg
 
                 TreatmentHypertensionAddCarvedilol ->
-                    { english = "Carvedilol (6.25mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Carvedilol625mg
 
                 TreatmentHypertensionAddAmlodipine ->
-                    { english = "Amlodipine (5mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Amlodipine5mg
 
                 TreatmentHydrochlorothiazide ->
                     { english = "Hydrochlorothiazide (12.5mg)"
@@ -22152,11 +21256,7 @@ translationSet trans =
                     }
 
                 TreatmentAmlodipine ->
-                    { english = "Amlodipine (5mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Amlodipine5mg
 
                 TreatmentNifedipine ->
                     { english = "Nifedipine (20mg)"
@@ -22278,46 +21378,22 @@ translationSet trans =
                     }
 
                 TreatmentMetformin1m1e ->
-                    { english = "Metformin (500mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Metformin500mg
 
                 TreatmentGlipenclamide1m1e ->
-                    { english = "Glipenclamide (5mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Glipenclamide5mg
 
                 TreatmentMetformin2m1e ->
-                    { english = "Metformin (500mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Metformin500mg
 
                 TreatmentGlipenclamide2m1e ->
-                    { english = "Glipenclamide (5mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Glipenclamide5mg
 
                 TreatmentMetformin2m2e ->
-                    { english = "Metformin (500mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Metformin500mg
 
                 TreatmentGlipenclamide2m2e ->
-                    { english = "Glipenclamide (5mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Glipenclamide5mg
 
                 TreatmentMetformin2m2eGlipenclamide1m1e ->
                     { english = "Metformin (500mg), Glipenclamide (5mg)"
@@ -22714,11 +21790,7 @@ translationSet trans =
                     }
 
                 ComponentAntenatalLabsResults ->
-                    { english = "Labs Results"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Inyishu z'ibipimo vy'ingwara"
-                    , somali = Nothing
-                    }
+                    translationSet LabsResults
 
                 ComponentAntenatalProgressPhotos ->
                     { english = "Progress Photos"
@@ -22754,11 +21826,7 @@ translationSet trans =
                     }
 
                 ComponentNCDLabsResults ->
-                    { english = "Labs Results"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Inyishu z'ibipimo vy'ingwara"
-                    , somali = Nothing
-                    }
+                    translationSet LabsResults
 
         ReportComponentWellChild component ->
             case component of
@@ -22889,11 +21957,7 @@ translationSet trans =
                     }
 
                 ResilienceCategoryConnecting ->
-                    { english = "Connecting"
-                    , kinyarwanda = Just "Gusabana"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet Connecting
 
                 ResilienceCategorySelfCare ->
                     { english = "Self Care"
@@ -23344,11 +22408,7 @@ translationSet trans =
             }
 
         ResilienceMessageGrowth9Paragraph2 ->
-            { english = "Remember: Make your co-workers your work family."
-            , kinyarwanda = Just ""
-            , kirundi = Nothing
-            , somali = Nothing
-            }
+            translationSet RememberMakeYourCoworkersYourWorkFamily
 
         ResilienceMessageGrowth10Title ->
             { english = "A team is more a collection of people"
@@ -24877,11 +23937,7 @@ translationSet trans =
             }
 
         ResilienceMessageConnecting12Paragraph2 ->
-            { english = "Remember: Make your co-workers your work family."
-            , kinyarwanda = Just ""
-            , kirundi = Nothing
-            , somali = Nothing
-            }
+            translationSet RememberMakeYourCoworkersYourWorkFamily
 
         ResilienceMessageConnecting13Title ->
             { english = "Important reminder, you can talk to your trusted friend"
@@ -26155,11 +25211,7 @@ translationSet trans =
         ResilienceRole role ->
             case role of
                 ResilienceRoleCHW ->
-                    { english = "CHW"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet CHW
 
                 ResilienceRoleNurse ->
                     { english = "Health Care Worker (HC)"
@@ -27250,11 +26302,7 @@ translationSet trans =
         StockSupplier value ->
             case value of
                 SupplierAheza ->
-                    { english = "AHEZA"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet AHEZA
 
                 SupplierMOH ->
                     { english = "MOH (Ministry of Health)"
@@ -27271,11 +26319,7 @@ translationSet trans =
                     }
 
                 SupplierUNICEF ->
-                    { english = "UNICEF"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet UNICEF
 
                 SupplierRMSCentral ->
                     { english = "RWANDA MEDICAL SUPPLY (RMS)-Central Level"
@@ -27301,11 +26345,7 @@ translationSet trans =
         StockSupplierAbbrev value ->
             case value of
                 SupplierAheza ->
-                    { english = "AHEZA"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet AHEZA
 
                 SupplierMOH ->
                     { english = "MOH"
@@ -27322,11 +26362,7 @@ translationSet trans =
                     }
 
                 SupplierUNICEF ->
-                    { english = "UNICEF"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet UNICEF
 
                 SupplierRMSCentral ->
                     { english = "RMS-Central"
@@ -27350,11 +26386,7 @@ translationSet trans =
                     }
 
         StuntingLevelLabel ->
-            { english = "Level of stunting using child length mat"
-            , kinyarwanda = Just "Ikigero cyo kugwingira hakoreshejwe agasambi"
-            , kirundi = Nothing
-            , somali = Just "Heerka nafaqo darrda ayadoo la isticmaalayo xariga cabirka"
-            }
+            translationSet LevelOfStuntingUsingChildLengthMat
 
         StuntingLevel value ->
             case value of
@@ -27571,18 +26603,10 @@ translationSet trans =
                     }
 
                 SymptomsGeneralConvulsions ->
-                    { english = "Convulsions"
-                    , kinyarwanda = Just "Kugagara"
-                    , kirundi = Just "Ibisahuzi"
-                    , somali = Just "Gariir"
-                    }
+                    translationSet ConvulsionsLabel
 
                 SpontaneousBleeding ->
-                    { english = "Spontaneous Bleeding"
-                    , kinyarwanda = Just "Kuva amaraso bitunguranye"
-                    , kirundi = Just "Ukuva amaraso aho nyene"
-                    , somali = Just "Dhiigbax aan waqti lahayn"
-                    }
+                    translationSet SpontaneousBleedingLabel
 
                 NoSymptomsGeneral ->
                     translationSet NoneOfTheAbove
@@ -27590,11 +26614,7 @@ translationSet trans =
         SymptomsGISign sign ->
             case sign of
                 SymptomGIAbdominalPain ->
-                    { english = "Abdominal Pain"
-                    , kinyarwanda = Just "Kubabara mu nda"
-                    , kirundi = Just "Ukubabara mu nda"
-                    , somali = Just "Calool Xanuun"
-                    }
+                    translationSet AbdominalPainLabel
 
                 BloodyDiarrhea ->
                     { english = "Bloody Diarrhea"
@@ -29064,11 +28084,7 @@ translationSet trans =
                             }
 
                         VaccineOPV ->
-                            { english = "Oral Polio Vaccine (OPV)"
-                            , kinyarwanda = Just "Urukingo rw'imbasa rutangwa mu kanwa"
-                            , kirundi = Just "Urucanco rw'ubukangwe (amama)"
-                            , somali = Just "Tallaalka Afka ee Dabeysha (OPV)"
-                            }
+                            translationSet OralPolioVaccineOPV
 
                         VaccineDTP ->
                             case site of
@@ -29382,21 +28398,13 @@ translationSet trans =
                     }
 
                 WellChildImmunisation ->
-                    { english = "Immunizations"
-                    , kinyarwanda = Just "Ikingira"
-                    , kirundi = Just "Incanco"
-                    , somali = Just "Tallaalada"
-                    }
+                    translationSet Immunizations
 
                 WellChildNextSteps ->
                     translationSet NextSteps
 
                 WellChildPhoto ->
-                    { english = "Photo"
-                    , kinyarwanda = Just "Ifoto"
-                    , kirundi = Just "Ifoto"
-                    , somali = Just "Sawir"
-                    }
+                    translationSet Photo
 
                 WellChildNCDA ->
                     translationSet ChildScorecard
@@ -29738,11 +28746,7 @@ translationSet trans =
                     }
 
                 VaccineOPV ->
-                    { english = "Oral Polio Vaccine (OPV)"
-                    , kinyarwanda = Just "Urukingo rw'imbasa rutangwa mu kanwa"
-                    , kirundi = Just "Urucanco rw'ubukangwe (amama)"
-                    , somali = Just "Tallaalka Afka ee Dabeysha (OPV)"
-                    }
+                    translationSet OralPolioVaccineOPV
 
                 VaccinePCV13 ->
                     { english = "Pneumococcal Vaccine (PCV 13)"
@@ -29949,11 +28953,7 @@ translationSet trans =
         WellChildNextStepsTask isChw task ->
             case task of
                 TaskContributingFactors ->
-                    { english = "Contributing Factors"
-                    , kinyarwanda = Just "Impamvu zateye uburwayi"
-                    , kirundi = Just "Ivyatumye arwara"
-                    , somali = Just "Waxyaabaha Keeni kara"
-                    }
+                    translationSet ContributingFactors
 
                 TaskHealthEducation ->
                     translationSet HealthEducation
@@ -29985,11 +28985,7 @@ translationSet trans =
                     }
 
                 SymptomConvulsions ->
-                    { english = "Convulsions"
-                    , kinyarwanda = Just "Kugagara"
-                    , kirundi = Just "Ibisahuzi"
-                    , somali = Just "Gariir"
-                    }
+                    translationSet ConvulsionsLabel
 
                 SymptomLethargyOrUnresponsiveness ->
                     { english = "Lethargy or unresponsiveness"
@@ -30096,11 +29092,7 @@ translationSet trans =
                             }
 
                 VaccineDTPStandalone ->
-                    { english = "DTP - HepB - Hib"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
+                    translationSet DTPHepBHib
 
                 VaccineHPV ->
                     { english = "HPV"

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -2800,46 +2800,6 @@ translationSet trans =
             , somali = Just "Xanuun soo Bood ah oo Cusub"
             }
 
-        AcuteIllnessOutcomeLabel ->
-            { english = "Acute Illness Outcome"
-            , kinyarwanda = Just "Iherezo ry'indwara ifatiyeho\n"
-            , kirundi = Just "Inkurikizi/ingaruka z'ingwara ibabaza cane/ikaze"
-            , somali = Just "Natiijada Xanuunka soo Boodada ah"
-            }
-
-        AcuteIllnessStatus status ->
-            case status of
-                AcuteIllnessBegan ->
-                    { english = "Began"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Yatanguye"
-                    , somali = Just "Bilowday"
-                    }
-
-                AcuteIllnessUpdated ->
-                    { english = "Updated"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Vyagiye ku gihe"
-                    , somali = Just "La cusbooneysiiyay"
-                    }
-
-                AcuteIllnessResolved ->
-                    translationSet Resolved
-
-        AcuteMalnutrition ->
-            { english = "Acute Malnutrition"
-            , kinyarwanda = Just "Imirire mibi ihutiyeho"
-            , kirundi = Nothing
-            , somali = Just "Nafaqo darrda"
-            }
-
-        ActiveDiagnosis ->
-            { english = "Active Diagnosis"
-            , kinyarwanda = Just "Uburwayi Bwasuzumwe"
-            , kirundi = Just "Indwara arwaye ubu"
-            , somali = Just "Baaritaan cusub"
-            }
-
         AcuteIllnessOutcome outcome ->
             case outcome of
                 OutcomeIllnessResolved ->
@@ -2880,216 +2840,44 @@ translationSet trans =
                 OutcomeOther ->
                     translationSet OtherLabel
 
-        AddChild ->
-            { english = "Add Child"
-            , kinyarwanda = Just "Ongeraho umwana"
-            , kirundi = Just "Kongerako umwana"
-            , somali = Just "Ku dar Canug"
+        AcuteIllnessOutcomeLabel ->
+            { english = "Acute Illness Outcome"
+            , kinyarwanda = Just "Iherezo ry'indwara ifatiyeho\n"
+            , kirundi = Just "Inkurikizi/ingaruka z'ingwara ibabaza cane/ikaze"
+            , somali = Just "Natiijada Xanuunka soo Boodada ah"
             }
 
-        AddContact ->
-            { english = "Add Contact"
-            , kinyarwanda = Just "Ongeraho uwo bahuye"
-            , kirundi = Just "Kongerako aho yotorwa/ingene yotorwa"
-            , somali = Nothing
-            }
+        AcuteIllnessStatus status ->
+            case status of
+                AcuteIllnessBegan ->
+                    { english = "Began"
+                    , kinyarwanda = Nothing
+                    , kirundi = Just "Yatanguye"
+                    , somali = Just "Bilowday"
+                    }
 
-        AddedToPatientRecordOn ->
-            { english = "Added to patient record on"
-            , kinyarwanda = Just "Yongewe ku makuru y'umurwayi kuwa"
-            , kirundi = Just "Kongerako aho abagwayi bamaze kwandikwa"
-            , somali = Just "Ku dar xogta bukaanka"
-            }
+                AcuteIllnessUpdated ->
+                    { english = "Updated"
+                    , kinyarwanda = Nothing
+                    , kirundi = Just "Vyagiye ku gihe"
+                    , somali = Just "La cusbooneysiiyay"
+                    }
 
-        AddFamilyMember ->
-            { english = "Add Family Member"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Kongerako umwe mu bagize umuryango"
-            , somali = Just "Ku dar Xubin Qoys"
-            }
+                AcuteIllnessResolved ->
+                    translationSet Resolved
 
-        AddFamilyMemberFor name ->
-            { english = "Add Family Member for " ++ name
-            , kinyarwanda = Nothing
-            , kirundi = Just <| "Kongerako umwe mu bagize umuryango wa " ++ name
-            , somali = Just <| "Ku dar Xubin Qoyska ah ee " ++ name
-            }
-
-        AddNewParticipant ->
-            { english = "Add new participant"
-            , kinyarwanda = Just "Ongeramo Umugenerwabikorwa musha"
-            , kirundi = Just "Andika Umurwayi mushasha yitavye igikorwa"
-            , somali = Just "Ku dar qof cusub"
-            }
-
-        AddParentOrCaregiver ->
-            { english = "Add Parent or Caregiver"
-            , kinyarwanda = Just "Ongeraho umubyeyi cyangwa umurezi"
-            , kirundi = Just "Kongerako umuvyeyi canke umurezi"
-            , somali = Just "Ku dar Waalid ama Daryeele"
-            }
-
-        AddToGroup ->
-            { english = "Add to Group..."
-            , kinyarwanda = Just "Ongeraho itsinda..."
-            , kirundi = Just "Ongerako Mumurwi..."
-            , somali = Just "Ku dar Kooxda"
-            }
-
-        Administer ->
-            { english = "Administer"
-            , kinyarwanda = Just "Tanga umuti"
-            , kirundi = Just "Tanga umuti"
-            , somali = Just "U qor"
-            }
-
-        AdministerAlbendazoleHelper ->
-            translationSet GiveTheChildOneTabletByMouth
-
-        AdministerAspirinHelper ->
-            { english = "1 tablet 150 mg by mouth daily"
-            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 150 buri munsi"
+        AcuteMalnutrition ->
+            { english = "Acute Malnutrition"
+            , kinyarwanda = Just "Imirire mibi ihutiyeho"
             , kirundi = Nothing
-            , somali = Nothing
+            , somali = Just "Nafaqo darrda"
             }
 
-        AdministerAzithromycinHelper ->
-            { english = "By mouth 1x"
-            , kinyarwanda = Just "Inshuro imwe mu kanwa"
-            , kirundi = Just "Kumira incuro 1"
-            , somali = Nothing
-            }
-
-        AdministerCalciumHelper ->
-            { english = "1 tablet 500 mg by mouth daily"
-            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 500 buri munsi"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        AdministerCeftriaxoneHelper ->
-            { english = "IM once"
-            , kinyarwanda = Just "Urushinge mu mikaya inshuro imwe"
-            , kirundi = Just "Gucisha umuti mu mutsi rimwe"
-            , somali = Nothing
-            }
-
-        AdministerFefolHelper ->
-            translationSet OneTabletByMouthDaily
-
-        AdministerFolicAcidHelper ->
-            { english = "1 tablet 400 IU by mouth daily for 3 months"
-            , kinyarwanda = Just "Ikinini 1 mu kanwa (400 IU) buri munsi mu gihe cy'amezi 3"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        AdministerHIVARVHelper ->
-            { english = "Take 1x a day by mouth"
-            , kinyarwanda = Just "Fata ikinini 1 ku munsi mu kanwa"
-            , kirundi = Just "Ugufata ikinini 1, ukimize, 1 ku munsi"
-            , somali = Just "Qaado 1 kaniini afka x halki maalin"
-            }
-
-        AdministerIronHelper ->
-            { english = "1 tablet 60 mg by mouth 2x a day for 3 months"
-            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 60 inshuro 2 ku munsi mu gihe cy'amezi 3"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        AdministerMebendezoleHelper ->
-            translationSet GiveTheChildOneTabletByMouth
-
-        AdministerMetronidazoleHelper ->
-            { english = "By mouth twice a day for 7 days"
-            , kinyarwanda = Just "Kunywa ikinini inshuro ebyiri ku munsi mu minsi irindwi"
-            , kirundi = Nothing
-            , somali = Just "Afka laba jeer maalinki ilaa 7 maalin"
-            }
-
-        AdministerMMSHelper ->
-            { english = "1 tablet by mouth daily - 180 tablets dispensed"
-            , kinyarwanda = Just "Kunywa ikinini kimwe ku munsi - Hatanzwe ibinini 180"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        AdministerParacetamolHelper ->
-            { english = "Take 1 tablet by mouth 3 times a day for 5 days"
-            , kinyarwanda = Just "Fata ikinini 1 mu kanwa inshuro 3 ku munsi mu minsi 5"
-            , kirundi = Just "Ugufata ikinini 1, ukimize, 3 ku munsi mu minsi 5"
-            , somali = Just "Qaado 1 kaniini afka 3 mar halki maalin mudo 5 maalin ah"
-            }
-
-        AdministerPrenatalMebendezoleHelper ->
-            { english = "1 tablet 500 mg by mouth ONCE"
-            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 500 INSHURO IMWE GUSA"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        AdministerVitaminAHelperPrenatal ->
-            { english = "Vitamin A is given once"
-            , kinyarwanda = Just "Vitamine A itangwa inshuro 1"
-            , kirundi = Just "Vitamine A yatanzwe rimwe"
-            , somali = Just "Vitamin baa la siiyay hal mar"
-            }
-
-        AdministerVitaminAHelperWellChild ->
-            { english = "Put the correct number of drops directly into the mouth of the child"
-            , kinyarwanda = Just "Shyira mu kanwa k'umwana ibitonyanga bigenwe"
-            , kirundi = Just "Shira igitigiri gikwiye aho nyene mu kanwa k'umwana"
-            , somali = Just "Ku shub tirada saxda ee dhibicyada afka canuga"
-            }
-
-        Administered ->
-            { english = "Administered"
-            , kinyarwanda = Just "Umuti watanzwe"
-            , kirundi = Just "Gutwagwa"
-            , somali = Nothing
-            }
-
-        AdministeredMedicationQuestion ->
-            { english = "Have you administered"
-            , kinyarwanda = Just "Watanze umuti"
-            , kirundi = Just "Woba warigeze utanga umuti"
-            , somali = Just "Ma u qortay"
-            }
-
-        AdministeredOneOfAboveMedicinesQuestion ->
-            { english = "Have you administered one of the above medicines to the patient"
-            , kinyarwanda = Just "Waba wahaye umurwyayi umwe mu miti yavuzwe haruguru"
-            , kirundi = Just "Woba warigeze utanga umwe mu miti iraho hejuru k'umugwayi"
-            , somali = Just "Ma u qortay bukaanka mid ka mid ah dawooyinka kor ku xusan"
-            }
-
-        AddressInformation ->
-            { english = "Address Information"
-            , kinyarwanda = Just "Aho atuye/Aho abarizwa"
-            , kirundi = Just "Amakuru ajanye n'aho aba"
-            , somali = Just "Macluumaadka Cinwaanka"
-            }
-
-        AfterEachLiquidStool ->
-            { english = "after each liquid stool"
-            , kinyarwanda = Just "buri uko amaze kwituma ibyoroshye"
-            , kirundi = Just "Inyuma ya buri mwanda mukuru w'amazi"
-            , somali = Just "kadib sarao walba oo jilcan"
-            }
-
-        AgeAxisLabel ->
-            { english = "Age (years-months)"
-            , kinyarwanda = Just "Imyaka (imyaka-amezi)"
-            , kirundi = Just "Imyaka (imyaka-amezi)"
-            , somali = Just "Da'da (sano-bilood)"
-            }
-
-        AgeWord ->
-            { english = "Age"
-            , kinyarwanda = Just "Imyaka"
-            , kirundi = Just "Imyaka"
-            , somali = Just "Da`da"
+        ActiveDiagnosis ->
+            { english = "Active Diagnosis"
+            , kinyarwanda = Just "Uburwayi Bwasuzumwe"
+            , kirundi = Just "Indwara arwaye ubu"
+            , somali = Just "Baaritaan cusub"
             }
 
         Activities ->
@@ -3429,6 +3217,197 @@ translationSet trans =
                 AcuteIllnessDangerSigns ->
                     translationSet DangerSigns
 
+        AddChild ->
+            { english = "Add Child"
+            , kinyarwanda = Just "Ongeraho umwana"
+            , kirundi = Just "Kongerako umwana"
+            , somali = Just "Ku dar Canug"
+            }
+
+        AddContact ->
+            { english = "Add Contact"
+            , kinyarwanda = Just "Ongeraho uwo bahuye"
+            , kirundi = Just "Kongerako aho yotorwa/ingene yotorwa"
+            , somali = Nothing
+            }
+
+        AddedToPatientRecordOn ->
+            { english = "Added to patient record on"
+            , kinyarwanda = Just "Yongewe ku makuru y'umurwayi kuwa"
+            , kirundi = Just "Kongerako aho abagwayi bamaze kwandikwa"
+            , somali = Just "Ku dar xogta bukaanka"
+            }
+
+        AddFamilyMember ->
+            { english = "Add Family Member"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Kongerako umwe mu bagize umuryango"
+            , somali = Just "Ku dar Xubin Qoys"
+            }
+
+        AddFamilyMemberFor name ->
+            { english = "Add Family Member for " ++ name
+            , kinyarwanda = Nothing
+            , kirundi = Just <| "Kongerako umwe mu bagize umuryango wa " ++ name
+            , somali = Just <| "Ku dar Xubin Qoyska ah ee " ++ name
+            }
+
+        AddNewParticipant ->
+            { english = "Add new participant"
+            , kinyarwanda = Just "Ongeramo Umugenerwabikorwa musha"
+            , kirundi = Just "Andika Umurwayi mushasha yitavye igikorwa"
+            , somali = Just "Ku dar qof cusub"
+            }
+
+        AddParentOrCaregiver ->
+            { english = "Add Parent or Caregiver"
+            , kinyarwanda = Just "Ongeraho umubyeyi cyangwa umurezi"
+            , kirundi = Just "Kongerako umuvyeyi canke umurezi"
+            , somali = Just "Ku dar Waalid ama Daryeele"
+            }
+
+        AddToGroup ->
+            { english = "Add to Group..."
+            , kinyarwanda = Just "Ongeraho itsinda..."
+            , kirundi = Just "Ongerako Mumurwi..."
+            , somali = Just "Ku dar Kooxda"
+            }
+
+        Administer ->
+            { english = "Administer"
+            , kinyarwanda = Just "Tanga umuti"
+            , kirundi = Just "Tanga umuti"
+            , somali = Just "U qor"
+            }
+
+        AdministerAlbendazoleHelper ->
+            translationSet GiveTheChildOneTabletByMouth
+
+        AdministerAspirinHelper ->
+            { english = "1 tablet 150 mg by mouth daily"
+            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 150 buri munsi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AdministerAzithromycinHelper ->
+            { english = "By mouth 1x"
+            , kinyarwanda = Just "Inshuro imwe mu kanwa"
+            , kirundi = Just "Kumira incuro 1"
+            , somali = Nothing
+            }
+
+        AdministerCalciumHelper ->
+            { english = "1 tablet 500 mg by mouth daily"
+            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 500 buri munsi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AdministerCeftriaxoneHelper ->
+            { english = "IM once"
+            , kinyarwanda = Just "Urushinge mu mikaya inshuro imwe"
+            , kirundi = Just "Gucisha umuti mu mutsi rimwe"
+            , somali = Nothing
+            }
+
+        AdministerFefolHelper ->
+            translationSet OneTabletByMouthDaily
+
+        AdministerFolicAcidHelper ->
+            { english = "1 tablet 400 IU by mouth daily for 3 months"
+            , kinyarwanda = Just "Ikinini 1 mu kanwa (400 IU) buri munsi mu gihe cy'amezi 3"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AdministerHIVARVHelper ->
+            { english = "Take 1x a day by mouth"
+            , kinyarwanda = Just "Fata ikinini 1 ku munsi mu kanwa"
+            , kirundi = Just "Ugufata ikinini 1, ukimize, 1 ku munsi"
+            , somali = Just "Qaado 1 kaniini afka x halki maalin"
+            }
+
+        AdministerIronHelper ->
+            { english = "1 tablet 60 mg by mouth 2x a day for 3 months"
+            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 60 inshuro 2 ku munsi mu gihe cy'amezi 3"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AdministerMebendezoleHelper ->
+            translationSet GiveTheChildOneTabletByMouth
+
+        AdministerMetronidazoleHelper ->
+            { english = "By mouth twice a day for 7 days"
+            , kinyarwanda = Just "Kunywa ikinini inshuro ebyiri ku munsi mu minsi irindwi"
+            , kirundi = Nothing
+            , somali = Just "Afka laba jeer maalinki ilaa 7 maalin"
+            }
+
+        AdministerMMSHelper ->
+            { english = "1 tablet by mouth daily - 180 tablets dispensed"
+            , kinyarwanda = Just "Kunywa ikinini kimwe ku munsi - Hatanzwe ibinini 180"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AdministerParacetamolHelper ->
+            { english = "Take 1 tablet by mouth 3 times a day for 5 days"
+            , kinyarwanda = Just "Fata ikinini 1 mu kanwa inshuro 3 ku munsi mu minsi 5"
+            , kirundi = Just "Ugufata ikinini 1, ukimize, 3 ku munsi mu minsi 5"
+            , somali = Just "Qaado 1 kaniini afka 3 mar halki maalin mudo 5 maalin ah"
+            }
+
+        AdministerPrenatalMebendezoleHelper ->
+            { english = "1 tablet 500 mg by mouth ONCE"
+            , kinyarwanda = Just "Ikinini kimwe mu kanwa cya mirigarama 500 INSHURO IMWE GUSA"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AdministerVitaminAHelperPrenatal ->
+            { english = "Vitamin A is given once"
+            , kinyarwanda = Just "Vitamine A itangwa inshuro 1"
+            , kirundi = Just "Vitamine A yatanzwe rimwe"
+            , somali = Just "Vitamin baa la siiyay hal mar"
+            }
+
+        AdministerVitaminAHelperWellChild ->
+            { english = "Put the correct number of drops directly into the mouth of the child"
+            , kinyarwanda = Just "Shyira mu kanwa k'umwana ibitonyanga bigenwe"
+            , kirundi = Just "Shira igitigiri gikwiye aho nyene mu kanwa k'umwana"
+            , somali = Just "Ku shub tirada saxda ee dhibicyada afka canuga"
+            }
+
+        Administered ->
+            { english = "Administered"
+            , kinyarwanda = Just "Umuti watanzwe"
+            , kirundi = Just "Gutwagwa"
+            , somali = Nothing
+            }
+
+        AdministeredMedicationQuestion ->
+            { english = "Have you administered"
+            , kinyarwanda = Just "Watanze umuti"
+            , kirundi = Just "Woba warigeze utanga umuti"
+            , somali = Just "Ma u qortay"
+            }
+
+        AdministeredOneOfAboveMedicinesQuestion ->
+            { english = "Have you administered one of the above medicines to the patient"
+            , kinyarwanda = Just "Waba wahaye umurwyayi umwe mu miti yavuzwe haruguru"
+            , kirundi = Just "Woba warigeze utanga umwe mu miti iraho hejuru k'umugwayi"
+            , somali = Just "Ma u qortay bukaanka mid ka mid ah dawooyinka kor ku xusan"
+            }
+
+        AddressInformation ->
+            { english = "Address Information"
+            , kinyarwanda = Just "Aho atuye/Aho abarizwa"
+            , kirundi = Just "Amakuru ajanye n'aho aba"
+            , somali = Just "Macluumaadka Cinwaanka"
+            }
+
         AdoptionSurveyBaselineScore score ->
             { english = "Baseline Score: " ++ String.fromInt score ++ "/60"
             , kinyarwanda = Just <| "Amanota wagize bwambere: " ++ String.fromInt score ++ "/60"
@@ -3535,6 +3514,27 @@ translationSet trans =
                 , somali = Just "Waxyeellooyin"
                 }
 
+        AfterEachLiquidStool ->
+            { english = "after each liquid stool"
+            , kinyarwanda = Just "buri uko amaze kwituma ibyoroshye"
+            , kirundi = Just "Inyuma ya buri mwanda mukuru w'amazi"
+            , somali = Just "kadib sarao walba oo jilcan"
+            }
+
+        AgeAxisLabel ->
+            { english = "Age (years-months)"
+            , kinyarwanda = Just "Imyaka (imyaka-amezi)"
+            , kirundi = Just "Imyaka (imyaka-amezi)"
+            , somali = Just "Da'da (sano-bilood)"
+            }
+
+        AgeWord ->
+            { english = "Age"
+            , kinyarwanda = Just "Imyaka"
+            , kirundi = Just "Imyaka"
+            , somali = Just "Da`da"
+            }
+
         Age months days ->
             { english = String.fromInt months ++ " months " ++ String.fromInt days ++ " days"
             , kinyarwanda = Just <| String.fromInt months ++ " Amezi " ++ String.fromInt days ++ " iminsi"
@@ -3568,6 +3568,13 @@ translationSet trans =
             , kinyarwanda = Just <| String.fromInt months ++ " Ukwezi " ++ String.fromInt days ++ " Iminsi"
             , kirundi = Just <| String.fromInt months ++ " Ukwezi " ++ String.fromInt days ++ " Iminsi"
             , somali = Just <| String.fromInt months ++ " Bil " ++ String.fromInt days ++ " maalin"
+            }
+
+        AgeSingleMonthWithoutDay month ->
+            { english = String.fromInt month ++ " month"
+            , kinyarwanda = Just <| String.fromInt month ++ " Ukwezi"
+            , kirundi = Nothing
+            , somali = Just <| String.fromInt month ++ " Bil"
             }
 
         AgeSingleDayWithMonth months days ->
@@ -3692,11 +3699,60 @@ translationSet trans =
                     , somali = Just "Baaritaanka deg dega ah ee Covid"
                     }
 
+        All ->
+            { english = "All"
+            , kinyarwanda = Just "Uburwayi bwose"
+            , kirundi = Just "Vyose"
+            , somali = Just "Dhamaan"
+            }
+
+        AllowedValuesRangeHelper constraints ->
+            { english = "Allowed values are between " ++ String.fromFloat constraints.minVal ++ " and " ++ String.fromFloat constraints.maxVal ++ "."
+            , kinyarwanda = Just <| "Imibare yemewe iri hagati ya " ++ String.fromFloat constraints.minVal ++ " na " ++ String.fromFloat constraints.maxVal ++ "."
+            , kirundi = Just <| "ibiharuro vyemewe biri hagati ya " ++ String.fromFloat constraints.minVal ++ " na " ++ String.fromFloat constraints.maxVal ++ "."
+            , somali = Just <| "Tirooyinka la oggol yahay waa " ++ String.fromFloat constraints.minVal ++ " iyo " ++ String.fromFloat constraints.maxVal ++ "."
+            }
+
+        AlmostEveryday ->
+            { english = "Almost everyday (6-7 days)"
+            , kinyarwanda = Just "Buri munsi (iminsi 6-7)"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        AmbulanceArrivalPeriodQuestion ->
+            { english = "How long did it take the ambulance to arrive"
+            , kinyarwanda = Just "Bitwara igihe kingana gute ngo imbangukiragutabara ihagere"
+            , kirundi = Just "Mbega Rusehabaniha (ambiranse) yafashe umwanya ungana gute kuhashisha"
+            , somali = Just "Illaa intee ayay ku qaadatay inuu yimaado gaariga gargaarka deg-dega "
+            }
+
         Amlodipine5mg ->
             { english = "Amlodipine (5mg)"
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing
+            }
+
+        ANCEncountersNotRecordedQuestion ->
+            { english = "Were there any ANC encounters that are not recorded above"
+            , kinyarwanda = Just "Haba hari ipimwa ry'inda ryakozwe bakaba batarabyanditse"
+            , kirundi = Nothing
+            , somali = Just "Ma jireen wax ogaansho DHU ah oo kor aan ku qorneyn"
+            }
+
+        ANCIndicateVisitsMonthsPhrase ->
+            { english = "Indicate the months of pregnancy in which a visit occured"
+            , kinyarwanda = Just "Hitamo amezi y'inda isuzuma ryakoreweho"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ANCNewborn ->
+            { english = "Antenatal Care & Newborn"
+            , kinyarwanda = Just "Kwita k’umugore utwite n’uruhinja"
+            , kirundi = Just "Gukurikirana umukenyezi wibungenze n'uruyoya"
+            , somali = Just "Daryeelka Uurreyda & Dhallaan"
             }
 
         And ->
@@ -3734,48 +3790,6 @@ translationSet trans =
             , somali = Just "Taariikhda Booqashada Uureyda"
             }
 
-        AlmostEveryday ->
-            { english = "Almost everyday (6-7 days)"
-            , kinyarwanda = Just "Buri munsi (iminsi 6-7)"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        AmbulanceArrivalPeriodQuestion ->
-            { english = "How long did it take the ambulance to arrive"
-            , kinyarwanda = Just "Bitwara igihe kingana gute ngo imbangukiragutabara ihagere"
-            , kirundi = Just "Mbega Rusehabaniha (ambiranse) yafashe umwanya ungana gute kuhashisha"
-            , somali = Just "Illaa intee ayay ku qaadatay inuu yimaado gaariga gargaarka deg-dega "
-            }
-
-        ANCEncountersNotRecordedQuestion ->
-            { english = "Were there any ANC encounters that are not recorded above"
-            , kinyarwanda = Just "Haba hari ipimwa ry'inda ryakozwe bakaba batarabyanditse"
-            , kirundi = Nothing
-            , somali = Just "Ma jireen wax ogaansho DHU ah oo kor aan ku qorneyn"
-            }
-
-        ANCIndicateVisitsMonthsPhrase ->
-            { english = "Indicate the months of pregnancy in which a visit occured"
-            , kinyarwanda = Just "Hitamo amezi y'inda isuzuma ryakoreweho"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        ANCNewborn ->
-            { english = "Antenatal Care & Newborn"
-            , kinyarwanda = Just "Kwita k’umugore utwite n’uruhinja"
-            , kirundi = Just "Gukurikirana umukenyezi wibungenze n'uruyoya"
-            , somali = Just "Daryeelka Uurreyda & Dhallaan"
-            }
-
-        AgeSingleMonthWithoutDay month ->
-            { english = String.fromInt month ++ " month"
-            , kinyarwanda = Just <| String.fromInt month ++ " Ukwezi"
-            , kirundi = Nothing
-            , somali = Just <| String.fromInt month ++ " Bil"
-            }
-
         AppName ->
             { english = "E-Heza System"
             , kinyarwanda = Just "E-heza sisiteme"
@@ -3795,20 +3809,6 @@ translationSet trans =
             , kinyarwanda = Just "Umubyeyi agomba kujya ku kigo nderabuzima ku itariki ikurikira"
             , kirundi = Just "Umurwayi ategerezwa kuja k'ivuriro kw'itarike ikurikira"
             , somali = Just "Bukaanka waa inuu booqdaaxarun caafimaad taariikhda soo socota"
-            }
-
-        All ->
-            { english = "All"
-            , kinyarwanda = Just "Uburwayi bwose"
-            , kirundi = Just "Vyose"
-            , somali = Just "Dhamaan"
-            }
-
-        AllowedValuesRangeHelper constraints ->
-            { english = "Allowed values are between " ++ String.fromFloat constraints.minVal ++ " and " ++ String.fromFloat constraints.maxVal ++ "."
-            , kinyarwanda = Just <| "Imibare yemewe iri hagati ya " ++ String.fromFloat constraints.minVal ++ " na " ++ String.fromFloat constraints.maxVal ++ "."
-            , kirundi = Just <| "ibiharuro vyemewe biri hagati ya " ++ String.fromFloat constraints.minVal ++ " na " ++ String.fromFloat constraints.maxVal ++ "."
-            , somali = Just <| "Tirooyinka la oggol yahay waa " ++ String.fromFloat constraints.minVal ++ " iyo " ++ String.fromFloat constraints.maxVal ++ "."
             }
 
         AreYouSure ->
@@ -4314,6 +4314,39 @@ translationSet trans =
             , somali = Nothing
             }
 
+        BreastExamSign option ->
+            case option of
+                Mass ->
+                    { english = "Mass"
+                    , kinyarwanda = Just "Utubyimba mu Ibere"
+                    , kirundi = Just "Imisa"
+                    , somali = Nothing
+                    }
+
+                Discharge ->
+                    { english = "Discharge"
+                    , kinyarwanda = Just "Gusohoka kw'ibintu bidasanzwe"
+                    , kirundi = Just "Gucugwa"
+                    , somali = Just "Ka saarid"
+                    }
+
+                Infection ->
+                    { english = "Infection"
+                    , kinyarwanda = Just "Indwara iterwa n'udukoko tutabonwa n'amaso (Microbes)"
+                    , kirundi = Just "Ivyanduza"
+                    , somali = Just "Caabuq"
+                    }
+
+                NormalBreast ->
+                    translationSet Normal
+
+                Warmth ->
+                    { english = "Warmth"
+                    , kinyarwanda = Just "Ubushyuhe"
+                    , kirundi = Just "Ubushuhe"
+                    , somali = Nothing
+                    }
+
         BreastExamDischargeQuestion ->
             { english = "What kind of discharge"
             , kinyarwanda = Nothing
@@ -4364,39 +4397,6 @@ translationSet trans =
             , kirundi = Just "Mbega wareretse umugwayi ingene yokwigirira igipimo c'ibere"
             , somali = Nothing
             }
-
-        BreastExamSign option ->
-            case option of
-                Mass ->
-                    { english = "Mass"
-                    , kinyarwanda = Just "Utubyimba mu Ibere"
-                    , kirundi = Just "Imisa"
-                    , somali = Nothing
-                    }
-
-                Discharge ->
-                    { english = "Discharge"
-                    , kinyarwanda = Just "Gusohoka kw'ibintu bidasanzwe"
-                    , kirundi = Just "Gucugwa"
-                    , somali = Just "Ka saarid"
-                    }
-
-                Infection ->
-                    { english = "Infection"
-                    , kinyarwanda = Just "Indwara iterwa n'udukoko tutabonwa n'amaso (Microbes)"
-                    , kirundi = Just "Ivyanduza"
-                    , somali = Just "Caabuq"
-                    }
-
-                NormalBreast ->
-                    translationSet Normal
-
-                Warmth ->
-                    { english = "Warmth"
-                    , kinyarwanda = Just "Ubushyuhe"
-                    , kirundi = Just "Ubushuhe"
-                    , somali = Nothing
-                    }
 
         BrittleHair ->
             { english = "Brittle Hair"
@@ -4517,20 +4517,6 @@ translationSet trans =
             , somali = Nothing
             }
 
-        Ceftriaxone1g ->
-            { english = "Ceftriaxone (1g)"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        Cell ->
-            { english = "Cell"
-            , kinyarwanda = Just "Akagali"
-            , kirundi = Just "cellule"
-            , somali = Just "Unug"
-            }
-
         CaseManagement ->
             { english = "Case Management"
             , kinyarwanda = Just "Gukurikirana Umurwayi"
@@ -4620,6 +4606,13 @@ translationSet trans =
                 FilterHIV ->
                     translationSet HIV
 
+        Ceftriaxone1g ->
+            { english = "Ceftriaxone (1g)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         Celsius ->
             { english = "Celsius"
             , kinyarwanda = Just "Serisiyusi"
@@ -4632,6 +4625,13 @@ translationSet trans =
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing
+            }
+
+        Cell ->
+            { english = "Cell"
+            , kinyarwanda = Just "Akagali"
+            , kirundi = Just "cellule"
+            , somali = Just "Unug"
             }
 
         ChartPhrase phrase ->
@@ -4731,6 +4731,20 @@ translationSet trans =
                     , kirundi = Just "Akayabagu gake"
                     , somali = Just "Cunno Xumo"
                     }
+
+        ChildName ->
+            { english = "Child Name"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Just "Magaca Canuga"
+            }
+
+        ChildNutrition ->
+            { english = "Child Nutrition"
+            , kinyarwanda = Just "Imirire y'Umwana"
+            , kirundi = Just "Ingaburo y’umwana"
+            , somali = Just "Nafaqada Canuga"
+            }
 
         Children ->
             { english = "Children"
@@ -4854,20 +4868,6 @@ translationSet trans =
             , somali = Just "Hawsha SHCB"
             }
 
-        ChildName ->
-            { english = "Child Name"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Just "Magaca Canuga"
-            }
-
-        ChildNutrition ->
-            { english = "Child Nutrition"
-            , kinyarwanda = Just "Imirire y'Umwana"
-            , kirundi = Just "Ingaburo y’umwana"
-            , somali = Just "Nafaqada Canuga"
-            }
-
         Clear ->
             { english = "Clear"
             , kinyarwanda = Just "Gukuraho"
@@ -4928,58 +4928,6 @@ translationSet trans =
             , kirundi = Just "Ivyo kwa muganga"
             , somali = Just "Daaweyn"
             }
-
-        Connecting ->
-            { english = "Connecting"
-            , kinyarwanda = Just "Gusabana"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        ConstipationLabel ->
-            { english = "Constipation"
-            , kinyarwanda = Just "Kwituma impatwe"
-            , kirundi = Just "Ukuzura inda"
-            , somali = Just "Calool istaag"
-            }
-
-        ContributingFactors ->
-            { english = "Contributing Factors"
-            , kinyarwanda = Just "Impamvu zateye uburwayi"
-            , kirundi = Just "Ivyatumye arwara"
-            , somali = Just "Waxyaabaha Keeni kara"
-            }
-
-        ConvulsionsLabel ->
-            { english = "Convulsions"
-            , kinyarwanda = Just "Kugagara"
-            , kirundi = Just "Ibisahuzi"
-            , somali = Just "Gariir"
-            }
-
-        CorePhysicalExamLabel ->
-            { english = "Core Physical Exam"
-            , kinyarwanda = Just "Isuzuma ryimbitse"
-            , kirundi = Just "Igipimo c'umubiri c'intango"
-            , somali = Nothing
-            }
-
-        COVID19WithSignsOfPneumonia ->
-            { english = "COVID-19 with signs of Pneumonia"
-            , kinyarwanda = Just "Uburwayi bwa Covid-19 hamwe n'ibimenyetso by'Umusonga"
-            , kirundi = Just "Virisi ya Korona - 19 n'ibimenyetso vy'umusonga"
-            , somali = Just "COVID-19 oo leh calaamadaha Oof wareenka"
-            }
-
-        Creatinine ->
-            { english = "Creatinine"
-            , kinyarwanda = Just "Keleyatinine"
-            , kirundi = Just "Créatinine"
-            , somali = Nothing
-            }
-
-        Dashboard dashboard ->
-            translateDashboard dashboard
 
         ClinicalProgressReport ->
             { english = "Clinical Progress Report"
@@ -5120,6 +5068,20 @@ translationSet trans =
             , somali = Nothing
             }
 
+        Connecting ->
+            { english = "Connecting"
+            , kinyarwanda = Just "Gusabana"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ConstipationLabel ->
+            { english = "Constipation"
+            , kinyarwanda = Just "Kwituma impatwe"
+            , kirundi = Just "Ukuzura inda"
+            , somali = Just "Calool istaag"
+            }
+
         Contacted114 ->
             { english = "Contacted 114"
             , kinyarwanda = Just "Namenyesheje 114"
@@ -5230,6 +5192,13 @@ translationSet trans =
                 NoContributingFactorsSign ->
                     translationSet NoneOfThese
 
+        ContributingFactors ->
+            { english = "Contributing Factors"
+            , kinyarwanda = Just "Impamvu zateye uburwayi"
+            , kirundi = Just "Ivyatumye arwara"
+            , somali = Just "Waxyaabaha Keeni kara"
+            }
+
         ContributingFactorsQuestion ->
             { english = "Has patient or patient’s mother experienced any of the following"
             , kinyarwanda = Just "Umurwayi cyangwa umubyeyi we bagaragaje ibimenyetso bikurikira"
@@ -5244,10 +5213,38 @@ translationSet trans =
             , somali = Nothing
             }
 
+        ConvulsionsLabel ->
+            { english = "Convulsions"
+            , kinyarwanda = Just "Kugagara"
+            , kirundi = Just "Ibisahuzi"
+            , somali = Just "Gariir"
+            }
+
         ConvulsionsPreviousDelivery ->
             { english = "Experienced convulsions in previous delivery"
             , kinyarwanda = Just "Ubushize yaragagaye abyara"
             , kirundi = Just "Yarumvise ibizunguzungu igihe aheruka kwibaruka"
+            , somali = Nothing
+            }
+
+        CorePhysicalExamLabel ->
+            { english = "Core Physical Exam"
+            , kinyarwanda = Just "Isuzuma ryimbitse"
+            , kirundi = Just "Igipimo c'umubiri c'intango"
+            , somali = Nothing
+            }
+
+        COVID19WithSignsOfPneumonia ->
+            { english = "COVID-19 with signs of Pneumonia"
+            , kinyarwanda = Just "Uburwayi bwa Covid-19 hamwe n'ibimenyetso by'Umusonga"
+            , kirundi = Just "Virisi ya Korona - 19 n'ibimenyetso vy'umusonga"
+            , somali = Just "COVID-19 oo leh calaamadaha Oof wareenka"
+            }
+
+        Creatinine ->
+            { english = "Creatinine"
+            , kinyarwanda = Just "Keleyatinine"
+            , kirundi = Just "Créatinine"
             , somali = Nothing
             }
 
@@ -5290,6 +5287,9 @@ translationSet trans =
             , kirundi = Just "Umuti ariko afata"
             , somali = Nothing
             }
+
+        Dashboard dashboard ->
+            translateDashboard dashboard
 
         DepressionNotLikely ->
             { english = "Depression not Likely"
@@ -5415,58 +5415,6 @@ translationSet trans =
             , kinyarwanda = Just "Gufunga"
             , kirundi = Just "Yugaye"
             , somali = Just "La xiray"
-            }
-
-        DeliveryComplication complication ->
-            case complication of
-                ComplicationGestationalDiabetes ->
-                    translationSet GestationalDiabetes
-
-                ComplicationEmergencyCSection ->
-                    { english = "Emergency C-Section"
-                    , kinyarwanda = Just "Kubagwa bitewe n'impamvu zihutirwa"
-                    , kirundi = Just "Ikorwa ry'ihuta"
-                    , somali = Nothing
-                    }
-
-                ComplicationPreclampsia ->
-                    translationSet Preeclampsia
-
-                ComplicationMaternalHemmorhage ->
-                    { english = "Maternal Hemorrhage"
-                    , kinyarwanda = Just "Kuva amaraso ku mubyeyi utwite cyangwa nyuma yo kubyara"
-                    , kirundi = Just "Ukuva amaraso kw'abavyeyi"
-                    , somali = Nothing
-                    }
-
-                ComplicationHiv ->
-                    translationSet HIV
-
-                ComplicationMaternalDeath ->
-                    { english = "Maternal Death"
-                    , kinyarwanda = Just "Urupfu rw'umubyeyi"
-                    , kirundi = Just "Urupfu rw'abavyeyi"
-                    , somali = Nothing
-                    }
-
-                ComplicationOther ->
-                    translationSet OtherLabel
-
-                NoDeliveryComplications ->
-                    translationSet NoneOfThese
-
-        DeliveryComplicationsPresentQuestion ->
-            { english = "Were there any complications with the delivery"
-            , kinyarwanda = Just "Haba hari ibibazo umubyeyi yagize abyara"
-            , kirundi = Just "Hoba hari ingorane zijanye no kuvyara, zijanye no gutanga"
-            , somali = Just "Ma jireen wax dhibaatooyin ah oo la xiriira dhalmada"
-            }
-
-        DeliveryComplicationsSelectionLabel ->
-            { english = "Which of the following were present"
-            , kinyarwanda = Just "Ni ibiki byagaragaye muri ibi bikurikira"
-            , kirundi = Just "Ninde muri aba bakurikira yari yaje"
-            , somali = Just "Kuwee muuqday oo kamid ah kuwan soo socda"
             }
 
         ConditionImproving isImproving ->
@@ -5604,6 +5552,13 @@ translationSet trans =
             , somali = Just "Abuur Xiriir"
             }
 
+        ChwDashboardLabel ->
+            { english = "CHW Snapshot"
+            , kinyarwanda = Just "Ishusho y'ibyagezweho"
+            , kirundi = Just "Igicapo c'Abaremeshakiyago"
+            , somali = Just "Goob qabadka SHCB"
+            }
+
         CurrentlyPregnant ->
             { english = "Currently Pregnant"
             , kinyarwanda = Just "Aratwite"
@@ -5623,41 +5578,6 @@ translationSet trans =
             , kinyarwanda = Just "Ibiri mu bubiko"
             , kirundi = Nothing
             , somali = Nothing
-            }
-
-        ChwDashboardLabel ->
-            { english = "CHW Snapshot"
-            , kinyarwanda = Just "Ishusho y'ibyagezweho"
-            , kirundi = Just "Igicapo c'Abaremeshakiyago"
-            , somali = Just "Goob qabadka SHCB"
-            }
-
-        DashboardLabel ->
-            { english = "Dashboard"
-            , kinyarwanda = Just "Ikibaho cy’amakuru y’ingenzi"
-            , kirundi = Just "Urubaho rw’amakuru"
-            , somali = Just "Daashbood"
-            }
-
-        Dashboards ->
-            { english = "Dashboards"
-            , kinyarwanda = Just "Ikibaho cy’amakuru y’ingenzi"
-            , somali = Just "Daashboodyo"
-            , kirundi = Just "Icegeranyo c'ibikorwa"
-            }
-
-        DateReceived ->
-            { english = "Date Received"
-            , kinyarwanda = Just "Italiki yakiriweho"
-            , kirundi = Just "Itarike yakiriwe"
-            , somali = Just "Taariikhda la Helay"
-            }
-
-        DeliveryLocation ->
-            { english = "Delivery Location"
-            , kinyarwanda = Just "Aho yabyariye"
-            , kirundi = Just "Ahantu ho kuvyarira"
-            , somali = Just "Goobta Dhalmada"
             }
 
         DangerSign sign ->
@@ -5761,15 +5681,6 @@ translationSet trans =
             , somali = Just "Bukaanka waxaa ka muuqda calaamadaha"
             }
 
-        DangerSignsTask task ->
-            case task of
-                ReviewDangerSigns ->
-                    { english = "Review Danger Signs"
-                    , kinyarwanda = Just "Kureba ibimenyetso mpuruza"
-                    , kirundi = Just "Subiramwo ibimenyetso mburizi"
-                    , somali = Just "Dib u eeg Calaamadaha Khatarta ah"
-                    }
-
         Date ->
             { english = "Date"
             , kinyarwanda = Just "Itariki"
@@ -5798,6 +5709,34 @@ translationSet trans =
             , somali = Just "Taariikhda la gaba gabeeyay Uurka"
             }
 
+        DashboardLabel ->
+            { english = "Dashboard"
+            , kinyarwanda = Just "Ikibaho cy’amakuru y’ingenzi"
+            , kirundi = Just "Urubaho rw’amakuru"
+            , somali = Just "Daashbood"
+            }
+
+        Dashboards ->
+            { english = "Dashboards"
+            , kinyarwanda = Just "Ikibaho cy’amakuru y’ingenzi"
+            , somali = Just "Daashboodyo"
+            , kirundi = Just "Icegeranyo c'ibikorwa"
+            }
+
+        DateReceived ->
+            { english = "Date Received"
+            , kinyarwanda = Just "Italiki yakiriweho"
+            , kirundi = Just "Itarike yakiriwe"
+            , somali = Just "Taariikhda la Helay"
+            }
+
+        DateOfBirth ->
+            { english = "Date of Birth"
+            , kinyarwanda = Just "Itariki y'amavuko"
+            , kirundi = Just "Itarike y'amavuko"
+            , somali = Just "Taariikhda Dhalashada"
+            }
+
         DayAbbrev ->
             { english = "Day"
             , kinyarwanda = Just "Umu"
@@ -5819,13 +5758,6 @@ translationSet trans =
                 , kirundi = Just <| String.fromInt value ++ " Iminsi"
                 , somali = Just <| String.fromInt value ++ " Maalin"
                 }
-
-        DateOfBirth ->
-            { english = "Date of Birth"
-            , kinyarwanda = Just "Itariki y'amavuko"
-            , kirundi = Just "Itarike y'amavuko"
-            , somali = Just "Taariikhda Dhalashada"
-            }
 
         DaysAbbrev ->
             { english = "days"
@@ -5861,6 +5793,65 @@ translationSet trans =
             , kinyarwanda = Just "Gusiba"
             , kirundi = Just "Ugufuta"
             , somali = Just "Tirtir"
+            }
+
+        DeliveryComplication complication ->
+            case complication of
+                ComplicationGestationalDiabetes ->
+                    translationSet GestationalDiabetes
+
+                ComplicationEmergencyCSection ->
+                    { english = "Emergency C-Section"
+                    , kinyarwanda = Just "Kubagwa bitewe n'impamvu zihutirwa"
+                    , kirundi = Just "Ikorwa ry'ihuta"
+                    , somali = Nothing
+                    }
+
+                ComplicationPreclampsia ->
+                    translationSet Preeclampsia
+
+                ComplicationMaternalHemmorhage ->
+                    { english = "Maternal Hemorrhage"
+                    , kinyarwanda = Just "Kuva amaraso ku mubyeyi utwite cyangwa nyuma yo kubyara"
+                    , kirundi = Just "Ukuva amaraso kw'abavyeyi"
+                    , somali = Nothing
+                    }
+
+                ComplicationHiv ->
+                    translationSet HIV
+
+                ComplicationMaternalDeath ->
+                    { english = "Maternal Death"
+                    , kinyarwanda = Just "Urupfu rw'umubyeyi"
+                    , kirundi = Just "Urupfu rw'abavyeyi"
+                    , somali = Nothing
+                    }
+
+                ComplicationOther ->
+                    translationSet OtherLabel
+
+                NoDeliveryComplications ->
+                    translationSet NoneOfThese
+
+        DeliveryComplicationsPresentQuestion ->
+            { english = "Were there any complications with the delivery"
+            , kinyarwanda = Just "Haba hari ibibazo umubyeyi yagize abyara"
+            , kirundi = Just "Hoba hari ingorane zijanye no kuvyara, zijanye no gutanga"
+            , somali = Just "Ma jireen wax dhibaatooyin ah oo la xiriira dhalmada"
+            }
+
+        DeliveryComplicationsSelectionLabel ->
+            { english = "Which of the following were present"
+            , kinyarwanda = Just "Ni ibiki byagaragaye muri ibi bikurikira"
+            , kirundi = Just "Ninde muri aba bakurikira yari yaje"
+            , somali = Just "Kuwee muuqday oo kamid ah kuwan soo socda"
+            }
+
+        DeliveryLocation ->
+            { english = "Delivery Location"
+            , kinyarwanda = Just "Aho yabyariye"
+            , kirundi = Just "Ahantu ho kuvyarira"
+            , somali = Just "Goobta Dhalmada"
             }
 
         DemographicInformation ->
@@ -6091,13 +6082,6 @@ translationSet trans =
             , somali = Just "Ay sabab u tahay"
             }
 
-        EarlyChildhoodDevelopment ->
-            { english = "Early Childhood Development"
-            , kinyarwanda = Just "Gahunda ikomatanije y'imikurire"
-            , kirundi = Just "Gukurikirana igikuriro c'umwana"
-            , somali = Nothing
-            }
-
         EarlyMastitisOrEngorgmentReliefMethod method ->
             case method of
                 ReliefMethodBreastMassage ->
@@ -6120,6 +6104,13 @@ translationSet trans =
                     , kirundi = Just "Kubandanya wonsa umwana canke ukoreshe ukuboka ukuremwo amata"
                     , somali = Nothing
                     }
+
+        EarlyChildhoodDevelopment ->
+            { english = "Early Childhood Development"
+            , kinyarwanda = Just "Gahunda ikomatanije y'imikurire"
+            , kirundi = Just "Gukurikirana igikuriro c'umwana"
+            , somali = Nothing
+            }
 
         Eclampsia ->
             { english = "Eclampsia"
@@ -6624,6 +6615,15 @@ translationSet trans =
             , somali = Just "Deji oo u Dir Daryeelka Dhalmada Deg Dega ah"
             }
 
+        DangerSignsTask task ->
+            case task of
+                ReviewDangerSigns ->
+                    { english = "Review Danger Signs"
+                    , kinyarwanda = Just "Kureba ibimenyetso mpuruza"
+                    , kirundi = Just "Subiramwo ibimenyetso mburizi"
+                    , somali = Just "Dib u eeg Calaamadaha Khatarta ah"
+                    }
+
         EmptyString ->
             { english = ""
             , kinyarwanda = Nothing
@@ -6651,62 +6651,6 @@ translationSet trans =
             , kirundi = Just "Ubwoko bw'umubonano"
             , somali = Just "Raadi qeybaha"
             }
-
-        EncounterTypeFollowUpQuestion encounterType ->
-            case encounterType of
-                AcuteIllnessEncounter ->
-                    { english = "Do you want to start a subsequent Acute Illness encounter for"
-                    , kinyarwanda = Just "Urashaka Gutangira Ibikorwa bikurikiyeho ku burwayi bwa"
-                    , kirundi = Just "Mbega urashaka gutangura gukurikirana ubugwayi bukomeye bwa"
-                    , somali = Just "Ma dooneysaa inaad billowdo ogaanshaha Xanuunka soo Boodada ah ee isku xig xiga ee"
-                    }
-
-                AntenatalEncounter ->
-                    { english = "What type of Antenatal encounter would you like to start for"
-                    , kinyarwanda = Just "Ni irihe suzuma ku mugore utwite ushaka gutangira kuri"
-                    , kirundi = Just "Ni ubuhe bwoko bwo guhura mu gihe c'imbanyi ipfuza gutangura"
-                    , somali = Just "Waa noocee ogaanshaha uurreyda ee doonayso iinaad billowdo"
-                    }
-
-                ChildScoreboardEncounter ->
-                    translationSet EmptyString
-
-                HIVEncounter ->
-                    { english = "Do you want to start a HIV Management encounter for"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Urashaka gutangura umubonano kuvyerekeye ingwara y'umugera wa SIDA kuri"
-                    , somali = Just "Ma doonaysaa inaad bilowdo maareynta HIV"
-                    }
-
-                HomeVisitEncounter ->
-                    { english = "Do you want to start a Home Visit assessment for"
-                    , kinyarwanda = Just "Urashaka gutangira igikorwa cyo gusura mu rugo"
-                    , kirundi = Just "Mbega urashaka gutangura kugendera ingo kugira ukore isuzuma ry'ibikorwa rya"
-                    , somali = Just "Ma dooneysaa inaad billowdo u kuurgalida Booqashada Guriga ee"
-                    }
-
-                InmmunizationEncounter ->
-                    translationSet EmptyString
-
-                Backend.IndividualEncounterParticipant.Model.NutritionEncounter ->
-                    translationSet EmptyString
-
-                NCDEncounter ->
-                    translationSet EmptyString
-
-                TuberculosisEncounter ->
-                    { english = "Do you want to start a Tuberculosis Management encounter for"
-                    , kinyarwanda = Just "Urashaka gutangira isura ryo gukurikirana umurwayi w'igituntu witwa"
-                    , kirundi = Just "Urashaka gutangura itunganywa ry'imibonano n'umurwayi w'igituntu kuri"
-                    , somali = Just "loo xisabinayo"
-                    }
-
-                WellChildEncounter ->
-                    { english = "Do you want to start a Well Child encounter for"
-                    , kinyarwanda = Just "Urashaka gutangira isuzuma ry'umwana umeze neza kuri"
-                    , kirundi = Nothing
-                    , somali = Just "Ma dooneysaa inaad bilowda qorista"
-                    }
 
         EncounterTypePageLabel page ->
             case page of
@@ -6766,6 +6710,62 @@ translationSet trans =
 
                 PageGroupEducation ->
                     translationSet GroupEducation
+
+        EncounterTypeFollowUpQuestion encounterType ->
+            case encounterType of
+                AcuteIllnessEncounter ->
+                    { english = "Do you want to start a subsequent Acute Illness encounter for"
+                    , kinyarwanda = Just "Urashaka Gutangira Ibikorwa bikurikiyeho ku burwayi bwa"
+                    , kirundi = Just "Mbega urashaka gutangura gukurikirana ubugwayi bukomeye bwa"
+                    , somali = Just "Ma dooneysaa inaad billowdo ogaanshaha Xanuunka soo Boodada ah ee isku xig xiga ee"
+                    }
+
+                AntenatalEncounter ->
+                    { english = "What type of Antenatal encounter would you like to start for"
+                    , kinyarwanda = Just "Ni irihe suzuma ku mugore utwite ushaka gutangira kuri"
+                    , kirundi = Just "Ni ubuhe bwoko bwo guhura mu gihe c'imbanyi ipfuza gutangura"
+                    , somali = Just "Waa noocee ogaanshaha uurreyda ee doonayso iinaad billowdo"
+                    }
+
+                ChildScoreboardEncounter ->
+                    translationSet EmptyString
+
+                HIVEncounter ->
+                    { english = "Do you want to start a HIV Management encounter for"
+                    , kinyarwanda = Nothing
+                    , kirundi = Just "Urashaka gutangura umubonano kuvyerekeye ingwara y'umugera wa SIDA kuri"
+                    , somali = Just "Ma doonaysaa inaad bilowdo maareynta HIV"
+                    }
+
+                HomeVisitEncounter ->
+                    { english = "Do you want to start a Home Visit assessment for"
+                    , kinyarwanda = Just "Urashaka gutangira igikorwa cyo gusura mu rugo"
+                    , kirundi = Just "Mbega urashaka gutangura kugendera ingo kugira ukore isuzuma ry'ibikorwa rya"
+                    , somali = Just "Ma dooneysaa inaad billowdo u kuurgalida Booqashada Guriga ee"
+                    }
+
+                InmmunizationEncounter ->
+                    translationSet EmptyString
+
+                Backend.IndividualEncounterParticipant.Model.NutritionEncounter ->
+                    translationSet EmptyString
+
+                NCDEncounter ->
+                    translationSet EmptyString
+
+                TuberculosisEncounter ->
+                    { english = "Do you want to start a Tuberculosis Management encounter for"
+                    , kinyarwanda = Just "Urashaka gutangira isura ryo gukurikirana umurwayi w'igituntu witwa"
+                    , kirundi = Just "Urashaka gutangura itunganywa ry'imibonano n'umurwayi w'igituntu kuri"
+                    , somali = Just "loo xisabinayo"
+                    }
+
+                WellChildEncounter ->
+                    { english = "Do you want to start a Well Child encounter for"
+                    , kinyarwanda = Just "Urashaka gutangira isuzuma ry'umwana umeze neza kuri"
+                    , kirundi = Nothing
+                    , somali = Just "Ma dooneysaa inaad bilowda qorista"
+                    }
 
         EncounterWarningForDiagnosisPane warning suffix ->
             let
@@ -6913,482 +6913,6 @@ translationSet trans =
 
                 StatusResolved ->
                     translationSet Resolved
-
-        HardlyEver ->
-            { english = "Hardly ever"
-            , kinyarwanda = Just "Gake gashoboka"
-            , kirundi = Just "Biragoye bukebuke"
-            , somali = Just "Marnaba aan dhicin"
-            }
-
-        HaveYouCounseledPatientOnPositiveHIVTestMeaning ->
-            { english = "Have you counseled patient on positive HIV test meaning"
-            , kinyarwanda = Just "Waba wasobanuriye umurwayi (umubyeyi) icyo bisibanuye kugira ibisubizo biri positifu ku bwandu bw'agakoko gatera SIDA"
-            , kirundi = Just "Mbega warahanuye wongera urabwira umugwayi iciza c'igipimo c'umugera wa SIDA"
-            , somali = Just "Ma kala talisay bukaanka macnaha baaritaanka togan ee HIV"
-            }
-
-        HaveYouCounseledPatientOnSaferSexPractices ->
-            { english = "Have you counseled patient on safer sex practices"
-            , kinyarwanda = Just "Wagiriye inama umubyeyi ku bijyanye no gukora imibonano mpuzabitsina ikingiye"
-            , kirundi = Just "Mbega warahanuye  umugwayi kuvyerekeye iciza co kwikingira mu gihe c'imibonano mpuza ibitsina"
-            , somali = Just "Ma kala talisay bukaanka galmada badqabka leh"
-            }
-
-        HaveYouEncouragedThePatientsPartnerToGetTested ->
-            { english = "Have you encouraged the patient’s partner to get tested"
-            , kinyarwanda = Just "Waba washishikarije umubyueyi kubwira uwo babana kwipimisha"
-            , kirundi = Just "Mbega wateye inguvu umufasha w'umugwayi kugira yipimishe"
-            , somali = Nothing
-            }
-
-        HBA1C ->
-            { english = "HBA1C"
-            , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
-            , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
-            , somali = Nothing
-            }
-
-        HeartburnLabel ->
-            { english = "Heartburn"
-            , kinyarwanda = Just "Ikirungurira"
-            , kirundi = Just "Ugusha k'umutima"
-            , somali = Nothing
-            }
-
-        Hello ->
-            { english = "Hello "
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        HemoglobinTestHistory ->
-            { english = "Hemoglobin Test History"
-            , kinyarwanda = Just "Amakuru ku kizamini cy'ingano y'amaraso"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        HighRiskOfPreeclampsia ->
-            { english = "High Risk of Preeclampsia"
-            , kinyarwanda = Just "Afite ibyago byinshi byo kugira Preklampusi"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        HistoryOfMentalHealthProblems ->
-            { english = "History of Mental Health Problems"
-            , kinyarwanda = Just "Niba yaragize uburwayi bwo mumutwe"
-            , kirundi = Just "Akahise k'ingorane y'ingwara yo mu mutwe"
-            , somali = Nothing
-            }
-
-        HIVPCRTestResult ->
-            { english = "HIV PCR Test Result"
-            , kinyarwanda = Just "Ibisubizo by'ikizamini cya PCR gipima Virusi itera SIDA"
-            , kirundi = Just "Inyishu y'igipimo ca PCR ya VIH"
-            , somali = Nothing
-            }
-
-        HyperemesisGravidum ->
-            { english = "Hyperemesis Gravidum"
-            , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
-            , kirundi = Just "Hyperémèse gravidique"
-            , somali = Nothing
-            }
-
-        IMDailyX10Days ->
-            { english = "IM daily x 10 days"
-            , kinyarwanda = Just "IM buri munsi mu minsi 10"
-            , kirundi = Just "IM buri munsi mu kiringo c'iminsi 10"
-            , somali = Nothing
-            }
-
-        ImminentDeliveryLabel ->
-            { english = "Imminent Delivery"
-            , kinyarwanda = Just "Kubyara biri hafi"
-            , kirundi = Just "Gutanga bigaragara/"
-            , somali = Nothing
-            }
-
-        Immunizations ->
-            { english = "Immunizations"
-            , kinyarwanda = Just "Ikingira"
-            , kirundi = Just "Incanco"
-            , somali = Just "Tallaalada"
-            }
-
-        IMX1 ->
-            { english = "IM x 1"
-            , kinyarwanda = Just "IM inshuro 1"
-            , kirundi = Just "IM Gucisha umuti mu mutsi incuro 1 gusa"
-            , somali = Nothing
-            }
-
-        Indeterminate ->
-            { english = "Indeterminate"
-            , kinyarwanda = Just "Ntibisobanutse"
-            , kirundi = Just "Ntibizwi neza"
-            , somali = Just "Aan horay laga ogaan karin"
-            }
-
-        KnownAllergy ->
-            { english = "Known Allergy"
-            , kinyarwanda = Just "Uyu muti usanzwe umutera ifurutwa"
-            , kirundi = Just "Ihindagurika ry'umuiri rizwi"
-            , somali = Just "Lagu yaqaano xasaasiyad"
-            }
-
-        KnownAllergyOrReaction ->
-            { english = "Known Allergy or Reaction"
-            , kinyarwanda = Just "Agira ingaruka zizwi kubera uru rukingo/umuti"
-            , kirundi = Just "Ihindagurika ry'umuiri rizwi"
-            , somali = Nothing
-            }
-
-        LaborDelivery ->
-            { english = "Labor + Delivery"
-            , kinyarwanda = Just "Kujya ku nda + Kubyara"
-            , kirundi = Just "Ibise + Kuvyara"
-            , somali = Just "Fool + Dhalmo"
-            }
-
-        LabsResults ->
-            { english = "Labs Results"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Inyishu z'ibipimo vy'ingwara"
-            , somali = Nothing
-            }
-
-        LegCrampsLabel ->
-            { english = "Leg Cramps"
-            , kinyarwanda = Just "Ibinya mu maguru"
-            , kirundi = Just "Ibinyanya vy'amaguru"
-            , somali = Just "Kabaabyo Lugaha ah"
-            }
-
-        LevelOfStuntingUsingChildLengthMat ->
-            { english = "Level of stunting using child length mat"
-            , kinyarwanda = Just "Ikigero cyo kugwingira hakoreshejwe agasambi"
-            , kirundi = Nothing
-            , somali = Just "Heerka nafaqo darrda ayadoo la isticmaalayo xariga cabirka"
-            }
-
-        LiverFunction ->
-            { english = "Liver Function"
-            , kinyarwanda = Just "Imikorere y'Umwijima"
-            , kirundi = Just "Ugukora kw'Igitigu"
-            , somali = Nothing
-            }
-
-        LowerBackPain ->
-            { english = "Lower Back Pain"
-            , kinyarwanda = Just "Kubabara umugongo wo hasi"
-            , kirundi = Just "Ububabare bw'umugongo wo hasi"
-            , somali = Just "Xanuun Dhinca dambe ah"
-            }
-
-        MalariaWithAnemia ->
-            { english = "Malaria with Anemia"
-            , kinyarwanda = Just "Malariya n'Amaraso Macye"
-            , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri"
-            , somali = Nothing
-            }
-
-        MalariaWithAnemiaContinued ->
-            { english = "Malaria with Anemia Continued"
-            , kinyarwanda = Just "Malariya n'Amaraso Macye bikigaragara"
-            , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri birabandanya"
-            , somali = Nothing
-            }
-
-        MalariaWithoutComplications ->
-            { english = "Malaria Without Complications"
-            , kinyarwanda = Just "Afite Malariya yoroheje"
-            , kirundi = Just "Malariya itagira ingorane zikomeye"
-            , somali = Just "Duumo aan Lahayn Waxyeello"
-            }
-
-        MalariaWithSevereAnemia ->
-            { english = "Malaria with Severe Anemia"
-            , kinyarwanda = Just "Malariya n'Amaraso Macye Cyane"
-            , kirundi = Just "Malariya kumwe n'igabanuka ry'amaraso m'umubiri ridasanzwe"
-            , somali = Just "Duumo leh Dhiig la`aan Daran"
-            }
-
-        MastersDegreeLabel ->
-            { english = "Masters Degree"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Urupapuro rw'umutsindo rw'igice ca 3 mashule (Maîtrise)"
-            , somali = Nothing
-            }
-
-        Mastitis ->
-            { english = "Mastitis"
-            , kinyarwanda = Just "Uburwayi bw'amabere"
-            , kirundi = Just "Ingwara y'imoko ituma amaberebere adasohoka"
-            , somali = Nothing
-            }
-
-        MaternalComplications ->
-            { english = "Maternal Complications"
-            , kinyarwanda = Just "Ibibazo bishobora kwibasira umugore utwite"
-            , kirundi = Just "Ingorane z'abavyeyi"
-            , somali = Nothing
-            }
-
-        Mebendazole ->
-            { english = "Mebendazole"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        MemoryQuota quota ->
-            { english = "Memory used " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " MB of available " ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024)) ++ " MB"
-            , kinyarwanda = Just <| "Hamaze gukoreshwa umwanya wa memori (ushobora kubika amakuru igihe gito) ungana na MB" ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " kuri MB" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
-            , kirundi = Just <| "Memoire imaze gukoreshwa ungana na MO(Mégaoctets) " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " kuri MO(Mégaoctets)" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
-            , somali = Just <| "Xasuus keydka la adeegsaday " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " MB banaan" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
-            }
-
-        Metformin500mg ->
-            { english = "Metformin (500mg)"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        Methyldopa250mg ->
-            { english = "Methyldopa (250mg)"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        MildToModeratePreeclampsia ->
-            { english = "Mild to Moderate Preeclampsia"
-            , kinyarwanda = Just "Preklampusi Yoroheje"
-            , kirundi = Just "Umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
-            , somali = Just "Dhiig karka Uurka u dhaxeeya mid hoose iyo mid dhexe"
-            }
-
-        MissedECDMilestone ->
-            { english = "Missed ECD Milestone"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        MMSLabel ->
-            { english = "MMS"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        ModerateRiskOfPreeclampsia ->
-            { english = "Moderate Risk of Preeclampsia"
-            , kinyarwanda = Just "Afite ibyago biringaniye byo kugira Preklampusi"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        NCDLabs ->
-            { english = "NCD Labs"
-            , kinyarwanda = Just "Ibizamini bikorerwa ufite indwara zitandura"
-            , kirundi = Just "Ibipimo vy'ingwara zitandukira"
-            , somali = Nothing
-            }
-
-        NoDiagnosis ->
-            { english = "No Diagnosis"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Nta Gupima/gusuzuma"
-            , somali = Just "Ma jiro Baaritaan"
-            }
-
-        OralPolioVaccineOPV ->
-            { english = "Oral Polio Vaccine (OPV)"
-            , kinyarwanda = Just "Urukingo rw'imbasa rutangwa mu kanwa"
-            , kirundi = Just "Urucanco rw'ubukangwe (amama)"
-            , somali = Just "Tallaalka Afka ee Dabeysha (OPV)"
-            }
-
-        OtherLabel ->
-            { english = "Other"
-            , kinyarwanda = Just "Ibindi"
-            , kirundi = Just "Ibindi"
-            , somali = Just "Kale"
-            }
-
-        Paralysis ->
-            { english = "Paralysis"
-            , kinyarwanda = Just "Igice cy'umubiri kidakora"
-            , kirundi = Just "Ubumuga"
-            , somali = Just "Curyaan"
-            }
-
-        PatientDeclined ->
-            { english = "Patient Declined"
-            , kinyarwanda = Just "Umurwayi yanze"
-            , kirundi = Just "Umurwayi yaranse"
-            , somali = Just "Bukaanka ayaa Diiday"
-            }
-
-        PatientShowsSignsOfHighRiskForPreclampsia ->
-            { english = "Patient shows signs of High Risk for Preclampsia"
-            , kinyarwanda = Just "Umubyeyi agaragaza ibimenyetso biri hejuru byo kugira Preklampusi"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        PatientShowsSignsOfMildToModeratePreeclampsia ->
-            { english = "Patient shows signs of Mild to Moderate Preeclampsia"
-            , kinyarwanda = Just "Agaragaza ibimenyetso byoroheje bya Preklampusi"
-            , kirundi = Just "Yerekana ibimenyetso vy'umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
-            , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Dhiig karka Uurka u dhaxeeya mid Hoose iyo mid Dhexe"
-            }
-
-        PatientShowsSignsOfSeverePreeclampsia ->
-            { english = "Patient shows signs of Severe Preeclampsia"
-            , kinyarwanda = Just "Agaragaza ibimenyetso bikabije bya Preklampusi"
-            , kirundi = Just "Yerekana ibimenyetso vy'Umuvuduko w'amaraso mu gihe c'imbanyi ukaze"
-            , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Daran ee Dhiig karka Uurka"
-            }
-
-        PatientUnableToAfford ->
-            { english = "Patient Unable to Afford"
-            , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
-            , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
-            , somali = Just "Bukaanka ma Awoodo Qarashka"
-            }
-
-        PelvicPainLabel ->
-            { english = "Pelvic Pain"
-            , kinyarwanda = Just "Kubabara mu kiziba cy'inda"
-            , kirundi = Just "Ububabare bwo mu nda yo hepfo"
-            , somali = Just "Dhabar Xanuun"
-            }
-
-        PerinealPainOrDischarge ->
-            { english = "Perineal Pain or Discharge"
-            , kinyarwanda = Just "Arababara perine cg aratakaza ibintu budasanzwe"
-            , kirundi = Just "Ububabare bw'umugongo hepfo"
-            , somali = Just "Xanuun qaska ah ama Dheecaan"
-            }
-
-        Postpartum ->
-            { english = "Postpartum"
-            , kinyarwanda = Just "Igihe cya nyuma cyo kubyara"
-            , kirundi = Just "Inyuma yo kwibaruka"
-            , somali = Just "Dhalmada kadib"
-            }
-
-        PregnancyInducedHypertension ->
-            { english = "Pregnancy-Induced Hypertension"
-            , kinyarwanda = Just "Umuvuduko w'amaraso watewe no gutwita"
-            , kirundi = Just "Umuvuduko w'amaraso utewe n'imbanyi"
-            , somali = Nothing
-            }
-
-        PrimarySchoolLabel ->
-            { english = "Primary School"
-            , kinyarwanda = Just "Abanza"
-            , kirundi = Just "Amashule matoya"
-            , somali = Just "Dugsi Hoose"
-            }
-
-        ProbableDepression ->
-            { english = "Probable Depression"
-            , kinyarwanda = Just "Birashoboka ko afite indwara y'agahinda gakabije"
-            , kirundi = Just "Ukwihebura gushoboka"
-            , somali = Just "U eg Niyad Jab"
-            }
-
-        RandomBloodSugarTestResult ->
-            { english = "Random Blood Sugar Test Result"
-            , kinyarwanda = Just "Igisubizo ku kizamini gipima ingano y'isukari mu maraso"
-            , kirundi = Just "Inyishu y'igipimo c'Isukari mu Maraso umwanya uwariwo wose"
-            , somali = Nothing
-            }
-
-        Referral ->
-            { english = "Referral"
-            , kinyarwanda = Just "Kohereza"
-            , kirundi = Just "Kurungika"
-            , somali = Just "Gudbin"
-            }
-
-        RememberMakeYourCoworkersYourWorkFamily ->
-            { english = "Remember: Make your co-workers your work family."
-            , kinyarwanda = Just ""
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        Resolved ->
-            { english = "Resolved"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Cakemutse"
-            , somali = Just "La xaliyay"
-            }
-
-        SelectNutritionVisit ->
-            { english = "Select Nutrition Visit"
-            , kinyarwanda = Just "Hitamo isuzuma ry’imirire"
-            , kirundi = Just "Hitamo isuzumwa ry'ingaburo"
-            , somali = Just "Dooro Booqasho Nafaqo"
-            }
-
-        SevereCOVID19 ->
-            { english = "Severe COVID-19"
-            , kinyarwanda = Just "Uburwayi bwa Covid-19 bukabije"
-            , kirundi = Just "COVID-19 ikaze"
-            , somali = Just "COVID-19 aad u daran"
-            }
-
-        SevereVomitingLabel ->
-            { english = "Severe Vomiting"
-            , kinyarwanda = Just "Kuruka bikabije"
-            , kirundi = Just "Ukudahwa gukaze"
-            , somali = Nothing
-            }
-
-        SimpleCOVID19 ->
-            { english = "Simple COVID-19"
-            , kinyarwanda = Just "Uburwayi bwa Covid-19 bworoheje"
-            , kirundi = Just "Korona (COVID-19) isanzwe"
-            , somali = Just "COVID-19 Fudud"
-            }
-
-        SpontaneousBleedingLabel ->
-            { english = "Spontaneous Bleeding"
-            , kinyarwanda = Just "Kuva amaraso bitunguranye"
-            , kirundi = Just "Ukuva amaraso aho nyene"
-            , somali = Just "Dhiigbax aan waqti lahayn"
-            }
-
-        StageOneHypertension ->
-            { english = "Stage One Hypertension"
-            , kinyarwanda = Just "Umuvuduko w'amaraso uri ku rwego rwa mbere"
-            , kirundi = Just "Umuvuduko w'amaraso uri mu c'iciro/mu gice ca mbere"
-            , somali = Nothing
-            }
-
-        StorageQuota quota ->
-            { english = "Storage used " ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " MB of available " ++ String.fromInt (quota.quota // (1024 * 1024)) ++ " MB"
-            , kinyarwanda = Just <| "Hamaze gukoreshwa umwanya ungana na MB" ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " umwanya wose ungana na MB " ++ String.fromInt (quota.quota // (1024 * 1024))
-            , kirundi = Just <| "Ububiko bwakoreshejwe bungana na MO(Mégaoctets) " ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " umwanya wose ungana na MO(Mégaoctets) " ++ String.fromInt (quota.quota // (1024 * 1024))
-            , somali = Just <| "Keydka la adeegsaday " ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " MB ga la heli karo " ++ String.fromInt (quota.quota // (1024 * 1024)) ++ " MB"
-            }
-
-        SubmitPairingCode ->
-            { english = "Submit Pairing Code"
-            , kinyarwanda = Just "Umubare uhuza igikoresho cy'ikoranabuhanga na apulikasiyo"
-            , kirundi = Just "Tanga ikode yo kuringanisha"
-            , somali = Just "Xaree Af-garadka Labaalaha ah"
-            }
 
         EPDSPreformedOn ->
             { english = "EPDS performed on"
@@ -7692,29 +7216,6 @@ translationSet trans =
             , somali = Nothing
             }
 
-        FbfDistribution clinicType ->
-            case clinicType of
-                Achi ->
-                    { english = "Aheza Distribution"
-                    , kinyarwanda = Just "Gutanga Aheza"
-                    , kirundi = Just "Ugutanga kwa Aheza"
-                    , somali = Nothing
-                    }
-
-                _ ->
-                    { english = "FBF Distribution"
-                    , kinyarwanda = Just "Gutanga FBF (Shishakibondo)"
-                    , kirundi = Just "Itangwa rya FBF"
-                    , somali = Just "Qeybinta FBF"
-                    }
-
-        Feeding ->
-            { english = "Feeding"
-            , kinyarwanda = Just "Kugaburira umwana"
-            , kirundi = Just "Kugaburira umwana"
-            , somali = Just "Quudin"
-            }
-
         FatherOrChiefId ->
             { english = "Father or Chief of Family ID"
             , kinyarwanda = Just "Indangamuntu y'Umukuru w'Umuryango"
@@ -7751,6 +7252,29 @@ translationSet trans =
                 , somali = Nothing
                 }
 
+        FbfDistribution clinicType ->
+            case clinicType of
+                Achi ->
+                    { english = "Aheza Distribution"
+                    , kinyarwanda = Just "Gutanga Aheza"
+                    , kirundi = Just "Ugutanga kwa Aheza"
+                    , somali = Nothing
+                    }
+
+                _ ->
+                    { english = "FBF Distribution"
+                    , kinyarwanda = Just "Gutanga FBF (Shishakibondo)"
+                    , kirundi = Just "Itangwa rya FBF"
+                    , somali = Just "Qeybinta FBF"
+                    }
+
+        Feeding ->
+            { english = "Feeding"
+            , kinyarwanda = Just "Kugaburira umwana"
+            , kirundi = Just "Kugaburira umwana"
+            , somali = Just "Quudin"
+            }
+
         FeelingBetter ->
             { english = "Feeling Better"
             , kinyarwanda = Nothing
@@ -7762,13 +7286,6 @@ translationSet trans =
             { english = "Fetal Heart Rate"
             , kinyarwanda = Just "Uko umutima w'umwana utera"
             , kirundi = Just "Urugero rw'umwana ari mu nda"
-            , somali = Nothing
-            }
-
-        HeartRateNotAudible ->
-            { english = "Heart rate not audible"
-            , kinyarwanda = Just "Umutima w'umwana ntago wumvikana"
-            , kirundi = Nothing
             , somali = Nothing
             }
 
@@ -7902,18 +7419,18 @@ translationSet trans =
             , somali = Just "Sugnaanta Cunnada"
             }
 
-        FollowUp ->
-            { english = "Follow Up"
-            , kinyarwanda = Just "Gukurikirana umurwayi"
-            , kirundi = Just "Kurikirana"
-            , somali = Just "Ka Warqab"
-            }
-
         FollowPostpartumProtocols ->
             { english = "Follow Postpartum Protocols"
             , kinyarwanda = Just "Kurikiza amabwiriza yo kwita ku mubyeyi wabyaye"
             , kirundi = Just "Gukurikiza Inyandiko Ntumberezo zerekeye inyuma yo kwibaruka"
             , somali = Just "Raac Hababka Dhalmada kadib"
+            }
+
+        FollowUp ->
+            { english = "Follow Up"
+            , kinyarwanda = Just "Gukurikirana umurwayi"
+            , kirundi = Just "Kurikirana"
+            , somali = Just "Ka Warqab"
             }
 
         FollowUpWithPatientIn ->
@@ -8187,6 +7704,28 @@ translationSet trans =
             , somali = Just "garaamyo"
             }
 
+        Gravida ->
+            { english = "Gravida"
+            , kinyarwanda = Just "Inda zose watwise"
+            , kirundi = Just "Inday ya"
+            , somali = Just "Tirada Dhalmada"
+            }
+
+        GroupEducation ->
+            { english = "Group Education"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Inyigisho mukibano"
+            , somali = Just "Wacyi gelin Kooxeed"
+            }
+
+        GroupEncounterType encounterType ->
+            case encounterType of
+                GroupEncounterNutrition ->
+                    translationSet ChildNutrition
+
+                GroupEncounterEducation ->
+                    translationSet HealthEducation
+
         GroupOfFoods value ->
             case value of
                 Staples ->
@@ -8251,28 +7790,6 @@ translationSet trans =
             , kirundi = Just "Ugukura"
             , somali = Just "Koriinsho"
             }
-
-        Gravida ->
-            { english = "Gravida"
-            , kinyarwanda = Just "Inda zose watwise"
-            , kirundi = Just "Inday ya"
-            , somali = Just "Tirada Dhalmada"
-            }
-
-        GroupEducation ->
-            { english = "Group Education"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Inyigisho mukibano"
-            , somali = Just "Wacyi gelin Kooxeed"
-            }
-
-        GroupEncounterType encounterType ->
-            case encounterType of
-                GroupEncounterNutrition ->
-                    translationSet ChildNutrition
-
-                GroupEncounterEducation ->
-                    translationSet HealthEducation
 
         GuideMessage ->
             { english = "Guide Message"
@@ -8357,8 +7874,43 @@ translationSet trans =
                 NormalHands ->
                     translationSet Normal
 
+        HardlyEver ->
+            { english = "Hardly ever"
+            , kinyarwanda = Just "Gake gashoboka"
+            , kirundi = Just "Biragoye bukebuke"
+            , somali = Just "Marnaba aan dhicin"
+            }
+
+        HaveYouCounseledPatientOnPositiveHIVTestMeaning ->
+            { english = "Have you counseled patient on positive HIV test meaning"
+            , kinyarwanda = Just "Waba wasobanuriye umurwayi (umubyeyi) icyo bisibanuye kugira ibisubizo biri positifu ku bwandu bw'agakoko gatera SIDA"
+            , kirundi = Just "Mbega warahanuye wongera urabwira umugwayi iciza c'igipimo c'umugera wa SIDA"
+            , somali = Just "Ma kala talisay bukaanka macnaha baaritaanka togan ee HIV"
+            }
+
+        HaveYouCounseledPatientOnSaferSexPractices ->
+            { english = "Have you counseled patient on safer sex practices"
+            , kinyarwanda = Just "Wagiriye inama umubyeyi ku bijyanye no gukora imibonano mpuzabitsina ikingiye"
+            , kirundi = Just "Mbega warahanuye  umugwayi kuvyerekeye iciza co kwikingira mu gihe c'imibonano mpuza ibitsina"
+            , somali = Just "Ma kala talisay bukaanka galmada badqabka leh"
+            }
+
+        HaveYouEncouragedThePatientsPartnerToGetTested ->
+            { english = "Have you encouraged the patient’s partner to get tested"
+            , kinyarwanda = Just "Waba washishikarije umubyueyi kubwira uwo babana kwipimisha"
+            , kirundi = Just "Mbega wateye inguvu umufasha w'umugwayi kugira yipimishe"
+            , somali = Nothing
+            }
+
         HbA1c ->
             { english = "HBA1c"
+            , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
+            , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
+            , somali = Nothing
+            }
+
+        HBA1C ->
+            { english = "HBA1C"
             , kinyarwanda = Just "Ikigereranyo cy'isukari mu maraso mu mezi atatu ashize"
             , kirundi = Just "Igipimo co kuraba ingene isukari ingana mu maraso"
             , somali = Nothing
@@ -8523,6 +8075,13 @@ translationSet trans =
             , somali = Just "Wadne"
             }
 
+        HeartburnLabel ->
+            { english = "Heartburn"
+            , kinyarwanda = Just "Ikirungurira"
+            , kirundi = Just "Ugusha k'umutima"
+            , somali = Nothing
+            }
+
         HeartburnReliefMethod method ->
             case method of
                 ReliefMethodAvoidLargeMeals ->
@@ -8604,11 +8163,32 @@ translationSet trans =
             , somali = Just "Garaaca Wadnaha"
             }
 
+        HeartRateNotAudible ->
+            { english = "Heart rate not audible"
+            , kinyarwanda = Just "Umutima w'umwana ntago wumvikana"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
         Height ->
             { english = "Height"
             , kinyarwanda = Just "Uburebure"
             , kirundi = Just "Uburebure"
             , somali = Just "Dhirika"
+            }
+
+        Hello ->
+            { english = "Hello "
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        HemoglobinTestHistory ->
+            { english = "Hemoglobin Test History"
+            , kinyarwanda = Just "Amakuru ku kizamini cy'ingano y'amaraso"
+            , kirundi = Nothing
+            , somali = Nothing
             }
 
         High ->
@@ -8653,6 +8233,13 @@ translationSet trans =
             , kinyarwanda = Just "Abafite ibyago byinshi byo"
             , kirundi = Just "Impamvu z'ingorane zaduze"
             , somali = Just "Arrimaha Halista Sare leh"
+            }
+
+        HighRiskOfPreeclampsia ->
+            { english = "High Risk of Preeclampsia"
+            , kinyarwanda = Just "Afite ibyago byinshi byo kugira Preklampusi"
+            , kirundi = Nothing
+            , somali = Nothing
             }
 
         HighSeverityAlert alert ->
@@ -8704,6 +8291,13 @@ translationSet trans =
             , kinyarwanda = Just "Amakuru"
             , kirundi = Just "Akahise"
             , somali = Just "Taariikh"
+            }
+
+        HistoryOfMentalHealthProblems ->
+            { english = "History of Mental Health Problems"
+            , kinyarwanda = Just "Niba yaragize uburwayi bwo mumutwe"
+            , kirundi = Just "Akahise k'ingorane y'ingwara yo mu mutwe"
+            , somali = Nothing
             }
 
         HistoryTask task ->
@@ -8807,6 +8401,13 @@ translationSet trans =
                     , kirundi = Nothing
                     , somali = Nothing
                     }
+
+        HIVPCRTestResult ->
+            { english = "HIV PCR Test Result"
+            , kinyarwanda = Just "Ibisubizo by'ikizamini cya PCR gipima Virusi itera SIDA"
+            , kirundi = Just "Inyishu y'igipimo ca PCR ya VIH"
+            , somali = Nothing
+            }
 
         HIVPositiveDateCorrectQuestion date ->
             { english = "The patient tested positive for HIV on " ++ formatDDMMYYYY date ++ ". Is this date correct"
@@ -9219,6 +8820,13 @@ translationSet trans =
                 , somali = Nothing
                 }
 
+        HowManyPerWeek ->
+            { english = "How many per week"
+            , kinyarwanda = Just "Unywa imiti y'itabi ingahe ku cyumweru"
+            , kirundi = Just "Mbega ni bingahe ku ndwi"
+            , somali = Just "Meeqo usbuucii"
+            }
+
         Hygiene ->
             { english = "Hygiene"
             , kinyarwanda = Just "Isuku"
@@ -9226,11 +8834,11 @@ translationSet trans =
             , somali = Just "Nadaafad"
             }
 
-        HowManyPerWeek ->
-            { english = "How many per week"
-            , kinyarwanda = Just "Unywa imiti y'itabi ingahe ku cyumweru"
-            , kirundi = Just "Mbega ni bingahe ku ndwi"
-            , somali = Just "Meeqo usbuucii"
+        HyperemesisGravidum ->
+            { english = "Hyperemesis Gravidum"
+            , kinyarwanda = Just "Kuruka bikabije k'umugore utwite"
+            , kirundi = Just "Hyperémèse gravidique"
+            , somali = Nothing
             }
 
         Hypertension ->
@@ -9454,6 +9062,20 @@ translationSet trans =
                 NoIllnessSymptoms ->
                     translationSet NoneOfThese
 
+        IMDailyX10Days ->
+            { english = "IM daily x 10 days"
+            , kinyarwanda = Just "IM buri munsi mu minsi 10"
+            , kirundi = Just "IM buri munsi mu kiringo c'iminsi 10"
+            , somali = Nothing
+            }
+
+        ImminentDeliveryLabel ->
+            { english = "Imminent Delivery"
+            , kinyarwanda = Just "Kubyara biri hafi"
+            , kirundi = Just "Gutanga bigaragara/"
+            , somali = Nothing
+            }
+
         Immunisation ->
             { english = "Immunization"
             , kinyarwanda = Just "Inkingo"
@@ -9473,6 +9095,27 @@ translationSet trans =
             , kinyarwanda = Just "Amakuru ku nkingo yafashe"
             , kirundi = Just "Akahise k'urucanco"
             , somali = Just "Taariikhda Tallaalka"
+            }
+
+        Immunizations ->
+            { english = "Immunizations"
+            , kinyarwanda = Just "Ikingira"
+            , kirundi = Just "Incanco"
+            , somali = Just "Tallaalada"
+            }
+
+        IMX1 ->
+            { english = "IM x 1"
+            , kinyarwanda = Just "IM inshuro 1"
+            , kirundi = Just "IM Gucisha umuti mu mutsi incuro 1 gusa"
+            , somali = Nothing
+            }
+
+        Indeterminate ->
+            { english = "Indeterminate"
+            , kinyarwanda = Just "Ntibisobanutse"
+            , kirundi = Just "Ntibizwi neza"
+            , somali = Just "Aan horay laga ogaan karin"
             }
 
         IndexPatient ->
@@ -9849,17 +9492,17 @@ translationSet trans =
                         , somali = Nothing
                         }
 
-        InfrastructureEnvironment ->
-            { english = "Infrastructure, Environment"
-            , kinyarwanda = Just "Ibikorwa remezo n’ibidukikije"
-            , kirundi = Just "Inyubako, Ibidukikije"
-            , somali = Nothing
-            }
-
         InfectiousDiseases ->
             { english = "Infectious diseases"
             , kinyarwanda = Just "Indwara zandura"
             , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        InfrastructureEnvironment ->
+            { english = "Infrastructure, Environment"
+            , kinyarwanda = Just "Ibikorwa remezo n’ibidukikije"
+            , kirundi = Just "Inyubako, Ibidukikije"
             , somali = Nothing
             }
 
@@ -9976,6 +9619,20 @@ translationSet trans =
             , kinyarwanda = Just "kg / ukwezi"
             , kirundi = Just "kg / ukwezi"
             , somali = Just "kg / bishii"
+            }
+
+        KnownAllergy ->
+            { english = "Known Allergy"
+            , kinyarwanda = Just "Uyu muti usanzwe umutera ifurutwa"
+            , kirundi = Just "Ihindagurika ry'umuiri rizwi"
+            , somali = Just "Lagu yaqaano xasaasiyad"
+            }
+
+        KnownAllergyOrReaction ->
+            { english = "Known Allergy or Reaction"
+            , kinyarwanda = Just "Agira ingaruka zizwi kubera uru rukingo/umuti"
+            , kirundi = Just "Ihindagurika ry'umuiri rizwi"
+            , somali = Nothing
             }
 
         KnownAsPositiveQuestion task ->
@@ -10778,47 +10435,12 @@ translationSet trans =
                 TestLipidPanel ->
                     translationSet LipidPanel
 
-        PrenatalLabsCaseManagementEntryTypeResults ->
-            { english = "ANC Lab Results"
-            , kinyarwanda = Just "Ibisubizo by'Ibizamini Byafashwe ku mugore utwite"
-            , kirundi = Just "Inyishu z'ibipimo vyakozwe mu gusuzumisha imbanyi"
-            , somali = Nothing
+        LaborDelivery ->
+            { english = "Labor + Delivery"
+            , kinyarwanda = Just "Kujya ku nda + Kubyara"
+            , kirundi = Just "Ibise + Kuvyara"
+            , somali = Just "Fool + Dhalmo"
             }
-
-        PrenatalLabsCaseManagementEntryTypeVitals ->
-            translationSet VitalsRecheck
-
-        PrenatalMedicationTask task ->
-            case task of
-                TaskCalcium ->
-                    translationSet CalciumLabel
-
-                TaskFefol ->
-                    { english = "Fefol"
-                    , kinyarwanda = Just "Ibinini by'ubutare (Fefol)"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                TaskFolate ->
-                    { english = "Folate"
-                    , kinyarwanda = Just "Ibinini bya Acide Folic"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                TaskIron ->
-                    { english = "Iron"
-                    , kinyarwanda = Just "Yafashe umuti wongera amaraso"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                TaskMMS ->
-                    translationSet MMSLabel
-
-                TaskMebendazole ->
-                    translationSet Mebendazole
 
         LabsEntryState isLabTech state ->
             case state of
@@ -11691,6 +11313,13 @@ translationSet trans =
                     , somali = Nothing
                     }
 
+        LabsResults ->
+            { english = "Labs Results"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Inyishu z'ibipimo vy'ingwara"
+            , somali = Nothing
+            }
+
         LastChecked ->
             { english = "Last checked"
             , kinyarwanda = Just "Isuzuma riheruka"
@@ -11724,6 +11353,13 @@ translationSet trans =
             , kinyarwanda = Just "Ibumoso"
             , kirundi = Just "Ububamfu"
             , somali = Just "Bidix"
+            }
+
+        LegCrampsLabel ->
+            { english = "Leg Cramps"
+            , kinyarwanda = Just "Ibinya mu maguru"
+            , kirundi = Just "Ibinyanya vy'amaguru"
+            , somali = Just "Kabaabyo Lugaha ah"
             }
 
         LegCrampsReliefMethod method ->
@@ -11910,6 +11546,13 @@ translationSet trans =
                 MastersDegree ->
                     translationSet MastersDegreeLabel
 
+        LevelOfStuntingUsingChildLengthMat ->
+            { english = "Level of stunting using child length mat"
+            , kinyarwanda = Just "Ikigero cyo kugwingira hakoreshejwe agasambi"
+            , kirundi = Nothing
+            , somali = Just "Heerka nafaqo darrda ayadoo la isticmaalayo xariga cabirka"
+            }
+
         LipidPanel ->
             { english = "Lipid Panel"
             , kinyarwanda = Just "Itsinda ry'ibizamini bipima ibinure (Lipid Panel)"
@@ -11921,6 +11564,13 @@ translationSet trans =
             { english = "Live Children"
             , kinyarwanda = Just "Abana bariho"
             , kirundi = Just "Abana bariho"
+            , somali = Nothing
+            }
+
+        LiverFunction ->
+            { english = "Liver Function"
+            , kinyarwanda = Just "Imikorere y'Umwijima"
+            , kirundi = Just "Ugukora kw'Igitigu"
             , somali = Nothing
             }
 
@@ -12034,6 +11684,13 @@ translationSet trans =
             , kinyarwanda = Just "Kwemeza amakosa"
             , kirundi = Nothing
             , somali = Just "Hoose"
+            }
+
+        LowerBackPain ->
+            { english = "Lower Back Pain"
+            , kinyarwanda = Just "Kubabara umugongo wo hasi"
+            , kirundi = Just "Ububabare bw'umugongo wo hasi"
+            , somali = Just "Xanuun Dhinca dambe ah"
             }
 
         LowRiskCase ->
@@ -12252,11 +11909,228 @@ translationSet trans =
             , somali = Just "Dooro dawada ugu fiican ee bukaanka hoos ku xusan"
             }
 
+        MalariaWithAnemia ->
+            { english = "Malaria with Anemia"
+            , kinyarwanda = Just "Malariya n'Amaraso Macye"
+            , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri"
+            , somali = Nothing
+            }
+
+        MalariaWithAnemiaContinued ->
+            { english = "Malaria with Anemia Continued"
+            , kinyarwanda = Just "Malariya n'Amaraso Macye bikigaragara"
+            , kirundi = Just "Malariya hamwe n'igabanuka ry'amaraso m'umubiri birabandanya"
+            , somali = Nothing
+            }
+
         MalariaWithGIComplications ->
             { english = "Malaria with GI complications"
             , kinyarwanda = Just "Malariya iherekejwe no guhitwa cyangwa kuruka"
             , kirundi = Just "Malariya kumwe n'ingorane zo mu nda"
             , somali = Just "Duumo leh waxyeello Uur ku jirta ah"
+            }
+
+        MalariaWithoutComplications ->
+            { english = "Malaria Without Complications"
+            , kinyarwanda = Just "Afite Malariya yoroheje"
+            , kirundi = Just "Malariya itagira ingorane zikomeye"
+            , somali = Just "Duumo aan Lahayn Waxyeello"
+            }
+
+        MalariaWithSevereAnemia ->
+            { english = "Malaria with Severe Anemia"
+            , kinyarwanda = Just "Malariya n'Amaraso Macye Cyane"
+            , kirundi = Just "Malariya kumwe n'igabanuka ry'amaraso m'umubiri ridasanzwe"
+            , somali = Just "Duumo leh Dhiig la`aan Daran"
+            }
+
+        MastersDegreeLabel ->
+            { english = "Masters Degree"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Urupapuro rw'umutsindo rw'igice ca 3 mashule (Maîtrise)"
+            , somali = Nothing
+            }
+
+        Mastitis ->
+            { english = "Mastitis"
+            , kinyarwanda = Just "Uburwayi bw'amabere"
+            , kirundi = Just "Ingwara y'imoko ituma amaberebere adasohoka"
+            , somali = Nothing
+            }
+
+        MaternalComplications ->
+            { english = "Maternal Complications"
+            , kinyarwanda = Just "Ibibazo bishobora kwibasira umugore utwite"
+            , kirundi = Just "Ingorane z'abavyeyi"
+            , somali = Nothing
+            }
+
+        Mebendazole ->
+            { english = "Mebendazole"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Metformin500mg ->
+            { english = "Metformin (500mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Methyldopa250mg ->
+            { english = "Methyldopa (250mg)"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        MildToModeratePreeclampsia ->
+            { english = "Mild to Moderate Preeclampsia"
+            , kinyarwanda = Just "Preklampusi Yoroheje"
+            , kirundi = Just "Umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
+            , somali = Just "Dhiig karka Uurka u dhaxeeya mid hoose iyo mid dhexe"
+            }
+
+        MissedECDMilestone ->
+            { english = "Missed ECD Milestone"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        MMSLabel ->
+            { english = "MMS"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ModerateRiskOfPreeclampsia ->
+            { english = "Moderate Risk of Preeclampsia"
+            , kinyarwanda = Just "Afite ibyago biringaniye byo kugira Preklampusi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        NCDLabs ->
+            { english = "NCD Labs"
+            , kinyarwanda = Just "Ibizamini bikorerwa ufite indwara zitandura"
+            , kirundi = Just "Ibipimo vy'ingwara zitandukira"
+            , somali = Nothing
+            }
+
+        NoDiagnosis ->
+            { english = "No Diagnosis"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Nta Gupima/gusuzuma"
+            , somali = Just "Ma jiro Baaritaan"
+            }
+
+        OralPolioVaccineOPV ->
+            { english = "Oral Polio Vaccine (OPV)"
+            , kinyarwanda = Just "Urukingo rw'imbasa rutangwa mu kanwa"
+            , kirundi = Just "Urucanco rw'ubukangwe (amama)"
+            , somali = Just "Tallaalka Afka ee Dabeysha (OPV)"
+            }
+
+        OtherLabel ->
+            { english = "Other"
+            , kinyarwanda = Just "Ibindi"
+            , kirundi = Just "Ibindi"
+            , somali = Just "Kale"
+            }
+
+        Paralysis ->
+            { english = "Paralysis"
+            , kinyarwanda = Just "Igice cy'umubiri kidakora"
+            , kirundi = Just "Ubumuga"
+            , somali = Just "Curyaan"
+            }
+
+        PatientDeclined ->
+            { english = "Patient Declined"
+            , kinyarwanda = Just "Umurwayi yanze"
+            , kirundi = Just "Umurwayi yaranse"
+            , somali = Just "Bukaanka ayaa Diiday"
+            }
+
+        PatientShowsSignsOfHighRiskForPreclampsia ->
+            { english = "Patient shows signs of High Risk for Preclampsia"
+            , kinyarwanda = Just "Umubyeyi agaragaza ibimenyetso biri hejuru byo kugira Preklampusi"
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        PatientShowsSignsOfMildToModeratePreeclampsia ->
+            { english = "Patient shows signs of Mild to Moderate Preeclampsia"
+            , kinyarwanda = Just "Agaragaza ibimenyetso byoroheje bya Preklampusi"
+            , kirundi = Just "Yerekana ibimenyetso vy'umuvuduko w'amaraso mu gihe c'imbanyi woroshe"
+            , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Dhiig karka Uurka u dhaxeeya mid Hoose iyo mid Dhexe"
+            }
+
+        PatientShowsSignsOfSeverePreeclampsia ->
+            { english = "Patient shows signs of Severe Preeclampsia"
+            , kinyarwanda = Just "Agaragaza ibimenyetso bikabije bya Preklampusi"
+            , kirundi = Just "Yerekana ibimenyetso vy'Umuvuduko w'amaraso mu gihe c'imbanyi ukaze"
+            , somali = Just "Bukaanka waxaa ka muuqda calaamadaha Daran ee Dhiig karka Uurka"
+            }
+
+        PatientUnableToAfford ->
+            { english = "Patient Unable to Afford"
+            , kinyarwanda = Just "Nta bushobozi bwo kwishyura afite"
+            , kirundi = Just "Umurwayi ntashobora kuriha amafaranga"
+            , somali = Just "Bukaanka ma Awoodo Qarashka"
+            }
+
+        PelvicPainLabel ->
+            { english = "Pelvic Pain"
+            , kinyarwanda = Just "Kubabara mu kiziba cy'inda"
+            , kirundi = Just "Ububabare bwo mu nda yo hepfo"
+            , somali = Just "Dhabar Xanuun"
+            }
+
+        PerinealPainOrDischarge ->
+            { english = "Perineal Pain or Discharge"
+            , kinyarwanda = Just "Arababara perine cg aratakaza ibintu budasanzwe"
+            , kirundi = Just "Ububabare bw'umugongo hepfo"
+            , somali = Just "Xanuun qaska ah ama Dheecaan"
+            }
+
+        Postpartum ->
+            { english = "Postpartum"
+            , kinyarwanda = Just "Igihe cya nyuma cyo kubyara"
+            , kirundi = Just "Inyuma yo kwibaruka"
+            , somali = Just "Dhalmada kadib"
+            }
+
+        PregnancyInducedHypertension ->
+            { english = "Pregnancy-Induced Hypertension"
+            , kinyarwanda = Just "Umuvuduko w'amaraso watewe no gutwita"
+            , kirundi = Just "Umuvuduko w'amaraso utewe n'imbanyi"
+            , somali = Nothing
+            }
+
+        PrimarySchoolLabel ->
+            { english = "Primary School"
+            , kinyarwanda = Just "Abanza"
+            , kirundi = Just "Amashule matoya"
+            , somali = Just "Dugsi Hoose"
+            }
+
+        ProbableDepression ->
+            { english = "Probable Depression"
+            , kinyarwanda = Just "Birashoboka ko afite indwara y'agahinda gakabije"
+            , kirundi = Just "Ukwihebura gushoboka"
+            , somali = Just "U eg Niyad Jab"
+            }
+
+        RandomBloodSugarTestResult ->
+            { english = "Random Blood Sugar Test Result"
+            , kinyarwanda = Just "Igisubizo ku kizamini gipima ingano y'isukari mu maraso"
+            , kirundi = Just "Inyishu y'igipimo c'Isukari mu Maraso umwanya uwariwo wose"
+            , somali = Nothing
             }
 
         RapidTestResult result ->
@@ -13244,6 +13118,13 @@ translationSet trans =
             , kinyarwanda = Just "Ibibazo by’ubuzima bwo mu mutwe"
             , kirundi = Nothing
             , somali = Nothing
+            }
+
+        MemoryQuota quota ->
+            { english = "Memory used " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " MB of available " ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024)) ++ " MB"
+            , kinyarwanda = Just <| "Hamaze gukoreshwa umwanya wa memori (ushobora kubika amakuru igihe gito) ungana na MB" ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " kuri MB" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
+            , kirundi = Just <| "Memoire imaze gukoreshwa ungana na MO(Mégaoctets) " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " kuri MO(Mégaoctets)" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
+            , somali = Just <| "Xasuus keydka la adeegsaday " ++ String.fromInt (quota.usedJSHeapSize // (1024 * 1024)) ++ " MB banaan" ++ String.fromInt (quota.jsHeapSizeLimit // (1024 * 1024))
             }
 
         MessagingTab tab ->
@@ -14969,18 +14850,18 @@ translationSet trans =
             , somali = Just "Wax howl ah looma dhameynin ka soo qeyb galayaasha joogay"
             }
 
-        NoActivitiesPending ->
-            { english = "All activities are completed for the attending participants."
-            , kinyarwanda = Just "Ibikorwa byose byarangiye kubitabiriye."
-            , kirundi = Just "Ibikorwa vyose vyaheze kubitavye."
-            , somali = Just "Dhamaan howlaha waa loo dhameeyay dadka soo xaadiray"
-            }
-
         NoActivitiesCompletedForThisParticipant ->
             { english = "No activities are completed for this participant."
             , kinyarwanda = Just "Nta gikorwa cyarangiye kubitabiriye."
             , kirundi = Just "Nta bikorwa vy'abitavye inyigisho birahera"
             , somali = Just "Wax howhl ah looma dhameynin kasoo qeyb galahaan"
+            }
+
+        NoActivitiesPending ->
+            { english = "All activities are completed for the attending participants."
+            , kinyarwanda = Just "Ibikorwa byose byarangiye kubitabiriye."
+            , kirundi = Just "Ibikorwa vyose vyaheze kubitavye."
+            , somali = Just "Dhamaan howlaha waa loo dhameeyay dadka soo xaadiray"
             }
 
         NoActivitiesPendingForThisParticipant ->
@@ -15210,18 +15091,25 @@ translationSet trans =
                 _ ->
                     translationSet EmptyString
 
-        NoParticipantsCompleted ->
-            { english = "No participants have completed all their activities yet."
-            , kinyarwanda = Just "Ntagikorwa nakimwe kirarangira kubitabiriye."
-            , kirundi = Just "Ntabitavye inyigisho bahejeje inikorwa vyabo vyose"
-            , somali = Just "Ka qeyb galayaasha ma dhameynin howlahooda weli"
-            }
-
         NoParticipantsPending ->
             { english = "All attending participants have completed their activities."
             , kinyarwanda = Just "Abaje bose barangirijwe"
             , kirundi = Just "Abitavye inyigisho bose bahejeje ibikorwa vyabo"
             , somali = Just "Dhamaan dadka soo xaadiray way dhameeyeen howlahooda."
+            }
+
+        NoParticipantsPendingForThisActivity ->
+            { english = "All attending participants have completed this activitity."
+            , kinyarwanda = Just "Ababje bose barangirijwe."
+            , kirundi = Just "Abitavye ibikorwa bose bahejeje iki gikorwa"
+            , somali = Just "Dhamaan dadka soo xaadiray way dhameeyeen howshan."
+            }
+
+        NoParticipantsCompleted ->
+            { english = "No participants have completed all their activities yet."
+            , kinyarwanda = Just "Ntagikorwa nakimwe kirarangira kubitabiriye."
+            , kirundi = Just "Ntabitavye inyigisho bahejeje inikorwa vyabo vyose"
+            , somali = Just "Ka qeyb galayaasha ma dhameynin howlahooda weli"
             }
 
         NoParticipantsCompletedForThisActivity ->
@@ -15236,13 +15124,6 @@ translationSet trans =
             , kinyarwanda = Just "Nta koherezwa kwagaragaye"
             , kirundi = Just "Ntakurungika umugwayi ahandi (kubindi bitaro/kurindi vuriro) vyanditse"
             , somali = Just "Tixraac lama diiwaan gelin"
-            }
-
-        NoParticipantsPendingForThisActivity ->
-            { english = "All attending participants have completed this activitity."
-            , kinyarwanda = Just "Ababje bose barangirijwe."
-            , kirundi = Just "Abitavye ibikorwa bose bahejeje iki gikorwa"
-            , somali = Just "Dhamaan dadka soo xaadiray way dhameeyeen howshan."
             }
 
         Normal ->
@@ -15730,6 +15611,9 @@ translationSet trans =
                 NextStepFollowUp ->
                     translationSet FollowUp
 
+        NitritionSigns ->
+            translationSet NutritionSigns
+
         NutritionSupplementType type_ ->
             case type_ of
                 FortifiedPorridge ->
@@ -15762,9 +15646,6 @@ translationSet trans =
 
                 NoNutritionSupplementType ->
                     translationSet None
-
-        NitritionSigns ->
-            translationSet NutritionSigns
 
         Observations ->
             { english = "Observations"
@@ -16071,18 +15952,18 @@ translationSet trans =
             , somali = Just "ama"
             }
 
-        Overweight ->
-            { english = "Overweight"
-            , kinyarwanda = Just "Aftie ibiro byinshi"
-            , kirundi = Just "Ubunini burenzeko"
-            , somali = Just "Buurnaan xad dhaaf"
-            }
-
         OutsideCareLabel ->
             { english = "Outside Care"
             , kinyarwanda = Nothing
             , kirundi = Just "Ukuvurirwa hanze"
             , somali = Nothing
+            }
+
+        Overweight ->
+            { english = "Overweight"
+            , kinyarwanda = Just "Aftie ibiro byinshi"
+            , kirundi = Just "Ubunini burenzeko"
+            , somali = Just "Buurnaan xad dhaaf"
             }
 
         Overview ->
@@ -16113,6 +15994,13 @@ translationSet trans =
             , somali = Just "Waan ka xunnahay, waxba lagama helin URL kan"
             }
 
+        PaleConjuctiva ->
+            { english = "Pale Conjunctiva"
+            , kinyarwanda = Just "Ibihenehene byeruruka"
+            , kirundi = Just "Ihinduka ry'ibara ku maso"
+            , somali = Just "Indho Casaan"
+            }
+
         Pallor ->
             { english = "Pallor"
             , kinyarwanda = Just "Kweruruka (k'urugingo rw'umubiri)"
@@ -16139,13 +16027,6 @@ translationSet trans =
             , kinyarwanda = Just "Ese ababyeyi bombi bariho kandi bafite ubuzima bwiza"
             , kirundi = Just "Mbega ufise abavyeyi uko ari babiri bafise n'amagara meza"
             , somali = Just "Ma yihiin labada waalid kuwa nool oo caafimaad qaba"
-            }
-
-        PaleConjuctiva ->
-            { english = "Pale Conjunctiva"
-            , kinyarwanda = Just "Ibihenehene byeruruka"
-            , kirundi = Just "Ihinduka ry'ibara ku maso"
-            , somali = Just "Indho Casaan"
             }
 
         Participants ->
@@ -16239,13 +16120,6 @@ translationSet trans =
             , somali = Nothing
             }
 
-        PatientGotDiabetesHeader ->
-            { english = "This patient has Diabetes"
-            , kinyarwanda = Just "Uyu murwayi afite indwara ya Diyabete"
-            , kirundi = Just "Uyu mugwayi afise Diyabete"
-            , somali = Nothing
-            }
-
         PatientGotDiabetesByGlucoseHeader fasting value ->
             if fasting then
                 { english = "This patient has Diabetes with glucose levels before a meal (fasting) of " ++ String.fromFloat value ++ " mg/dL"
@@ -16265,6 +16139,13 @@ translationSet trans =
             { english = "This patient has Diabetes with Urine Dip glucose levels of " ++ value
             , kinyarwanda = Just <| "Afite Diyabete hamwe n'ibipimo by'isukari mu nkari bingana na " ++ value
             , kirundi = Just <| "Afise Diyabete hamwe n'ibipimo vy'isukari iri mu mukoyo (glucose) bingana " ++ value
+            , somali = Nothing
+            }
+
+        PatientGotDiabetesHeader ->
+            { english = "This patient has Diabetes"
+            , kinyarwanda = Just "Uyu murwayi afite indwara ya Diyabete"
+            , kirundi = Just "Uyu mugwayi afise Diyabete"
             , somali = Nothing
             }
 
@@ -16364,20 +16245,6 @@ translationSet trans =
             , somali = Just "Bukaano"
             }
 
-        Pediatrics ->
-            { english = "Pediatrics"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        PediatricVisit ->
-            { english = "Pediatric Visit"
-            , kinyarwanda = Just "Isura ry'umwana"
-            , kirundi = Just "Kugendera abana"
-            , somali = Just "Booqashada Carruurta"
-            }
-
         PediatricCareMilestone milestone ->
             case milestone of
                 Milestone6Weeks ->
@@ -16449,6 +16316,20 @@ translationSet trans =
                     , kirundi = Just "Imyaka 4"
                     , somali = Just "4 Sano"
                     }
+
+        Pediatrics ->
+            { english = "Pediatrics"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        PediatricVisit ->
+            { english = "Pediatric Visit"
+            , kinyarwanda = Just "Isura ry'umwana"
+            , kirundi = Just "Kugendera abana"
+            , somali = Just "Booqashada Carruurta"
+            }
 
         People ->
             { english = "People"
@@ -18531,6 +18412,13 @@ translationSet trans =
                 NoFlankPain ->
                     translationSet None
 
+        PrenatalHealthEducationAppropriateProvided ->
+            { english = "Have you provided the appropriate health education to the patient"
+            , kinyarwanda = Just "Wahaye umubyeyi inyigisho zabugenewe ku buzima"
+            , kirundi = Just "Mbega waratanze inyigisho kuvyerekeye amagara meza k'umugwayi"
+            , somali = Nothing
+            }
+
         PrenatalHealthEducationSignsDiagnosis isInitial date sign ->
             case sign of
                 EducationNauseaVomiting ->
@@ -18716,13 +18604,6 @@ translationSet trans =
 
                 _ ->
                     translationSet EmptyString
-
-        PrenatalHealthEducationAppropriateProvided ->
-            { english = "Have you provided the appropriate health education to the patient"
-            , kinyarwanda = Just "Wahaye umubyeyi inyigisho zabugenewe ku buzima"
-            , kirundi = Just "Mbega waratanze inyigisho kuvyerekeye amagara meza k'umugwayi"
-            , somali = Nothing
-            }
 
         PrenatalHealthEducationQuestion isChw sign ->
             case sign of
@@ -18914,117 +18795,6 @@ translationSet trans =
             , somali = Just "Sii talo la xiriirta caafimaad qabka dhimirka hooyada uurka leh"
             }
 
-        PrenatalNCDProgramHeaderPrefix ->
-            { english = "This patient was diagnosed with"
-            , kinyarwanda = Just "Umurwayi yasuzumwe uburwayi bwa"
-            , kirundi = Just "Uyu mugwayi basanze afise"
-            , somali = Just "Bukaankan waxaa lagahelay"
-            }
-
-        PrenatalNCDProgramHeaderSuffix ->
-            { english = "during her pregnancy"
-            , kinyarwanda = Just "mu gihe yari atwite"
-            , kirundi = Just "Mu gihe c'imbanyi yiwe"
-            , somali = Nothing
-            }
-
-        PrenatalNCDProgramInstructions ->
-            { english = "Refer patient to NCD services for further management"
-            , kinyarwanda = Just "Ohereza umurwayi muri serivisi y'indwara zitandura bamwiteho byimbitse"
-            , kirundi = Just "Rungika umugwayi mu gisata c'ingwara zitandukira kugira bagire ibindi bipimo vyiyongerako"
-            , somali = Just "U gudbi bukaanka adeegyada NCD si uu u helo maareyn dheeraad ah"
-            }
-
-        PrenatalUltrasoundHeader ->
-            { english = "This patient is uncertain of LMP dating"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        PrenatalUltrasoundInstructions ->
-            { english = "Refer patient to ultrasound for further evaluation"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        PrenatalNextStepsTask isChw task ->
-            case task of
-                Pages.Prenatal.Activity.Types.NextStepsAppointmentConfirmation ->
-                    { english = "Appointment Confirmation"
-                    , kinyarwanda = Just "Kwemeza itariki yo kugaruka"
-                    , kirundi = Just "Kwemeza isango"
-                    , somali = Just "Xaqiijinta Ballanta"
-                    }
-
-                Pages.Prenatal.Activity.Types.NextStepsFollowUp ->
-                    { english = "CHW Follow Up"
-                    , kinyarwanda = Just "Isura ry'umujyanama w'ubuzima"
-                    , kirundi = Just "Ikurikiranwa rikozwe n'Abaremeshakiyago"
-                    , somali = Just "Ka war qabka SHCB"
-                    }
-
-                Pages.Prenatal.Activity.Types.NextStepsSendToHC ->
-                    if isChw then
-                        translationSet SendToHC
-
-                    else
-                        { english = "Referral"
-                        , kinyarwanda = Just "Kohereza"
-                        , kirundi = Just "Kurungika"
-                        , somali = Just "Gudbin"
-                        }
-
-                Pages.Prenatal.Activity.Types.NextStepsHealthEducation ->
-                    translationSet HealthEducation
-
-                Pages.Prenatal.Activity.Types.NextStepsNewbornEnrolment ->
-                    { english = "Newborn Enrollment"
-                    , kinyarwanda = Just "Kwandika uruhinja"
-                    , kirundi = Just "Ukwandika abana bavutse"
-                    , somali = Just "Qorista Dhallaan"
-                    }
-
-                Pages.Prenatal.Activity.Types.NextStepsMedicationDistribution ->
-                    translationSet MedicationDistribution
-
-                Pages.Prenatal.Activity.Types.NextStepsWait ->
-                    { english = "Wait"
-                    , kinyarwanda = Just "Tegereza"
-                    , kirundi = Just "Rindira"
-                    , somali = Just "Sug"
-                    }
-
-                Pages.Prenatal.Activity.Types.NextStepsNextVisit ->
-                    { english = "Next ANC Visit"
-                    , kinyarwanda = Just "Izuzuma ku mugore utwite rikurikira"
-                    , kirundi = Just "Isango rikurikira"
-                    , somali = Just "Booqashada DHU ee xigta"
-                    }
-
-        PrescribedMedication ->
-            { english = "Prescribed Medication"
-            , kinyarwanda = Just "Imiti yatanzwe"
-            , kirundi = Just "Imiti yandikiwe"
-            , somali = Just "Dawada la Qoray"
-            }
-
-        PrenatalRecurrentNextStepsTask task ->
-            case task of
-                Pages.Prenatal.RecurrentActivity.Types.NextStepsSendToHC ->
-                    { english = "Referral"
-                    , kinyarwanda = Just "Kohereza"
-                    , kirundi = Just "Kurungika"
-                    , somali = Just "Gudbin"
-                    }
-
-                Pages.Prenatal.RecurrentActivity.Types.NextStepsMedicationDistribution ->
-                    translationSet MedicationDistribution
-
-                Pages.Prenatal.RecurrentActivity.Types.NextStepsHealthEducation ->
-                    translationSet HealthEducation
-
         PrenatalARVProgramInstructions forPostpartum ->
             if forPostpartum then
                 { english = "Refer patient to ARV services for further management"
@@ -19120,6 +18890,48 @@ translationSet trans =
                     , kirundi = Just "Akahise ka Rudadaza"
                     , somali = Just "Taariikhda Teetanada"
                     }
+
+        PrenatalLabsCaseManagementEntryTypeResults ->
+            { english = "ANC Lab Results"
+            , kinyarwanda = Just "Ibisubizo by'Ibizamini Byafashwe ku mugore utwite"
+            , kirundi = Just "Inyishu z'ibipimo vyakozwe mu gusuzumisha imbanyi"
+            , somali = Nothing
+            }
+
+        PrenatalLabsCaseManagementEntryTypeVitals ->
+            translationSet VitalsRecheck
+
+        PrenatalMedicationTask task ->
+            case task of
+                TaskCalcium ->
+                    translationSet CalciumLabel
+
+                TaskFefol ->
+                    { english = "Fefol"
+                    , kinyarwanda = Just "Ibinini by'ubutare (Fefol)"
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                TaskFolate ->
+                    { english = "Folate"
+                    , kinyarwanda = Just "Ibinini bya Acide Folic"
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                TaskIron ->
+                    { english = "Iron"
+                    , kinyarwanda = Just "Yafashe umuti wongera amaraso"
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                TaskMMS ->
+                    translationSet MMSLabel
+
+                TaskMebendazole ->
+                    translationSet Mebendazole
 
         PrenatalMentalHealthQuestion question ->
             case question of
@@ -19503,6 +19315,88 @@ translationSet trans =
             , somali = Nothing
             }
 
+        PrenatalNCDProgramHeaderPrefix ->
+            { english = "This patient was diagnosed with"
+            , kinyarwanda = Just "Umurwayi yasuzumwe uburwayi bwa"
+            , kirundi = Just "Uyu mugwayi basanze afise"
+            , somali = Just "Bukaankan waxaa lagahelay"
+            }
+
+        PrenatalNCDProgramHeaderSuffix ->
+            { english = "during her pregnancy"
+            , kinyarwanda = Just "mu gihe yari atwite"
+            , kirundi = Just "Mu gihe c'imbanyi yiwe"
+            , somali = Nothing
+            }
+
+        PrenatalNCDProgramInstructions ->
+            { english = "Refer patient to NCD services for further management"
+            , kinyarwanda = Just "Ohereza umurwayi muri serivisi y'indwara zitandura bamwiteho byimbitse"
+            , kirundi = Just "Rungika umugwayi mu gisata c'ingwara zitandukira kugira bagire ibindi bipimo vyiyongerako"
+            , somali = Just "U gudbi bukaanka adeegyada NCD si uu u helo maareyn dheeraad ah"
+            }
+
+        PrenatalNextStepsTask isChw task ->
+            case task of
+                Pages.Prenatal.Activity.Types.NextStepsAppointmentConfirmation ->
+                    { english = "Appointment Confirmation"
+                    , kinyarwanda = Just "Kwemeza itariki yo kugaruka"
+                    , kirundi = Just "Kwemeza isango"
+                    , somali = Just "Xaqiijinta Ballanta"
+                    }
+
+                Pages.Prenatal.Activity.Types.NextStepsFollowUp ->
+                    { english = "CHW Follow Up"
+                    , kinyarwanda = Just "Isura ry'umujyanama w'ubuzima"
+                    , kirundi = Just "Ikurikiranwa rikozwe n'Abaremeshakiyago"
+                    , somali = Just "Ka war qabka SHCB"
+                    }
+
+                Pages.Prenatal.Activity.Types.NextStepsSendToHC ->
+                    if isChw then
+                        translationSet SendToHC
+
+                    else
+                        { english = "Referral"
+                        , kinyarwanda = Just "Kohereza"
+                        , kirundi = Just "Kurungika"
+                        , somali = Just "Gudbin"
+                        }
+
+                Pages.Prenatal.Activity.Types.NextStepsHealthEducation ->
+                    translationSet HealthEducation
+
+                Pages.Prenatal.Activity.Types.NextStepsNewbornEnrolment ->
+                    { english = "Newborn Enrollment"
+                    , kinyarwanda = Just "Kwandika uruhinja"
+                    , kirundi = Just "Ukwandika abana bavutse"
+                    , somali = Just "Qorista Dhallaan"
+                    }
+
+                Pages.Prenatal.Activity.Types.NextStepsMedicationDistribution ->
+                    translationSet MedicationDistribution
+
+                Pages.Prenatal.Activity.Types.NextStepsWait ->
+                    { english = "Wait"
+                    , kinyarwanda = Just "Tegereza"
+                    , kirundi = Just "Rindira"
+                    , somali = Just "Sug"
+                    }
+
+                Pages.Prenatal.Activity.Types.NextStepsNextVisit ->
+                    { english = "Next ANC Visit"
+                    , kinyarwanda = Just "Izuzuma ku mugore utwite rikurikira"
+                    , kirundi = Just "Isango rikurikira"
+                    , somali = Just "Booqashada DHU ee xigta"
+                    }
+
+        PrescribedMedication ->
+            { english = "Prescribed Medication"
+            , kinyarwanda = Just "Imiti yatanzwe"
+            , kirundi = Just "Imiti yandikiwe"
+            , somali = Just "Dawada la Qoray"
+            }
+
         OutsideCareSignQuestion sign ->
             case sign of
                 SeenAtAnotherFacility ->
@@ -19535,6 +19429,113 @@ translationSet trans =
 
                 -- There's not question for this sign.
                 NoOutsideCareSigns ->
+                    translationSet EmptyString
+
+        OutsideCareMedicationLabel medication ->
+            case medication of
+                OutsideCareMedicationQuinineSulphate ->
+                    { english = "Quinine Sulphate per os (10 mg/kg/dose)"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                OutsideCareMedicationCoartem ->
+                    { english = "Coartem"
+                    , kinyarwanda = Just "Kowaritemu"
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                NoOutsideCareMedicationForMalaria ->
+                    translationSet NoneOfThese
+
+                OutsideCareMedicationPenecilin1 ->
+                    { english = "Penicillin (2.4 million units)"
+                    , kinyarwanda = Just "Penisilini (Miliyoni 2.4)"
+                    , kirundi = Just "Penisiline (udupimo tungana na miliyoni 2,4)"
+                    , somali = Just "Penicillin (2.4 malayn qeyb)"
+                    }
+
+                OutsideCareMedicationPenecilin3 ->
+                    { english = "Penicillin (2.4 million units)"
+                    , kinyarwanda = Just "Penisilini (Miliyoni 2.4)"
+                    , kirundi = Just "Penisiline (udupimo tungana na miliyoni 2,4)"
+                    , somali = Nothing
+                    }
+
+                OutsideCareMedicationErythromycin ->
+                    translationSet Erythromycin500mg
+
+                OutsideCareMedicationAzithromycin ->
+                    translationSet Azithromycin2g
+
+                OutsideCareMedicationCeftriaxon ->
+                    translationSet Ceftriaxone1g
+
+                NoOutsideCareMedicationForSyphilis ->
+                    translationSet NoneOfThese
+
+                OutsideCareMedicationMethyldopa2 ->
+                    translationSet Methyldopa250mg
+
+                OutsideCareMedicationMethyldopa3 ->
+                    translationSet Methyldopa250mg
+
+                OutsideCareMedicationMethyldopa4 ->
+                    translationSet Methyldopa250mg
+
+                OutsideCareMedicationCarvedilol ->
+                    translationSet Carvedilol625mg
+
+                OutsideCareMedicationAmlodipine ->
+                    translationSet Amlodipine5mg
+
+                NoOutsideCareMedicationForHypertension ->
+                    translationSet NoneOfThese
+
+                OutsideCareMedicationTDF3TC ->
+                    { english = "TDF+3TC"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                OutsideCareMedicationDolutegravir ->
+                    { english = "Dolutegravir (50mg)"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                NoOutsideCareMedicationForHIV ->
+                    translationSet NoneOfThese
+
+                OutsideCareMedicationIron1 ->
+                    { english = "Iron (60mg)"
+                    , kinyarwanda = Just "Fer (60mg)"
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                OutsideCareMedicationIron2 ->
+                    { english = "Iron (60mg)"
+                    , kinyarwanda = Just "Fer (60mg)"
+                    , kirundi = Just "Fer (60mg)"
+                    , somali = Nothing
+                    }
+
+                OutsideCareMedicationFolicAcid ->
+                    { english = "Folic Acid (400IU)"
+                    , kinyarwanda = Nothing
+                    , kirundi = Just "Acide Folique (400IU)"
+                    , somali = Nothing
+                    }
+
+                NoOutsideCareMedicationForAnemia ->
+                    translationSet NoneOfThese
+
+                _ ->
                     translationSet EmptyString
 
         OutsideCareMedicationDosage medication ->
@@ -19654,119 +19655,27 @@ translationSet trans =
                 _ ->
                     translationSet EmptyString
 
-        OutsideCareMedicationLabel medication ->
-            case medication of
-                OutsideCareMedicationQuinineSulphate ->
-                    { english = "Quinine Sulphate per os (10 mg/kg/dose)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                OutsideCareMedicationCoartem ->
-                    { english = "Coartem"
-                    , kinyarwanda = Just "Kowaritemu"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                NoOutsideCareMedicationForMalaria ->
-                    translationSet NoneOfThese
-
-                OutsideCareMedicationPenecilin1 ->
-                    { english = "Penicillin (2.4 million units)"
-                    , kinyarwanda = Just "Penisilini (Miliyoni 2.4)"
-                    , kirundi = Just "Penisiline (udupimo tungana na miliyoni 2,4)"
-                    , somali = Just "Penicillin (2.4 malayn qeyb)"
-                    }
-
-                OutsideCareMedicationPenecilin3 ->
-                    { english = "Penicillin (2.4 million units)"
-                    , kinyarwanda = Just "Penisilini (Miliyoni 2.4)"
-                    , kirundi = Just "Penisiline (udupimo tungana na miliyoni 2,4)"
-                    , somali = Nothing
-                    }
-
-                OutsideCareMedicationErythromycin ->
-                    translationSet Erythromycin500mg
-
-                OutsideCareMedicationAzithromycin ->
-                    translationSet Azithromycin2g
-
-                OutsideCareMedicationCeftriaxon ->
-                    translationSet Ceftriaxone1g
-
-                NoOutsideCareMedicationForSyphilis ->
-                    translationSet NoneOfThese
-
-                OutsideCareMedicationMethyldopa2 ->
-                    translationSet Methyldopa250mg
-
-                OutsideCareMedicationMethyldopa3 ->
-                    translationSet Methyldopa250mg
-
-                OutsideCareMedicationMethyldopa4 ->
-                    translationSet Methyldopa250mg
-
-                OutsideCareMedicationCarvedilol ->
-                    translationSet Carvedilol625mg
-
-                OutsideCareMedicationAmlodipine ->
-                    translationSet Amlodipine5mg
-
-                NoOutsideCareMedicationForHypertension ->
-                    translationSet NoneOfThese
-
-                OutsideCareMedicationTDF3TC ->
-                    { english = "TDF+3TC"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                OutsideCareMedicationDolutegravir ->
-                    { english = "Dolutegravir (50mg)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                NoOutsideCareMedicationForHIV ->
-                    translationSet NoneOfThese
-
-                OutsideCareMedicationIron1 ->
-                    { english = "Iron (60mg)"
-                    , kinyarwanda = Just "Fer (60mg)"
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                OutsideCareMedicationIron2 ->
-                    { english = "Iron (60mg)"
-                    , kinyarwanda = Just "Fer (60mg)"
-                    , kirundi = Just "Fer (60mg)"
-                    , somali = Nothing
-                    }
-
-                OutsideCareMedicationFolicAcid ->
-                    { english = "Folic Acid (400IU)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Acide Folique (400IU)"
-                    , somali = Nothing
-                    }
-
-                NoOutsideCareMedicationForAnemia ->
-                    translationSet NoneOfThese
-
-                _ ->
-                    translationSet EmptyString
-
         PrenatalPhotoHelper ->
             { english = "Take a picture of the mother's belly. Then you and the mother will see how the belly has grown!"
             , kinyarwanda = Just "Fata ifoto y'inda y'umubyeyi hanyuma uyimwereke arebe uko yakuze/yiyongereye."
             , kirundi = Just "Fata ifoto y'inda y'umuvyeyi. Hama wewe n'umuvyeyi muzoza muraraba ingene inda ikura!"
             , somali = Just "Sawir ka qaad caloosha hooyada. Kadibna isla eega sida ay caloosha u kortay adiga iyo hooyada!"
             }
+
+        PrenatalRecurrentNextStepsTask task ->
+            case task of
+                Pages.Prenatal.RecurrentActivity.Types.NextStepsSendToHC ->
+                    { english = "Referral"
+                    , kinyarwanda = Just "Kohereza"
+                    , kirundi = Just "Kurungika"
+                    , somali = Just "Gudbin"
+                    }
+
+                Pages.Prenatal.RecurrentActivity.Types.NextStepsMedicationDistribution ->
+                    translationSet MedicationDistribution
+
+                Pages.Prenatal.RecurrentActivity.Types.NextStepsHealthEducation ->
+                    translationSet HealthEducation
 
         PrenatalSymptom value ->
             case value of
@@ -19971,6 +19880,69 @@ translationSet trans =
             , somali = Just "Bukaanka wuxuu muujiyay calaamado u baahan su`aalo ka war qab ah."
             }
 
+        Referral ->
+            { english = "Referral"
+            , kinyarwanda = Just "Kohereza"
+            , kirundi = Just "Kurungika"
+            , somali = Just "Gudbin"
+            }
+
+        RememberMakeYourCoworkersYourWorkFamily ->
+            { english = "Remember: Make your co-workers your work family."
+            , kinyarwanda = Just ""
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        Resolved ->
+            { english = "Resolved"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Cakemutse"
+            , somali = Just "La xaliyay"
+            }
+
+        SelectNutritionVisit ->
+            { english = "Select Nutrition Visit"
+            , kinyarwanda = Just "Hitamo isuzuma ry’imirire"
+            , kirundi = Just "Hitamo isuzumwa ry'ingaburo"
+            , somali = Just "Dooro Booqasho Nafaqo"
+            }
+
+        SevereCOVID19 ->
+            { english = "Severe COVID-19"
+            , kinyarwanda = Just "Uburwayi bwa Covid-19 bukabije"
+            , kirundi = Just "COVID-19 ikaze"
+            , somali = Just "COVID-19 aad u daran"
+            }
+
+        SevereVomitingLabel ->
+            { english = "Severe Vomiting"
+            , kinyarwanda = Just "Kuruka bikabije"
+            , kirundi = Just "Ukudahwa gukaze"
+            , somali = Nothing
+            }
+
+        SimpleCOVID19 ->
+            { english = "Simple COVID-19"
+            , kinyarwanda = Just "Uburwayi bwa Covid-19 bworoheje"
+            , kirundi = Just "Korona (COVID-19) isanzwe"
+            , somali = Just "COVID-19 Fudud"
+            }
+
+        SpontaneousBleedingLabel ->
+            { english = "Spontaneous Bleeding"
+            , kinyarwanda = Just "Kuva amaraso bitunguranye"
+            , kirundi = Just "Ukuva amaraso aho nyene"
+            , somali = Just "Dhiigbax aan waqti lahayn"
+            }
+
+        StageOneHypertension ->
+            { english = "Stage One Hypertension"
+            , kinyarwanda = Just "Umuvuduko w'amaraso uri ku rwego rwa mbere"
+            , kirundi = Just "Umuvuduko w'amaraso uri mu c'iciro/mu gice ca mbere"
+            , somali = Nothing
+            }
+
         SuicideRisk ->
             { english = "Suicide Risk"
             , kinyarwanda = Just "Afite ibyago byo kwiyahura"
@@ -20070,6 +20042,20 @@ translationSet trans =
 
                 TestIndeterminate ->
                     translationSet Indeterminate
+
+        PrenatalUltrasoundHeader ->
+            { english = "This patient is uncertain of LMP dating"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        PrenatalUltrasoundInstructions ->
+            { english = "Refer patient to ultrasound for further evaluation"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
 
         PrenatalVaccineLabel value ->
             case value of
@@ -20175,6 +20161,13 @@ translationSet trans =
             , kinyarwanda = Nothing
             , kirundi = Just "Ni iyihe miti umurwayi afata? Raba Mugatabo kumurwayi."
             , somali = Just "Waa maxay dawooyinka la qoray"
+            }
+
+        PreTermPregnancy ->
+            { english = "Number of Pre-term Pregnancies (Live Birth)"
+            , kinyarwanda = Just "Umubare w'abavutse ari bazima badashyitse"
+            , kirundi = Just "Igitigiri c'imbanyi zavutse zitageze kw'itarike (Ariko abana bakaba bariho)"
+            , somali = Just "Tirada Carruurta aan bilo Dhameysan (Ku Dhashay Nolol)"
             }
 
         PreviousCSectionScar ->
@@ -20306,111 +20299,11 @@ translationSet trans =
             , somali = Nothing
             }
 
-        PreTermPregnancy ->
-            { english = "Number of Pre-term Pregnancies (Live Birth)"
-            , kinyarwanda = Just "Umubare w'abavutse ari bazima badashyitse"
-            , kirundi = Just "Igitigiri c'imbanyi zavutse zitageze kw'itarike (Ariko abana bakaba bariho)"
-            , somali = Just "Tirada Carruurta aan bilo Dhameysan (Ku Dhashay Nolol)"
-            }
-
-        TestDate ->
-            { english = "Date of Test"
-            , kinyarwanda = Just "Itariki y'Ikizamini"
-            , kirundi = Just "Itarike y'igipimo"
-            , somali = Nothing
-            }
-
-        TestName ->
-            { english = "Test name"
-            , kinyarwanda = Just "Izina ry'ikizamini"
-            , kirundi = Just "Izina ry'igipimo"
-            , somali = Just "Magaca Tijaabada"
-            }
-
-        TestPerformedQuestion ->
-            { english = "Were you able to perform the test"
-            , kinyarwanda = Just "Waba wakoze ikizamini"
-            , kirundi = Just "Woba warashoboye gukora igipimo; gukora ikibazo"
-            , somali = Nothing
-            }
-
-        TestPerformedTodayQuestion ->
-            { english = "Did you perform this test today"
-            , kinyarwanda = Just "Waba wakoze iki kizamini uyu munsi"
-            , kirundi = Just "Mbega wagize ico gipimo uno munsi"
-            , somali = Nothing
-            }
-
-        TestPrerequisiteQuestion value ->
-            case value of
-                PrerequisiteFastFor12h ->
-                    translationSet WasThisTestPerformedBeforeAMeal
-
-                PrerequisiteImmediateResult ->
-                    { english = "Where was this test performed"
-                    , kinyarwanda = Just "Iki Kizamini cyakozwe"
-                    , kirundi = Just "iki gipimo cabereye hehe"
-                    , somali = Nothing
-                    }
-
-                NoTestPrerequisites ->
-                    translationSet None
-
-        TestUniversalPrerequisiteQuestion value ->
-            case value of
-                PrerequisiteFastFor12h ->
-                    translationSet WasThisTestPerformedBeforeAMeal
-
-                PrerequisiteImmediateResult ->
-                    { english = "Where will this test be"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                NoTestPrerequisites ->
-                    translationSet None
-
-        TestVariantUrineDipstickQuestion ->
-            { english = "Which type of urine dipstick test was run"
-            , kinyarwanda = Just "Ni ikihe kizamini cy'inkari cyakozwe"
-            , kirundi = Just "Mbega ni ubuhe bwoko bw'igipimo c'umukoyo bwakozwe"
-            , somali = Nothing
-            }
-
-        TestWillBePerformedTodayQuestion ->
-            { english = "Will this test be performed today"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        TestResultQuestion ->
-            { english = "What was the result of the test"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Ni iyihe nyishu y'igipimo"
-            , somali = Nothing
-            }
-
-        TestResultsQuestion ->
-            { english = "What were the results of the test"
-            , kinyarwanda = Just "Ibisubizo by'ikizamini byabaye ibihe"
-            , kirundi = Just "Ni izihe nyishu z'ibipimo"
-            , somali = Nothing
-            }
-
         PriorDiagnosis ->
             { english = "Prior Diagnosis"
             , kinyarwanda = Just "Uburwayi yagize/yigeze kurwara"
             , kirundi = Just "Imbere y'isuzuma"
             , somali = Just "Baaritaanka Ka hor"
-            }
-
-        ProvidedHealthEducationAction ->
-            { english = "Provided health education and anticipatory guidance"
-            , kinyarwanda = Nothing
-            , kirundi = Just "Tanga inyigisho yerekeye amagara y'abantu kandi utange intumbero hakiri kare"
-            , somali = Just "La siiyay wacyi gelin caafimaad iyo hagid hordhac ah"
             }
 
         ProvideHealthEducation ->
@@ -20425,6 +20318,13 @@ translationSet trans =
             , kinyarwanda = Just "Tanga inyigisho ku buzima n' umurongo ngenderwaho ku kwirinda"
             , kirundi = Just "Tanga inyigisho yerekeye amagara y'abantu kandi utange intumbero hakiri kare"
             , somali = Just "Sii wacyi gelin caafimaad iyo hagid hordhac ah"
+            }
+
+        ProvidedHealthEducationAction ->
+            { english = "Provided health education and anticipatory guidance"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Tanga inyigisho yerekeye amagara y'abantu kandi utange intumbero hakiri kare"
+            , somali = Just "La siiyay wacyi gelin caafimaad iyo hagid hordhac ah"
             }
 
         ProvidedPreventionEducationQuestion ->
@@ -20477,28 +20377,6 @@ translationSet trans =
                 , somali = Nothing
                 }
 
-        ReadToggle isRead ->
-            if isRead then
-                { english = "Unread"
-                , kinyarwanda = Just "Ubutumwa utarasoma"
-                , kirundi = Just "Bitasomwe"
-                , somali = Just "Aan la aqrin"
-                }
-
-            else
-                { english = "Read"
-                , kinyarwanda = Just "Bwasomwe"
-                , kirundi = Just "Ivyasomwe"
-                , somali = Just "Aqri"
-                }
-
-        ReadyForReview ->
-            { english = "Ready for Review"
-            , kinyarwanda = Nothing
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
         RandomBloodSugarResultNormalRange type_ ->
             case type_ of
                 TestRunBeforeMeal _ ->
@@ -20520,6 +20398,28 @@ translationSet trans =
             , kinyarwanda = Just "Busome"
             , kirundi = Just "Ivyasomwe"
             , somali = Just "Aqri"
+            }
+
+        ReadToggle isRead ->
+            if isRead then
+                { english = "Unread"
+                , kinyarwanda = Just "Ubutumwa utarasoma"
+                , kirundi = Just "Bitasomwe"
+                , somali = Just "Aan la aqrin"
+                }
+
+            else
+                { english = "Read"
+                , kinyarwanda = Just "Bwasomwe"
+                , kirundi = Just "Ivyasomwe"
+                , somali = Just "Aqri"
+                }
+
+        ReadyForReview ->
+            { english = "Ready for Review"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
             }
 
         ReasonForDistribution ->
@@ -20608,6 +20508,42 @@ translationSet trans =
                 IsolationReasonNotApplicable ->
                     translationSet NotApplicable
 
+        ReasonForNotTaking reason ->
+            case reason of
+                NotTakingAdverseEvent ->
+                    { english = "Adverse event"
+                    , kinyarwanda = Just "Ibintu bidasanzwe (bitewe n'imiti wafashe)"
+                    , kirundi = Just "Icyabaye bibabaje"
+                    , somali = Just "Waxyeelo"
+                    }
+
+                NotTakingNoMoney ->
+                    { english = "No money for medication"
+                    , kinyarwanda = Just "Nta mafaranga yo kwishyura imiti afite"
+                    , kirundi = Just "Nta mafaranga yo kugura imiti"
+                    , somali = Just "Lacag uma heysto dawada"
+                    }
+
+                NotTakingMemoryProblems ->
+                    { english = "Memory problems"
+                    , kinyarwanda = Just "Ibibazo byo kwibagirwa"
+                    , kirundi = Just "Ingorane zo kwibuka"
+                    , somali = Just "Dhibaato la xiriirta Keydka Xasuusta"
+                    }
+
+                NotTakingTreatmentNotStarted ->
+                    { english = "Treatment not started"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                NotTakingOther ->
+                    translationSet OtherLabel
+
+                NoReasonForNotTakingSign ->
+                    translationSet EmptyString
+
         ReasonForNotProvidingHealthEducation reason ->
             case reason of
                 PatientNeedsEmergencyReferral ->
@@ -20647,42 +20583,6 @@ translationSet trans =
                     , kirundi = Just "Nta citwazo"
                     , somali = Just "Sabab la`aan"
                     }
-
-        ReasonForNotTaking reason ->
-            case reason of
-                NotTakingAdverseEvent ->
-                    { english = "Adverse event"
-                    , kinyarwanda = Just "Ibintu bidasanzwe (bitewe n'imiti wafashe)"
-                    , kirundi = Just "Icyabaye bibabaje"
-                    , somali = Just "Waxyeelo"
-                    }
-
-                NotTakingNoMoney ->
-                    { english = "No money for medication"
-                    , kinyarwanda = Just "Nta mafaranga yo kwishyura imiti afite"
-                    , kirundi = Just "Nta mafaranga yo kugura imiti"
-                    , somali = Just "Lacag uma heysto dawada"
-                    }
-
-                NotTakingMemoryProblems ->
-                    { english = "Memory problems"
-                    , kinyarwanda = Just "Ibibazo byo kwibagirwa"
-                    , kirundi = Just "Ingorane zo kwibuka"
-                    , somali = Just "Dhibaato la xiriirta Keydka Xasuusta"
-                    }
-
-                NotTakingTreatmentNotStarted ->
-                    { english = "Treatment not started"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                NotTakingOther ->
-                    translationSet OtherLabel
-
-                NoReasonForNotTakingSign ->
-                    translationSet EmptyString
 
         Received ->
             { english = "Received"
@@ -21049,25 +20949,6 @@ translationSet trans =
                 _ ->
                     translationSet EmptyString
 
-        RecommendedTreatmentSignLabelForProgressReport sign ->
-            case sign of
-                TreatmentQuinineSulphate ->
-                    { english = "Quinine Sulphate - per os 10 mg/kg/dose, 3 times a day for 7 days"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Sulfate de quinine - per os 10 mg/kg/Idoze (igipimo),  Umuti wo gufata 3 k'umunsi mu kiringo c'iminsi indwi"
-                    , somali = Just "Quinine Sulphate - os kiiba 10 mg/kg/doos, 3 mar maalinki mudo 7 maalin ah"
-                    }
-
-                TreatmentCoartem ->
-                    { english = "Coartem - 4 tablets by mouth twice per day x 3 days"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Coartem - ibinini 4 vyo kumira kabiri ku munsi mu minsi 3"
-                    , somali = Just "Coartem - 4 kaniini oo afka ah laba jeer maalinki x 3 maalin"
-                    }
-
-                _ ->
-                    translationSet (RecommendedTreatmentSignLabel sign)
-
         RecommendedTreatmentSignLabel sign ->
             case sign of
                 TreatmentQuinineSulphate ->
@@ -21335,6 +21216,25 @@ translationSet trans =
                     , kirundi = Just "Nta muti watanzwe"
                     , somali = Nothing
                     }
+
+        RecommendedTreatmentSignLabelForProgressReport sign ->
+            case sign of
+                TreatmentQuinineSulphate ->
+                    { english = "Quinine Sulphate - per os 10 mg/kg/dose, 3 times a day for 7 days"
+                    , kinyarwanda = Nothing
+                    , kirundi = Just "Sulfate de quinine - per os 10 mg/kg/Idoze (igipimo),  Umuti wo gufata 3 k'umunsi mu kiringo c'iminsi indwi"
+                    , somali = Just "Quinine Sulphate - os kiiba 10 mg/kg/doos, 3 mar maalinki mudo 7 maalin ah"
+                    }
+
+                TreatmentCoartem ->
+                    { english = "Coartem - 4 tablets by mouth twice per day x 3 days"
+                    , kinyarwanda = Nothing
+                    , kirundi = Just "Coartem - ibinini 4 vyo kumira kabiri ku munsi mu minsi 3"
+                    , somali = Just "Coartem - 4 kaniini oo afka ah laba jeer maalinki x 3 maalin"
+                    }
+
+                _ ->
+                    translationSet (RecommendedTreatmentSignLabel sign)
 
         RecordAcuteIllnessOutcome ->
             { english = "Record Acute Illness Outcome"
@@ -21622,20 +21522,6 @@ translationSet trans =
             , somali = Nothing
             }
 
-        RenalDisease ->
-            { english = "Renal Disease"
-            , kinyarwanda = Just "Indwara z'impyiko"
-            , kirundi = Just "Ingwara yo mu mafyigo"
-            , somali = Nothing
-            }
-
-        RepeatHemoglobinTestQuestion ->
-            { english = "Have you counseled the patient to return to the health center to repeat the hemoglobin test in four weeks"
-            , kinyarwanda = Just "Wagiriye umubyeyi inama yo gusubira ku kigo nderabuzima gusubiramo ikizamini cy'ingano y'amaraso mu byumweru bine"
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
         RemainingForDownloadLabel ->
             { english = "Remaining for Download"
             , kinyarwanda = Just "Ibisigaye gukurwa kuri seriveri"
@@ -21661,6 +21547,20 @@ translationSet trans =
             { english = "Remind me of this message in:"
             , kinyarwanda = Just "Nyibutsa ubu butumwa mu:"
             , kirundi = Just "Unyibutse ubu butumwa mu:"
+            , somali = Nothing
+            }
+
+        RenalDisease ->
+            { english = "Renal Disease"
+            , kinyarwanda = Just "Indwara z'impyiko"
+            , kirundi = Just "Ingwara yo mu mafyigo"
+            , somali = Nothing
+            }
+
+        RepeatHemoglobinTestQuestion ->
+            { english = "Have you counseled the patient to return to the health center to repeat the hemoglobin test in four weeks"
+            , kinyarwanda = Just "Wagiriye umubyeyi inama yo gusubira ku kigo nderabuzima gusubiramo ikizamini cy'ingano y'amaraso mu byumweru bine"
+            , kirundi = Nothing
             , somali = Nothing
             }
 
@@ -23359,20 +23259,6 @@ translationSet trans =
             , somali = Nothing
             }
 
-        ResilienceMessageMindfulness5Bullet1 ->
-            { english = "Try to inhale through your nose for 4 seconds, this will make your stomach rise."
-            , kinyarwanda = Just "Gerageza winjize umwuka ukoresheje amazuru yawe mu masegonda 4, urumva igifu cyawe kizamuka."
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
-        ResilienceMessageMindfulness5Bullet2 ->
-            { english = "Exhale through your mouth for 4 seconds."
-            , kinyarwanda = Just "Sohora umwuka ukoresheje umunwa wawe amasegonda 4."
-            , kirundi = Nothing
-            , somali = Nothing
-            }
-
         ResilienceMessageMindfulness5Paragraph2 ->
             { english = "Just focus on how the breathing exercise is making your whole body feel."
             , kinyarwanda = Just "Tekereza gusa ukuntu umwitozo wo guhumeka uri gutuma wiyumva mu mubiri wose."
@@ -23383,6 +23269,20 @@ translationSet trans =
         ResilienceMessageMindfulness5Paragraph3 ->
             { english = "Remember: Breathe deep to release negative energy."
             , kinyarwanda = Just ""
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ResilienceMessageMindfulness5Bullet1 ->
+            { english = "Try to inhale through your nose for 4 seconds, this will make your stomach rise."
+            , kinyarwanda = Just "Gerageza winjize umwuka ukoresheje amazuru yawe mu masegonda 4, urumva igifu cyawe kizamuka."
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        ResilienceMessageMindfulness5Bullet2 ->
+            { english = "Exhale through your mouth for 4 seconds."
+            , kinyarwanda = Just "Sohora umwuka ukoresheje umunwa wawe amasegonda 4."
             , kirundi = Nothing
             , somali = Nothing
             }
@@ -24706,6 +24606,39 @@ translationSet trans =
             , somali = Nothing
             }
 
+        ResilienceRole role ->
+            case role of
+                ResilienceRoleCHW ->
+                    translationSet CHW
+
+                ResilienceRoleNurse ->
+                    { english = "Health Care Worker (HC)"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                ResilienceRoleLineManager ->
+                    { english = "Line Manager"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                ResilienceRoleSupervisor ->
+                    { english = "Supervisor"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                ResilienceRoleDirector ->
+                    { english = "Director General"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
         ResilienceNotificationHeader name ->
             { english = "Hello, " ++ name ++ "!"
             , kinyarwanda = Just <| "Bite, " ++ name ++ "!"
@@ -25124,39 +25057,6 @@ translationSet trans =
                 ResilienceReminderTakeBreak ->
                     { english = "Remember: The stiller you are, the calmer life is. Take a moment to be still."
                     , kinyarwanda = Just ""
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-        ResilienceRole role ->
-            case role of
-                ResilienceRoleCHW ->
-                    translationSet CHW
-
-                ResilienceRoleNurse ->
-                    { english = "Health Care Worker (HC)"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                ResilienceRoleLineManager ->
-                    { english = "Line Manager"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                ResilienceRoleSupervisor ->
-                    { english = "Supervisor"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
-                    }
-
-                ResilienceRoleDirector ->
-                    { english = "Director General"
-                    , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
@@ -26826,6 +26726,20 @@ translationSet trans =
             , somali = Just "Jooji Howl gelinta"
             }
 
+        StorageQuota quota ->
+            { english = "Storage used " ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " MB of available " ++ String.fromInt (quota.quota // (1024 * 1024)) ++ " MB"
+            , kinyarwanda = Just <| "Hamaze gukoreshwa umwanya ungana na MB" ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " umwanya wose ungana na MB " ++ String.fromInt (quota.quota // (1024 * 1024))
+            , kirundi = Just <| "Ububiko bwakoreshejwe bungana na MO(Mégaoctets) " ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " umwanya wose ungana na MO(Mégaoctets) " ++ String.fromInt (quota.quota // (1024 * 1024))
+            , somali = Just <| "Keydka la adeegsaday " ++ String.fromInt (quota.usage // (1024 * 1024)) ++ " MB ga la heli karo " ++ String.fromInt (quota.quota // (1024 * 1024)) ++ " MB"
+            }
+
+        SubmitPairingCode ->
+            { english = "Submit Pairing Code"
+            , kinyarwanda = Just "Umubare uhuza igikoresho cy'ikoranabuhanga na apulikasiyo"
+            , kirundi = Just "Tanga ikode yo kuringanisha"
+            , somali = Just "Xaree Af-garadka Labaalaha ah"
+            }
+
         Success ->
             { english = "Success"
             , kinyarwanda = Just "Byagezweho"
@@ -26910,6 +26824,92 @@ translationSet trans =
             , kinyarwanda = Just "Umubare w'abavutse ari bazima bashyitse"
             , kirundi = Just "Igitigiri c'imbanyi zashitse ku gihe (abana bakavuka bakomeye)"
             , somali = Just "Tirada Uurka Bilo Dhameystay (Ku Dhashay Nolol)"
+            }
+
+        TestDate ->
+            { english = "Date of Test"
+            , kinyarwanda = Just "Itariki y'Ikizamini"
+            , kirundi = Just "Itarike y'igipimo"
+            , somali = Nothing
+            }
+
+        TestName ->
+            { english = "Test name"
+            , kinyarwanda = Just "Izina ry'ikizamini"
+            , kirundi = Just "Izina ry'igipimo"
+            , somali = Just "Magaca Tijaabada"
+            }
+
+        TestPerformedQuestion ->
+            { english = "Were you able to perform the test"
+            , kinyarwanda = Just "Waba wakoze ikizamini"
+            , kirundi = Just "Woba warashoboye gukora igipimo; gukora ikibazo"
+            , somali = Nothing
+            }
+
+        TestPerformedTodayQuestion ->
+            { english = "Did you perform this test today"
+            , kinyarwanda = Just "Waba wakoze iki kizamini uyu munsi"
+            , kirundi = Just "Mbega wagize ico gipimo uno munsi"
+            , somali = Nothing
+            }
+
+        TestPrerequisiteQuestion value ->
+            case value of
+                PrerequisiteFastFor12h ->
+                    translationSet WasThisTestPerformedBeforeAMeal
+
+                PrerequisiteImmediateResult ->
+                    { english = "Where was this test performed"
+                    , kinyarwanda = Just "Iki Kizamini cyakozwe"
+                    , kirundi = Just "iki gipimo cabereye hehe"
+                    , somali = Nothing
+                    }
+
+                NoTestPrerequisites ->
+                    translationSet None
+
+        TestUniversalPrerequisiteQuestion value ->
+            case value of
+                PrerequisiteFastFor12h ->
+                    translationSet WasThisTestPerformedBeforeAMeal
+
+                PrerequisiteImmediateResult ->
+                    { english = "Where will this test be"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                NoTestPrerequisites ->
+                    translationSet None
+
+        TestResultQuestion ->
+            { english = "What was the result of the test"
+            , kinyarwanda = Nothing
+            , kirundi = Just "Ni iyihe nyishu y'igipimo"
+            , somali = Nothing
+            }
+
+        TestResultsQuestion ->
+            { english = "What were the results of the test"
+            , kinyarwanda = Just "Ibisubizo by'ikizamini byabaye ibihe"
+            , kirundi = Just "Ni izihe nyishu z'ibipimo"
+            , somali = Nothing
+            }
+
+        TestVariantUrineDipstickQuestion ->
+            { english = "Which type of urine dipstick test was run"
+            , kinyarwanda = Just "Ni ikihe kizamini cy'inkari cyakozwe"
+            , kirundi = Just "Mbega ni ubuhe bwoko bw'igipimo c'umukoyo bwakozwe"
+            , somali = Nothing
+            }
+
+        TestWillBePerformedTodayQuestion ->
+            { english = "Will this test be performed today"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
             }
 
         ThereAre ->
@@ -27192,18 +27192,18 @@ translationSet trans =
             , somali = Just "Doosyo aan qaadanin ma jiraan"
             }
 
-        TreatmentReviewQuestionStillTaking ->
-            { english = "Are you still taking this medication"
-            , kinyarwanda = Just "Uracyari gufata imiti"
-            , kirundi = Just "Uracafata uwo muti?"
-            , somali = Just "Daawadan weli ma qaadataa?"
-            }
-
         TreatmentReviewQuestionStillTakingForHIV ->
             { english = "Are you still taking ARVs"
             , kinyarwanda = Just "Uracyari gufata imiti igabanya ubukana bwa virusi itera SIDA"
             , kirundi = Just "Uracafata Umuti mukuru upfupfahaza umugera wa SIDA"
             , somali = Nothing
+            }
+
+        TreatmentReviewQuestionStillTaking ->
+            { english = "Are you still taking this medication"
+            , kinyarwanda = Just "Uracyari gufata imiti"
+            , kirundi = Just "Uracafata uwo muti?"
+            , somali = Just "Daawadan weli ma qaadataa?"
             }
 
         TreatmentReviewTask forModeratePreeclamsia task ->
@@ -27314,13 +27314,6 @@ translationSet trans =
                 Backend.TuberculosisActivity.Model.NextSteps ->
                     translationSet NextSteps
 
-        TuberculosisDiagnosedQuestion ->
-            { english = "Was this person diagnosed with Tuberculosis"
-            , kinyarwanda = Just "Uyu murwayi yaba yaragaragaweho uburwayi bw'igituntu"
-            , kirundi = Just "Uyu muntu baramusanganye indwara y'igituntu"
-            , somali = Just "Qofkan ma laga baaray Qaaxo"
-            }
-
         TuberculosisDiagnosis sign ->
             case sign of
                 TuberculosisPulmonary ->
@@ -27340,6 +27333,13 @@ translationSet trans =
                 NoTuberculosis ->
                     -- Not in use.
                     translationSet EmptyString
+
+        TuberculosisDiagnosedQuestion ->
+            { english = "Was this person diagnosed with Tuberculosis"
+            , kinyarwanda = Just "Uyu murwayi yaba yaragaragaweho uburwayi bw'igituntu"
+            , kirundi = Just "Uyu muntu baramusanganye indwara y'igituntu"
+            , somali = Just "Qofkan ma laga baaray Qaaxo"
+            }
 
         TuberculosisDistributeMedicationsQuestion ->
             { english = "Did you distribute the following medications"

--- a/docs/superpowers/follow-ups-translate-elm-bugs.md
+++ b/docs/superpowers/follow-ups-translate-elm-bugs.md
@@ -8,15 +8,25 @@ For context: the dedup refactor PR collapsed 252 duplicate-translation
 sites across 126 safe groups into `translationSet <Anchor>` dispatches.
 This doc lists the items it could NOT touch safely.
 
+## Resolved follow-ups
+
+Items that have since been fixed in subsequent commits on the same
+branch (`refactor/translate-elm-dedup`):
+
+| english | resolution | commit |
+|---|---|---|
+| Other | Added top-level `OtherLabel` anchor with canonical translations (en="Other", rw="Ibindi", rn="Ibindi", so="Kale") and refactored all 23 `*Other` case branches to dispatch via it. | `b41595799` |
+
 ## 1. Diverging duplicate-english groups (need native-speaker review)
 
-These **126 groups** have the same English label but different
+These **125 remaining groups** (126 originally; 1 resolved — see
+*Resolved follow-ups* above) have the same English label but different
 translations in at least one of rw/rn/so across their duplicate
 constructors. They were NOT refactored to `translationSet` because
 doing so would change the UI translation for some users. A
 native-speaker reviewer should pick the canonical per-locale
-translation for each group, then a follow-up PR can dedup them the
-same way as the safe groups.
+translation for each group, then a follow-up commit can dedup them
+the same way as `Other` was resolved.
 
 | english | constructors | divergence |
 |---|---|---|
@@ -29,7 +39,6 @@ same way as the safe groups.
 | Acute Illness History | `AcuteIllnessHistory`, `ComponentWellChildActiveDiagnoses` | rw differs (2 variants), so differs (2 variants) |
 | Active Diagnosis | `ActiveDiagnosis`, `ComponentNCDActiveDiagnosis` | rw differs (2 variants), rn differs (2 variants) |
 | Referred to Health Center | `OutcomePatientDied`, `ActionReferredToHealthCenter` | rw differs (2 variants) |
-| Other | `OutcomeOther`, `AdverseEventOther`, `AhezaDistributionReasonOther` + 20 more | rw differs (3 variants) |
 | Family Planning | `ActivitiesTitle`, `NCDActivityTitle`, `FilterFamilyPlanning` + 1 more | rw differs (2 variants) |
 | Physical Exam | `AcuteIllnessPhysicalExam`, `PhysicalExam` | rw differs (2 variants) |
 | Laboratory | `AcuteIllnessLaboratory`, `NCDActivityTitle`, `PrenatalPhoto` | rn differs (2 variants) |
@@ -37,7 +46,6 @@ same way as the safe groups.
 
 Notable rows worth pulling out:
 
-- **"Other" (×23 occurrences, 3 rw variants)** is the highest-volume divergence. Resolving it would dedupe 22+ literal blocks. Real reviewer payoff.
 - **"Simple Cold and Cough"** has the same constructor name `DiagnosisSimpleColdAndCough` appearing twice — once in `AcuteIllnessDiagnosis option ->` and once in `AcuteIllnessDiagnosisWarning option ->`. These are not unreachable code (different parent dispatches), but having different `rw` translations across two parallel contexts is suspicious — likely one of the two is the "newer/canonical" version and they should agree.
 - **Vaccine names** (`BCG`, `HPV`, `IPV`, `Measles-Rubella`, `OPV`, `PCV 13`, `Rotarix`, `Pentavalent`) all diverge between `SiteBurundi` and `Vaccine*` constructors on `rn` (Kirundi). Could be intentional (Burundi-specific Kirundi spellings vs general Kinyarwanda-leaning forms) but worth reviewer confirmation.
 

--- a/docs/superpowers/follow-ups-translate-elm-bugs.md
+++ b/docs/superpowers/follow-ups-translate-elm-bugs.md
@@ -1,0 +1,158 @@
+# Translate.elm — follow-up items
+
+Items surfaced during the `refactor/translate-elm-dedup` work that need
+review beyond the scope of that PR. None block normal use of E-Heza;
+all are quality / cleanliness opportunities.
+
+For context: the dedup refactor PR collapsed 252 duplicate-translation
+sites across 126 safe groups into `translationSet <Anchor>` dispatches.
+This doc lists the items it could NOT touch safely.
+
+## 1. Diverging duplicate-english groups (need native-speaker review)
+
+These **126 groups** have the same English label but different
+translations in at least one of rw/rn/so across their duplicate
+constructors. They were NOT refactored to `translationSet` because
+doing so would change the UI translation for some users. A
+native-speaker reviewer should pick the canonical per-locale
+translation for each group, then a follow-up PR can dedup them the
+same way as the safe groups.
+
+| english | constructors | divergence |
+|---|---|---|
+| Abdomen | `Abdomen`, `PainAbdomen` | rw differs (2 variants), so differs (2 variants) |
+| Poor Suck | `AcuteFindingsPoorSuck`, `PoorSuck` | rn differs (2 variants) |
+| Respiratory Distress | `DangerSignRespiratoryDistress`, `RespiratoryDistress` | rn differs (2 variants) |
+| Bloody Diarrhea | `DangerSignBloodyDiarrhea`, `BloodyDiarrhea` | rn differs (2 variants) |
+| Simple Cold and Cough | `DiagnosisSimpleColdAndCough` (×2 — different outer dispatches) | rw differs (2 variants) |
+| Suspected COVID-19 case | `DiagnosisCovid19Suspect`, `SuspectedCovid19CaseAlert` | rw differs (2 variants) |
+| Acute Illness History | `AcuteIllnessHistory`, `ComponentWellChildActiveDiagnoses` | rw differs (2 variants), so differs (2 variants) |
+| Active Diagnosis | `ActiveDiagnosis`, `ComponentNCDActiveDiagnosis` | rw differs (2 variants), rn differs (2 variants) |
+| Referred to Health Center | `OutcomePatientDied`, `ActionReferredToHealthCenter` | rw differs (2 variants) |
+| Other | `OutcomeOther`, `AdverseEventOther`, `AhezaDistributionReasonOther` + 20 more | rw differs (3 variants) |
+| Family Planning | `ActivitiesTitle`, `NCDActivityTitle`, `FilterFamilyPlanning` + 1 more | rw differs (2 variants) |
+| Physical Exam | `AcuteIllnessPhysicalExam`, `PhysicalExam` | rw differs (2 variants) |
+| Laboratory | `AcuteIllnessLaboratory`, `NCDActivityTitle`, `PrenatalPhoto` | rn differs (2 variants) |
+| ... (113 more rows; see `/tmp/translate-dedup-groups.json`'s `diverging` array) | | |
+
+Notable rows worth pulling out:
+
+- **"Other" (×23 occurrences, 3 rw variants)** is the highest-volume divergence. Resolving it would dedupe 22+ literal blocks. Real reviewer payoff.
+- **"Simple Cold and Cough"** has the same constructor name `DiagnosisSimpleColdAndCough` appearing twice — once in `AcuteIllnessDiagnosis option ->` and once in `AcuteIllnessDiagnosisWarning option ->`. These are not unreachable code (different parent dispatches), but having different `rw` translations across two parallel contexts is suspicious — likely one of the two is the "newer/canonical" version and they should agree.
+- **Vaccine names** (`BCG`, `HPV`, `IPV`, `Measles-Rubella`, `OPV`, `PCV 13`, `Rotarix`, `Pentavalent`) all diverge between `SiteBurundi` and `Vaccine*` constructors on `rn` (Kirundi). Could be intentional (Burundi-specific Kirundi spellings vs general Kinyarwanda-leaning forms) but worth reviewer confirmation.
+
+The full list lives in the analysis output JSON; the dedup PR's commit message points at this doc.
+
+## 2. Skipped during dedup refactor
+
+### 2a. Anchor-naming infeasible (20 cases)
+
+Cases where the proposed PascalCase anchor name would be:
+- Empty (english is `""` or single non-alphanumeric char)
+- Digit-leading (would be invalid Elm constructor name)
+- > 50 characters (e.g., long "1 tablet by mouth twice a day" style strings)
+- All-punctuation (`+`, `++`, `0`, `1`, `2`, `4`)
+
+| english | constructors |
+|---|---|
+| `Explain to the mother how to check the malnutrition signs fo` (long) | `ChildActivity`, `NutritionActivityHelper`, `NutritionHelper` |
+| `Calibrate the scale before taking the first baby's weight. P` (long) | `ChildActivity`, `NutritionActivityHelper` |
+| `+` | `BloodSmearPlus`, `NitritePlus` |
+| `++` | `BloodSmearPlusPlus`, `NitritePlusPlus` |
+| `` (empty) | `DeviceNotAuthorized`, `EmptyString`, `PageMain` + 1 more |
+| `<20 copies` | `ResultSuppressedViralLoad`, `LabResultsHistoryHIVPCR` |
+| `0` | `Protein0`, `Glucose0`, `LabResultsHistoryProtein` + 1 more |
+| `+1` | `ProteinPlus1`, `GlucosePlus1` |
+| `+2` | `ProteinPlus2`, `GlucosePlus2` |
+| `+3` | `ProteinPlus3`, `GlucosePlus3` |
+| `+4` | `ProteinPlus4`, `GlucosePlus4` |
+| `1` | `Urobilinogen10`, `Ubudehe1` |
+| `2` | `Urobilinogen20`, `Ubudehe2` |
+| `4` | `Urobilinogen40`, `Ubudehe4` |
+| `1 tablet by mouth twice a day` | `OutsideCareMedicationMethyldopa2`, `TreatmentMethyldopa2`, `TreatmentNifedipine` + 2 more |
+| `2 capsules by mouth 3 times a day for 7 days` | `TreatmentCloxacillin`, `TreatmentMastitisAmoxicillin` |
+| `1 tablet by mouth 3 times a day for 5 days` | `TreatmentParacetamol`, `TreatmentIbuprofen` |
+| `2 tablets by mouth in the morning and 1 tablet by mouth in t` (long) | `TreatmentMetformin2m1e`, `TreatmentGlipenclamide2m1e` |
+| `2 tablets by mouth twice a day` | `TreatmentMetformin2m2e`, `TreatmentGlipenclamide2m2e` |
+| `If distributed amount is not as per guidelines, select the r` (long) | `ChildActivity`, `MotherActivity` |
+
+These could be refactored if the team is willing to mint anchors with explicit human-chosen names (e.g., `ProteinPlus1` could anchor to a new `LabPlusOne` TranslationId; `1 tablet by mouth twice a day` could anchor to `DoseOneTabletTwiceDaily`). Out of scope for the mechanical refactor.
+
+### 2b. Anchor name clashes with existing top-level constructor (2 cases)
+
+Cases where the proposed PascalCase anchor name collides with an
+already-existing top-level `TranslationId` whose translations DIFFER
+from the duplicate group's. Refactoring would require either renaming
+the existing constructor (changes call sites) OR using a `Label` suffix
+on the new anchor — but unlike the 17 import-clash cases that DID get
+`Label`-suffixed in the dedup PR, these would also need linguistic
+review since the existing anchor's translations are themselves
+candidates for canonicalisation.
+
+| english | clash | duplicate constructors |
+|---|---|---|
+| None of the Above | clash with existing top-level `NoneOfTheAbove` | `NoMedicationCausingHypertension`, `NoMedicalConditions`, `NoMedicationTreatingDiabetes`, `NoMedicationTreatingHypertension`, `NoNCDDangerSigns`, `NoNCDGroup1Symptoms`, `NoNCDGroup2Symptoms`, `NoNCDPainSymptoms` |
+| Pregnancy Outcome | clash with existing top-level `PregnancyOutcome` | `BirthPlan`, `PregnancyOutcomeLabel` |
+
+For "None of the Above": the existing `NoneOfTheAbove` has slightly different translations than the 8 `No*` constructors above. A reviewer should decide which translations are canonical, then dedup all 9 entries.
+
+### 2c. Refactor sites with translation-mismatch within the safe group (handled in PR)
+
+The dedup PR also skipped 35 individual sites at refactor time where
+the literal's translations didn't byte-match the anchor's expected
+translations (data inconsistencies that snuck through the
+locale-equivalence check at group level — usually one record had
+slightly different whitespace, escape chars, or an empty Just where
+others had Nothing). These were left as literals to avoid silent
+translation drift. They're listed in the dedup PR's Commit 5 message
+body and don't need separate documentation here.
+
+## 3. Constructor-rename candidates (typos)
+
+Bugs revealed during exploration that involve renaming Elm
+constructors. Out of scope for the dedup PR because renames change call
+sites across the codebase; would need a focused PR each.
+
+| typo'd constructor | suggested rename | english | reasoning |
+|---|---|---|---|
+| `NitritionSigns` | `NutritionSigns` | "Nutrition Signs" | clear typo (Nitrition → Nutrition) |
+| `ResilienceSurveyTotalNumber0to1` etc. | various | n/a | check for similar typos in the resilience module |
+
+The `NitritionSigns` typo is the only confirmed one from the dedup
+exploration — others may surface during a careful read of `Translate.elm`.
+
+## 4. Empty-string english groups
+
+Groups where english is `""`. Likely intentional in some contexts
+(e.g., `EmptyString` is a sentinel; `DeviceNotAuthorized` and
+`PageMain` may use empty strings as fallback placeholders that get
+filled by the rendering layer). Listed in §2a above and safest to
+leave alone.
+
+## 5. Cross-check tool limitation (informational)
+
+The dedup refactor's verification tool (`/tmp/translate-cross-check.py`,
+not committed) had a known limitation: when an arg-taking outer
+constructor (e.g., `PrenatalDiagnosis diagnosis ->`) gets its FIRST
+inner case branch refactored from a literal to a `translationSet`
+dispatch, the tool's "find first literal in body" heuristic now picks
+the SECOND inner case branch as "first" and reports an apparent diff.
+
+This produced 20 false-positive "diffs" during the refactor, all
+manually verified to be benign (the affected dispatches resolve to
+anchors with byte-identical translations). The Elm compile + manual
+verification confirmed zero real translation drift.
+
+A future cross-check tool that resolves nested `translationSet`
+dispatches transitively (rather than relying on first-literal
+heuristic) would eliminate the false positives. Not blocking; just
+something to note if the verification tooling gets reused.
+
+## Source data
+
+- `/tmp/translate-dedup-groups.json` — canonical analysis output (not
+  committed; regenerate with `/tmp/translate-dedup-analysis.py` if
+  needed)
+- Branch: `refactor/translate-elm-dedup`
+- Commits: `0142c00f8` (spec/plan), `9e282eb21` (anchors), `30d1778a7`
+  (refactor)

--- a/docs/superpowers/plans/2026-04-20-translate-elm-dedup.md
+++ b/docs/superpowers/plans/2026-04-20-translate-elm-dedup.md
@@ -1,0 +1,1113 @@
+# Translate.elm dedup refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mechanically dedupe 149 locale-equivalent duplicate-english groups in `client/src/elm/Translate.elm` by routing them through `translationSet`. Add 111 new top-level `TranslationId` anchor constructors for groups that need one. Fix ~5–15 source bugs (duplicate case branches with conflicting translations) using internet research as tiebreaker. Document the 126 diverging groups as follow-ups.
+
+**Architecture:** Pure refactor inside one file (`client/src/elm/Translate.elm`). Each duplicate group's 5-line literal `english/kw/kn/so` block becomes a 1-line `translationSet <Anchor>` dispatch. New anchor constructors get added in alphabetical position to the `type TranslationId` declaration AND the main `translationSet` function. Verification per commit: elm-format, elm compile, and a Python script that diffs effective translations before vs after to ensure byte-identical UI behavior.
+
+**Tech Stack:** Elm 0.19.1, `elm-format`, `elm` (compiler), Python 3 for the analysis + cross-check scripts.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md`
+
+**Conventions enforced throughout:**
+- Per global preference: **always ask the user before running `git commit` or `git push`** — every commit step asks first.
+- Per CLAUDE.md: doc-only commits get `[ci skip]`; **non-doc commits do NOT get `[ci skip]`** (CI verification is critical for the Elm code changes).
+- Per spec §Verification: each non-doc commit must pass elm-format + elm compile + the cross-check translation diff before commit.
+- Per spec §Refactor mechanics: anchor naming is PascalCase-of-english; clashes/digit-leading/overlong names get skipped + flagged.
+- Per spec §Out of scope: NO changes outside `client/src/elm/Translate.elm` (and the `docs/superpowers/` spec/plan/follow-up doc files).
+
+---
+
+## File Structure
+
+**Modify (committed):**
+- `client/src/elm/Translate.elm` — bulk refactor; add ~111 new constructors + case branches; collapse ~370 literal blocks to `translationSet` dispatches; fix ~5–15 source bugs.
+
+**Create (committed):**
+- `docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md` — already written, uncommitted.
+- `docs/superpowers/plans/2026-04-20-translate-elm-dedup.md` — this file, uncommitted.
+- `docs/superpowers/follow-ups-translate-elm-bugs.md` — list of 126 diverging groups + skipped clash/overlong cases + structural anomalies for future review.
+
+**Working / scratch (NOT committed):**
+- `/tmp/translate-dedup-analysis.py` — duplicate-group analysis script.
+- `/tmp/translate-dedup-groups.json` — groups data: safe (149) split into needs-anchor (111) / has-anchor (38), plus diverging (126) and source bugs.
+- `/tmp/translate-cross-check.py` — verification script comparing effective translations before vs after the refactor.
+- `/tmp/translate-pre-snapshot.json` — captured pre-refactor effective translations per top-level constructor.
+
+**Already done before this plan starts:**
+- Branch `refactor/translate-elm-dedup` created off `origin/develop` (controller did this during brainstorming).
+- Spec at `docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md` is uncommitted in working tree.
+
+---
+
+## Task 1: Re-run duplicate-group analysis against current `develop`
+
+**Files:**
+- Create: `/tmp/translate-dedup-analysis.py` (NOT committed)
+- Write: `/tmp/translate-dedup-groups.json` (NOT committed)
+
+The brainstorming explored the duplicate landscape against the docs branch's `Translate.elm`. `develop` may have advanced. Re-run the analysis on the current branch's `Translate.elm` to confirm the counts haven't shifted materially.
+
+- [ ] **Step 1: Save the analysis script verbatim**
+
+Save to `/tmp/translate-dedup-analysis.py`:
+
+```python
+#!/usr/bin/env python3
+"""Analyze duplicate-english groups in Translate.elm's translationSet function.
+
+Output: JSON with safe groups (locale-equivalent), diverging groups, and source bugs.
+"""
+import json
+import re
+import sys
+from collections import defaultdict
+
+REPO = "/var/www/html/ihangane"
+TRANSLATE_PATH = f"{REPO}/client/src/elm/Translate.elm"
+
+
+def strip_comments(src):
+    src = re.sub(r"\{-[\s\S]*?-\}", "", src)
+    src = re.sub(r"--[^\n]*", "", src)
+    return src
+
+
+def find_function_body(src, fn_name):
+    """Find the body of `<fn_name> ... =\\n    case ... of\\n` and return (start, end)."""
+    m = re.search(rf"^{re.escape(fn_name)}\s+\w+\s*=\s*\n\s*case\s+\w+\s+of\s*\n", src, re.MULTILINE)
+    if not m:
+        return None
+    body_start = m.end()
+    end_m = re.search(r"^[a-z]\w*\s*[:=]", src[body_start:], re.MULTILINE)
+    body_end = body_start + (end_m.start() if end_m else len(src) - body_start)
+    return body_start, body_end
+
+
+def parse_top_level_constructors(src):
+    """Extract list of top-level TranslationId constructor names."""
+    m = re.search(r"^type TranslationId\s*\n", src, re.MULTILINE)
+    if not m:
+        sys.exit("can't find type TranslationId")
+    block_start = m.end()
+    end_m = re.search(r"^[a-z]\w*\s*[:=]", src[block_start:], re.MULTILINE)
+    block_end = block_start + (end_m.start() if end_m else len(src) - block_start)
+    block = src[block_start:block_end]
+    return set(re.findall(r"^\s*[|=]\s*([A-Z]\w*)", block, re.MULTILINE))
+
+
+def parse_records_with_constructors(body):
+    """For every literal `{ english=..., ... }` in body, find the nearest preceding `<Name> ->`."""
+    arrow_pattern = re.compile(r"^( *)([A-Z]\w*)(?:\s+\w+)*\s*->\s*$", re.MULTILINE)
+    arrows = [(m.start(), m.group(1), m.group(2)) for m in arrow_pattern.finditer(body)]
+
+    record_pattern = re.compile(
+        r"\{\s*english\s*=\s*\"((?:\\.|[^\"\\])*)\""
+        r"(?:\s*,\s*kinyarwanda\s*=\s*(Just\s*\"((?:\\.|[^\"\\])*)\"|Nothing))?"
+        r"(?:\s*,\s*kirundi\s*=\s*(Just\s*\"((?:\\.|[^\"\\])*)\"|Nothing))?"
+        r"(?:\s*,\s*somali\s*=\s*(Just\s*\"((?:\\.|[^\"\\])*)\"|Nothing))?",
+    )
+    records = []
+    for rm in record_pattern.finditer(body):
+        pos = rm.start()
+        en = rm.group(1)
+        rw = rm.group(3) if rm.group(3) is not None else None
+        rn = rm.group(5) if rm.group(5) is not None else None
+        so = rm.group(7) if rm.group(7) is not None else None
+        nearest = None
+        for ap, _, an in arrows:
+            if ap < pos:
+                nearest = an
+            else:
+                break
+        if nearest:
+            records.append((nearest, en, rw, rn, so, pos))
+    return records
+
+
+def main():
+    src = strip_comments(open(TRANSLATE_PATH).read())
+    top_level = parse_top_level_constructors(src)
+    fn_range = find_function_body(src, "translationSet")
+    if not fn_range:
+        sys.exit("can't find translationSet function")
+    body = src[fn_range[0]:fn_range[1]]
+    records = parse_records_with_constructors(body)
+    print(f"Found {len(records)} literal records in translationSet function", file=sys.stderr)
+    print(f"Top-level TranslationId constructors: {len(top_level)}", file=sys.stderr)
+
+    # Group by english
+    by_en = defaultdict(list)
+    for rec in records:
+        by_en[rec[1]].append(rec)
+
+    safe_with_anchor = []        # 38-ish: anchor exists at top level
+    safe_needs_anchor = []       # 111-ish: needs new anchor
+    diverging = []               # 126-ish: locales differ
+    source_bugs = []             # constructor appears 2+ times in same group
+
+    for en, recs in by_en.items():
+        if len(recs) < 2:
+            continue
+        # Check locale equivalence
+        locale_sets = set((r[2], r[3], r[4]) for r in recs)
+        # Detect source bugs: same constructor appears twice
+        ctor_counts = defaultdict(int)
+        for r in recs:
+            ctor_counts[r[0]] += 1
+        bug_ctors = [c for c, n in ctor_counts.items() if n >= 2]
+
+        if bug_ctors:
+            source_bugs.append({
+                "english": en,
+                "constructors": [r[0] for r in recs],
+                "duplicate_constructors": bug_ctors,
+                "locale_sets": [list(s) for s in locale_sets],
+                "records": [{"ctor": r[0], "rw": r[2], "rn": r[3], "so": r[4]} for r in recs],
+            })
+            continue  # source bugs are tracked separately
+
+        if len(locale_sets) == 1:
+            # Safe — find anchor candidate (PascalCase of english)
+            anchor_name = pascalize(en)
+            if anchor_name is None:
+                # Skip-and-flag (digit-leading, overlong, empty)
+                diverging.append({"english": en, "constructors": [r[0] for r in recs],
+                                  "skip_reason": "anchor naming infeasible"})
+                continue
+            existing_anchor = next((r[0] for r in recs if r[0] == anchor_name and r[0] in top_level), None)
+            if existing_anchor:
+                safe_with_anchor.append({
+                    "english": en, "anchor": existing_anchor,
+                    "constructors": [r[0] for r in recs],
+                    "rw": recs[0][2], "rn": recs[0][3], "so": recs[0][4],
+                })
+            elif anchor_name in top_level:
+                # Anchor name clashes with existing constructor that has DIFFERENT translations
+                diverging.append({"english": en, "constructors": [r[0] for r in recs],
+                                  "skip_reason": f"clash with existing top-level {anchor_name}"})
+            else:
+                safe_needs_anchor.append({
+                    "english": en, "anchor": anchor_name,
+                    "constructors": [r[0] for r in recs],
+                    "rw": recs[0][2], "rn": recs[0][3], "so": recs[0][4],
+                })
+        else:
+            diverging.append({
+                "english": en, "constructors": [r[0] for r in recs],
+                "locale_sets": [list(s) for s in locale_sets],
+                "records": [{"ctor": r[0], "rw": r[2], "rn": r[3], "so": r[4]} for r in recs],
+            })
+
+    out = {
+        "safe_with_anchor": safe_with_anchor,
+        "safe_needs_anchor": safe_needs_anchor,
+        "diverging": diverging,
+        "source_bugs": source_bugs,
+        "summary": {
+            "safe_with_anchor": len(safe_with_anchor),
+            "safe_needs_anchor": len(safe_needs_anchor),
+            "diverging": len(diverging),
+            "source_bugs": len(source_bugs),
+            "top_level_constructors": len(top_level),
+            "total_literal_records": len(records),
+        },
+    }
+    json.dump(out, sys.stdout, indent=2)
+    print(file=sys.stderr)
+    print("SUMMARY:", json.dumps(out["summary"], indent=2), file=sys.stderr)
+
+
+def pascalize(en):
+    """PascalCase of english label. Return None if infeasible (digit-leading, empty, too long, has bad chars)."""
+    if not en or en.strip() == "":
+        return None
+    # Strip parens content's interior chars but keep digits ("(250mg)" → "250mg")
+    cleaned = re.sub(r"[^\w\s]", "", en)
+    parts = cleaned.split()
+    if not parts:
+        return None
+    name = "".join(p[0].upper() + p[1:] for p in parts)
+    if not name or name[0].isdigit():
+        return None
+    if len(name) > 50:
+        return None
+    return name
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Verify the script parses**
+
+```bash
+python3 -m py_compile /tmp/translate-dedup-analysis.py && echo "ok"
+```
+
+Expected: `ok`. Any SyntaxError → typo, fix.
+
+- [ ] **Step 3: Run the analysis**
+
+```bash
+cd /var/www/html/ihangane && python3 /tmp/translate-dedup-analysis.py > /tmp/translate-dedup-groups.json 2> /tmp/translate-dedup-summary.txt
+echo "exit=$?"
+cat /tmp/translate-dedup-summary.txt
+```
+
+Expected:
+- `exit=0`
+- Summary in stderr lists counts. Brainstorming exploration counts (149 safe / 111 needs-anchor / 38 has-anchor / 126 diverging / a few source bugs) — current `develop` numbers should be in the same ballpark. If wildly different (>20% delta on safe-group count), STOP and report to controller — develop has shifted significantly and the design assumptions may need revisiting.
+
+- [ ] **Step 4: Quick sanity-check the JSON**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('/tmp/translate-dedup-groups.json'))
+for k, v in d['summary'].items():
+    print(f'  {k}: {v}')
+print()
+print('Sample safe-with-anchor (3):')
+for g in d['safe_with_anchor'][:3]:
+    print(f\"  english='{g['english']}' anchor={g['anchor']} ctors={g['constructors']}\")
+print()
+print('Sample safe-needs-anchor (3):')
+for g in d['safe_needs_anchor'][:3]:
+    print(f\"  english='{g['english']}' new_anchor={g['anchor']} ctors={g['constructors']}\")
+print()
+print('Source bugs:')
+for g in d['source_bugs']:
+    print(f\"  english='{g['english']}' duplicate_ctors={g['duplicate_constructors']}\")
+"
+```
+
+Expected: counts in line with brainstorming exploration; samples look like the kinds of groups expected.
+
+NO COMMIT (scratch files only).
+
+---
+
+## Task 2: Capture pre-refactor translations baseline
+
+**Files:**
+- Create: `/tmp/translate-cross-check.py` (NOT committed)
+- Write: `/tmp/translate-pre-snapshot.json` (NOT committed)
+
+The cross-check verification needs a baseline: for every TranslationId, what does it currently render? Capture that BEFORE any edits so we can compare AFTER.
+
+- [ ] **Step 1: Save the cross-check script**
+
+Save to `/tmp/translate-cross-check.py`:
+
+```python
+#!/usr/bin/env python3
+"""Capture or verify the effective translations of all top-level TranslationIds.
+
+Mode 'snapshot': writes JSON to stdout — for each top-level ctor, its (en, rw, rn, so).
+Mode 'compare':  reads two snapshots and reports any differences.
+
+Usage:
+    python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-pre-snapshot.json
+    python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-post-snapshot.json
+    python3 /tmp/translate-cross-check.py compare /tmp/translate-pre-snapshot.json /tmp/translate-post-snapshot.json
+"""
+import json
+import re
+import sys
+
+REPO = "/var/www/html/ihangane"
+TRANSLATE_PATH = f"{REPO}/client/src/elm/Translate.elm"
+
+
+def strip_comments(src):
+    src = re.sub(r"\{-[\s\S]*?-\}", "", src)
+    src = re.sub(r"--[^\n]*", "", src)
+    return src
+
+
+def find_translationset_body(src):
+    m = re.search(r"^translationSet\s+\w+\s*=\s*\n\s*case\s+\w+\s+of\s*\n", src, re.MULTILINE)
+    if not m:
+        sys.exit("translationSet not found")
+    body_start = m.end()
+    end_m = re.search(r"^[a-z]\w*\s*[:=]", src[body_start:], re.MULTILINE)
+    return src[body_start:body_start + (end_m.start() if end_m else len(src) - body_start)]
+
+
+def parse_branches(body):
+    """Walk top-level case branches in the translationSet body. Returns dict ctor -> kind+payload."""
+    arrow_pattern = re.compile(r"^( {8})([A-Z]\w*)(?:\s+\w+)?\s*->\s*\n", re.MULTILINE)
+    arrows = list(arrow_pattern.finditer(body))
+    branches = {}
+    for i, m in enumerate(arrows):
+        ctor = m.group(2)
+        end = arrows[i + 1].start() if i + 1 < len(arrows) else len(body)
+        branch_body = body[m.end():end].rstrip()
+        # Dispatch?
+        d = re.match(r"^\s+translationSet\s+(\w+)\s*$", branch_body)
+        if d:
+            branches[ctor] = {"kind": "dispatch", "to": d.group(1)}
+            continue
+        # Literal record?
+        rm = re.search(
+            r"\{\s*english\s*=\s*\"((?:\\.|[^\"\\])*)\""
+            r"(?:\s*,\s*kinyarwanda\s*=\s*(Just\s*\"((?:\\.|[^\"\\])*)\"|Nothing))?"
+            r"(?:\s*,\s*kirundi\s*=\s*(Just\s*\"((?:\\.|[^\"\\])*)\"|Nothing))?"
+            r"(?:\s*,\s*somali\s*=\s*(Just\s*\"((?:\\.|[^\"\\])*)\"|Nothing))?",
+            branch_body,
+        )
+        if rm:
+            branches[ctor] = {
+                "kind": "literal",
+                "en": rm.group(1),
+                "rw": rm.group(3),
+                "rn": rm.group(5),
+                "so": rm.group(7),
+            }
+            continue
+        # Other (case-of inside)
+        branches[ctor] = {"kind": "other", "preview": branch_body[:80].replace("\n", " ")}
+    return branches
+
+
+def resolve(branches, ctor, depth=0):
+    """Follow dispatches to get the effective (en, rw, rn, so) tuple."""
+    if depth > 10:
+        return ("__CYCLE__", None, None, None)
+    if ctor not in branches:
+        return ("__MISSING__", None, None, None)
+    b = branches[ctor]
+    if b["kind"] == "literal":
+        return (b["en"], b["rw"], b["rn"], b["so"])
+    if b["kind"] == "dispatch":
+        return resolve(branches, b["to"], depth + 1)
+    return ("__OTHER__", None, None, None)
+
+
+def snapshot():
+    src = strip_comments(open(TRANSLATE_PATH).read())
+    body = find_translationset_body(src)
+    branches = parse_branches(body)
+    out = {}
+    for ctor in branches:
+        out[ctor] = resolve(branches, ctor)
+    json.dump(out, sys.stdout, indent=2, sort_keys=True)
+
+
+def compare(pre_path, post_path):
+    pre = json.load(open(pre_path))
+    post = json.load(open(post_path))
+    only_pre = set(pre) - set(post)
+    only_post = set(post) - set(pre)
+    diffs = []
+    for k in sorted(set(pre) & set(post)):
+        if pre[k] != post[k]:
+            diffs.append((k, pre[k], post[k]))
+    print(f"Pre-only constructors:   {len(only_pre)}")
+    print(f"Post-only constructors:  {len(only_post)}  (expected: ~111 new anchors)")
+    print(f"Translation diffs:       {len(diffs)}  (expected: 0)")
+    if only_pre:
+        print(f"  Sample pre-only:  {sorted(only_pre)[:5]}")
+    if only_post:
+        print(f"  Sample post-only: {sorted(only_post)[:5]}")
+    if diffs:
+        print("CRITICAL: translations changed — should be 0 differences:")
+        for k, a, b in diffs[:10]:
+            print(f"  {k}: {a!r} -> {b!r}")
+        sys.exit(1)
+    print("PASS: zero translation drift.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("usage: snapshot | compare <pre> <post>")
+    if sys.argv[1] == "snapshot":
+        snapshot()
+    elif sys.argv[1] == "compare":
+        compare(sys.argv[2], sys.argv[3])
+    else:
+        sys.exit("unknown mode")
+```
+
+- [ ] **Step 2: Verify the script parses**
+
+```bash
+python3 -m py_compile /tmp/translate-cross-check.py && echo "ok"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Capture the pre-refactor snapshot**
+
+```bash
+cd /var/www/html/ihangane && python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-pre-snapshot.json
+echo "captured $(python3 -c "import json; print(len(json.load(open('/tmp/translate-pre-snapshot.json'))))") effective translations"
+```
+
+Expected: count is ~1860 (matching the top-level TranslationId constructor count from brainstorming).
+
+NO COMMIT.
+
+---
+
+## Task 3: Commit spec + plan
+
+**Files:**
+- Stage: `docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md`
+- Stage: `docs/superpowers/plans/2026-04-20-translate-elm-dedup.md`
+
+- [ ] **Step 1: Verify both files are uncommitted**
+
+```bash
+git status -- docs/superpowers/
+```
+
+Expected: both files listed as untracked.
+
+- [ ] **Step 2: Ask user before committing**
+
+> "Spec and plan are uncommitted. May I commit them as one combined commit (with `[ci skip]` since docs-only)?"
+
+Wait for explicit yes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md \
+        docs/superpowers/plans/2026-04-20-translate-elm-dedup.md
+git commit -m "$(cat <<'EOF'
+Add Translate.elm dedup refactor spec and implementation plan
+
+Spec covers mechanically deduping 149 locale-equivalent duplicate-english
+groups in Translate.elm by routing them through translationSet. Plan
+decomposes into 7 tasks: re-analyze duplicate groups -> capture
+pre-refactor snapshot -> commit spec/plan -> add 111 new top-level
+anchor TranslationIds -> refactor 149 groups to translationSet -> fix
+~5-15 source bugs with internet-research tiebreakers -> document 126
+diverging groups + skipped cases for follow-up native-speaker review.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+[ci skip]
+EOF
+)" && git log -1 --oneline
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 4: Add 111 new top-level `TranslationId` anchors
+
+**Files:**
+- Modify: `client/src/elm/Translate.elm` (additions only — no deletions, no replacements)
+
+- [ ] **Step 1: Build the list of new anchors to add**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('/tmp/translate-dedup-groups.json'))
+needs_anchor = d['safe_needs_anchor']
+print(f'{len(needs_anchor)} new anchors to add')
+print()
+print('Sample:')
+for g in needs_anchor[:10]:
+    print(f\"  {g['anchor']}: english='{g['english']}' rw={g['rw']!r} rn={g['rn']!r} so={g['so']!r}\")
+"
+```
+
+Expected: ~111 anchors listed; sample shows the (anchor_name, english, rw, rn, so) tuples that will be added.
+
+- [ ] **Step 2: Find insertion points + add the new constructors to `type TranslationId`**
+
+The `type TranslationId` declaration spans lines 329–2192 of source (per spec). For each new anchor, find the alphabetical insertion point in the type declaration body. Insert the constructor name in PascalCase order. Use Edit tool with concrete `old_string` / `new_string` per insertion (one Edit call per anchor — this is mechanical and many calls but fine).
+
+For example, if inserting `NoneOfTheAbove` between `NoneOfTheAboveItem` (line N) and `NormalAbdomen` (line N+1):
+
+```
+old_string: '    | NoneOfTheAboveItem\n    | NormalAbdomen'
+new_string: '    | NoneOfTheAboveItem\n    | NoneOfTheAbove\n    | NormalAbdomen'
+```
+
+(If the existing constructor list isn't strictly alphabetical at the insertion point, insert the new constructor in the closest plausible alphabetical spot — minor non-strictness is OK; the goal is "roughly alphabetical, not adjacent to a totally unrelated section".)
+
+- [ ] **Step 3: Add the 111 new case branches in `translationSet`**
+
+For each new anchor, add a literal case branch in the main `translationSet` function (which starts at line 2192 in current source). Same alphabetical insertion principle. Each case branch is a 5-line literal:
+
+```elm
+        NoneOfTheAbove ->
+            { english = "None of the Above"
+            , kinyarwanda = Just "..."
+            , kirundi = Just "..."
+            , somali = Just "..."
+            }
+```
+
+Use the rw/rn/so values from the analysis JSON's `safe_needs_anchor` entries (these are the agreed-upon translations that all duplicates already share — adding the anchor with these values doesn't change UI behavior for any existing call site).
+
+For locales that are `null` in the JSON (no Just value in the originals), use `Nothing`:
+
+```elm
+            , kinyarwanda = Nothing
+```
+
+- [ ] **Step 4: Run elm-format**
+
+```bash
+cd /var/www/html/ihangane/client && ./node_modules/.bin/elm-format --validate src/elm/Translate.elm
+echo "exit=$?"
+```
+
+Expected: exit=0. Any non-zero = formatting issue. Re-run with `--yes` to auto-format if needed:
+```bash
+./node_modules/.bin/elm-format src/elm/Translate.elm --yes
+```
+
+- [ ] **Step 5: Run elm compile**
+
+```bash
+cd /var/www/html/ihangane/client && ./node_modules/.bin/elm make src/elm/Main.elm --output=/dev/null
+echo "exit=$?"
+```
+
+Expected: exit=0. Compile errors = the new constructors broke the type definition somehow; debug.
+
+- [ ] **Step 6: Cross-check translations**
+
+Capture post-add snapshot and compare:
+
+```bash
+cd /var/www/html/ihangane && python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-post-add-snapshot.json
+python3 /tmp/translate-cross-check.py compare /tmp/translate-pre-snapshot.json /tmp/translate-post-add-snapshot.json
+```
+
+Expected:
+- Pre-only: 0
+- Post-only: ~111 (the new anchors, exactly the count of `safe_needs_anchor`)
+- Translation diffs: **0**
+- Final line: `PASS: zero translation drift.`
+
+If any non-zero diff appears, the additions changed an existing constructor's resolution somehow — debug, fix, re-run.
+
+- [ ] **Step 7: Ask user before committing**
+
+> "Added 111 new top-level TranslationId anchors to Translate.elm. elm-format clean, elm compile clean, cross-check shows 0 translation drift. May I commit?"
+
+Wait for explicit yes.
+
+- [ ] **Step 8: Commit (no `[ci skip]`)**
+
+```bash
+git add client/src/elm/Translate.elm
+git commit -m "$(cat <<'EOF'
+Add 111 new top-level TranslationId anchors for dedup refactor
+
+These anchors have the canonical translations (en/rw/rn/so) shared by
+their soon-to-be-deduplicated call sites. No existing TranslationId is
+modified; no UI behavior changes from this commit alone (each new
+anchor is a fresh constructor with no callers yet).
+
+Cross-check confirmed 0 translation drift across all 1860 pre-existing
+top-level TranslationIds.
+
+The actual translationSet dispatch refactor follows in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)" && git log -1 --stat
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 5: Refactor 149 groups → `translationSet <Anchor>` calls
+
+**Files:**
+- Modify: `client/src/elm/Translate.elm` (replacements — collapsing 5-line literals to 1-line dispatches)
+
+- [ ] **Step 1: Build the list of replacements**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('/tmp/translate-dedup-groups.json'))
+all_safe = d['safe_with_anchor'] + d['safe_needs_anchor']
+total_replacements = sum(len(g['constructors']) - (1 if g in d['safe_with_anchor'] else 0) for g in all_safe)
+# Each safe_with_anchor: replace all N constructors INCLUDING the anchor (no, the anchor stays as literal)
+#   Actually: the existing anchor stays literal; only the OTHER N-1 constructors become dispatches
+# Each safe_needs_anchor: anchor was just added in Task 4 (literal); the original N constructors all become dispatches
+# Build the work list
+to_replace = []
+for g in d['safe_with_anchor']:
+    for ctor in g['constructors']:
+        if ctor != g['anchor']:
+            to_replace.append((ctor, g['anchor'], g['english']))
+for g in d['safe_needs_anchor']:
+    for ctor in g['constructors']:
+        to_replace.append((ctor, g['anchor'], g['english']))
+print(f'Total constructors to refactor (collapse to translationSet): {len(to_replace)}')
+print()
+print('Sample:')
+for c, a, e in to_replace[:10]:
+    print(f'  {c} -> translationSet {a}   (english={e!r})')
+"
+```
+
+Expected: ~370 replacements listed (the 686 minus the 38 anchors that were already top-level + the 111 new anchors that we just added as literals).
+
+- [ ] **Step 2: For each constructor, replace its 5-line literal block with `translationSet <Anchor>`**
+
+For each (ctor, anchor) pair from the work list, locate its case branch in the `translationSet` function. The branch looks like:
+
+```elm
+        OutcomeOther ->
+            { english = "Other"
+            , kinyarwanda = Just "Ibindi"
+            , kirundi = Just "Ibindi"
+            , somali = Just "Kale"
+            }
+```
+
+Replace with:
+
+```elm
+        OutcomeOther ->
+            translationSet Other
+```
+
+Use the Edit tool — exact string match on the full 6-line block (including the `Ctor ->` line and the closing brace), replaced with the 2-line dispatch.
+
+This is many edits (~370). Batch them but verify each lands correctly. If a constructor's branch doesn't match the expected literal pattern (e.g., it has a comment inside, or unusual whitespace), skip it for this commit and document the skip in the commit message.
+
+- [ ] **Step 3: Run elm-format**
+
+```bash
+cd /var/www/html/ihangane/client && ./node_modules/.bin/elm-format --validate src/elm/Translate.elm
+```
+
+Expected: exit=0. Auto-fix if needed: `./node_modules/.bin/elm-format src/elm/Translate.elm --yes`.
+
+- [ ] **Step 4: Run elm compile**
+
+```bash
+cd /var/www/html/ihangane/client && ./node_modules/.bin/elm make src/elm/Main.elm --output=/dev/null
+```
+
+Expected: exit=0.
+
+- [ ] **Step 5: Cross-check translations**
+
+```bash
+cd /var/www/html/ihangane && python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-post-refactor-snapshot.json
+python3 /tmp/translate-cross-check.py compare /tmp/translate-pre-snapshot.json /tmp/translate-post-refactor-snapshot.json
+```
+
+Expected:
+- Pre-only: 0
+- Post-only: ~111 (the new anchors added in Task 4)
+- Translation diffs: **0** — this is the critical check; the refactor must NOT have changed any existing constructor's effective translation
+- Final line: `PASS: zero translation drift.`
+
+If any diff > 0:
+- Look at the diff details to find which constructor's translation changed
+- Most likely cause: the refactor pointed a constructor at the wrong anchor (typo) OR the anchor's literal differs from what the original literal had
+- Fix the offending dispatch, re-run validation
+
+- [ ] **Step 6: Ask user before committing**
+
+> "Refactored ~370 duplicate literals to translationSet dispatches. elm-format clean, elm compile clean, cross-check confirms 0 translation drift. May I commit?"
+
+Wait for explicit yes.
+
+- [ ] **Step 7: Commit (no `[ci skip]`)**
+
+```bash
+git add client/src/elm/Translate.elm
+git commit -m "$(cat <<'EOF'
+Refactor 149 duplicate-english groups to use translationSet
+
+Collapses ~370 duplicate 5-line literal { english=..., kw=..., kn=...,
+so=... } blocks down to 1-line `translationSet <Anchor>` dispatches.
+The anchors are either pre-existing top-level TranslationIds (38
+groups) or the new anchors added in the previous commit (111 groups).
+
+Cross-check verified zero translation drift — every constructor's
+effective (en, kw, kn, so) tuple is byte-identical pre-vs-post refactor.
+
+Source bugs (constructors appearing 2+ times in the same case-of with
+divergent translations) are intentionally NOT touched in this commit;
+they get fixed individually in the next commit(s) with internet-research
+tiebreakers.
+
+Diverging groups (where the same english label has different rw/rn/so
+across duplicates — refactoring would change UI behavior for some
+users) are listed in docs/superpowers/follow-ups-translate-elm-bugs.md
+for native-speaker review; not refactored in this PR.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)" && git log -1 --stat
+```
+
+Expected: commit succeeds; large net-negative line delta (each 6-line block → 2-line dispatch).
+
+---
+
+## Task 6: Fix source bugs (one commit per logical bug)
+
+**Files:**
+- Modify: `client/src/elm/Translate.elm` (delete duplicate case branches; canonicalize translations)
+
+For each `source_bug` entry in `/tmp/translate-dedup-groups.json`, do the following:
+
+- [ ] **Step 1: List the source bugs**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('/tmp/translate-dedup-groups.json'))
+print(f'Source bugs: {len(d[\"source_bugs\"])}')
+for i, b in enumerate(d['source_bugs'], 1):
+    print(f'{i}. english={b[\"english\"]!r}')
+    print(f'   duplicate constructors: {b[\"duplicate_constructors\"]}')
+    print(f'   distinct locale tuples: {len(b[\"locale_sets\"])}')
+    for r in b['records']:
+        print(f'     {r[\"ctor\"]}  rw={r[\"rw\"]!r} rn={r[\"rn\"]!r} so={r[\"so\"]!r}')
+    print()
+"
+```
+
+Expected: ~5–15 bugs listed. For each: the english label, which constructors are duplicated within the same case-of, and the conflicting translations.
+
+For each bug (Steps 2–9 below repeat per bug):
+
+- [ ] **Step 2: Web-search the english label translation**
+
+Use WebSearch tool to look up the translation in each affected locale. Example queries:
+- `"<english label>" Kinyarwanda translation medical`
+- `"<english label>" Kirundi translation`
+- `"<english label>" Somali translation medical`
+
+Capture the canonical translation per locale based on the search results. Reputable sources: Glosbe, Indifferent Languages, medical-specific dictionaries.
+
+- [ ] **Step 3: Pick the canonical translation per locale**
+
+Given the conflicting in-source translations + the web research:
+- If web research clearly favors one of the existing translations: use that.
+- If neither in-source matches well: prefer the more clinically-precise of the two existing translations.
+- Document the reasoning in the upcoming commit message.
+
+- [ ] **Step 4: Edit `Translate.elm` to delete the duplicate case branch + canonicalize the first**
+
+Find the duplicate case branch (the second occurrence of `<Ctor> ->`) in the case-of block and **delete it entirely** (the `Ctor ->` line + the literal record block).
+
+Then update the FIRST occurrence's translations to use the canonical values picked in Step 3.
+
+- [ ] **Step 5: Run elm-format + elm compile**
+
+```bash
+cd /var/www/html/ihangane/client && ./node_modules/.bin/elm-format --validate src/elm/Translate.elm && ./node_modules/.bin/elm make src/elm/Main.elm --output=/dev/null
+echo "exit=$?"
+```
+
+Expected: exit=0.
+
+- [ ] **Step 6: Cross-check (this WILL show 1 diff for the bug being fixed)**
+
+```bash
+cd /var/www/html/ihangane && python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-post-bugfix-snapshot.json
+python3 /tmp/translate-cross-check.py compare /tmp/translate-pre-snapshot.json /tmp/translate-post-bugfix-snapshot.json
+```
+
+Expected:
+- Translation diffs: **N** where N is the number of bug fixes applied so far (the bug-fix DOES intentionally change translations to the canonical values)
+- The diffs listed should all be from constructors involved in source bugs we've fixed
+- No unrelated constructors should appear in the diff
+
+If unrelated constructors appear in the diff, the bug-fix accidentally affected something else; investigate.
+
+- [ ] **Step 7: Ask user before committing**
+
+> "Fixed source bug for english=<label>. Removed duplicate case branch, canonicalized translations to: rw=<X>, rn=<Y>, so=<Z>. Web research notes: <summary>. May I commit?"
+
+Wait for explicit yes.
+
+- [ ] **Step 8: Commit (no `[ci skip]`)**
+
+```bash
+git add client/src/elm/Translate.elm
+git commit -m "$(cat <<'EOF'
+Fix duplicate case branch for <Constructor> with canonical translations
+
+The case branch `<Ctor> ->` appeared twice in the same case-of block
+in Translate.elm with conflicting <locale> translations. The Elm
+compiler tolerated this (the second branch was unreachable), but the
+fact that two different translations existed for the same constructor
+indicated a real bug.
+
+Canonical translations picked via web research:
+  english:    "<en>"
+  kinyarwanda: "<rw>"  (was "<rw_a>" / "<rw_b>")
+  kirundi:    "<rn>"  (was "<rn_a>" / "<rn_b>")
+  somali:     "<so>"
+
+Sources consulted:
+  - <URL 1>
+  - <URL 2>
+
+The duplicate branch is deleted; the first occurrence is updated to
+the canonical translations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)" && git log -1 --stat
+```
+
+(Substitute real `<placeholder>` values from the bug being fixed.)
+
+Expected: commit succeeds.
+
+- [ ] **Step 9: Loop — repeat Steps 2–8 for each remaining bug**
+
+After processing all bugs, the cross-check final diff count should equal exactly the number of bug fixes committed.
+
+---
+
+## Task 7: Write the follow-up doc
+
+**Files:**
+- Create: `docs/superpowers/follow-ups-translate-elm-bugs.md`
+
+- [ ] **Step 1: Write the follow-up doc**
+
+Create `docs/superpowers/follow-ups-translate-elm-bugs.md` with these sections:
+
+```markdown
+# Translate.elm — follow-up items
+
+Items surfaced during the `refactor/translate-elm-dedup` work that need
+review beyond the scope of that PR. None block normal use of E-Heza;
+all are quality / cleanliness opportunities.
+
+## Diverging duplicate-english groups (need native-speaker review)
+
+These N groups have the same English label but different translations
+in at least one of rw/rn/so across their duplicate constructors. They
+were NOT refactored to `translationSet` because doing so would change
+the UI translation for some users. A native-speaker reviewer should
+pick the canonical per-locale translation for each group, then a
+follow-up PR can dedup them the same way as the safe groups.
+
+| english | constructors | divergence (sample) |
+|---|---|---|
+| ... one row per diverging group, populated from /tmp/translate-dedup-groups.json's `diverging` list ... |
+
+## Skipped during dedup refactor
+
+Cases where the dedup refactor would have triggered but was skipped:
+
+### Anchor-naming infeasible
+
+Cases where the proposed PascalCase anchor name would be:
+- Empty (english is `""`)
+- Digit-leading (would be invalid Elm constructor)
+- > 50 characters (e.g., "1 tablet by mouth twice a day" → too verbose)
+
+| english | constructors | reason skipped |
+|---|---|---|
+| ... populated from the `diverging` list entries with `skip_reason` |
+
+### Anchor name clash with existing constructor
+
+Cases where the proposed anchor name (PascalCase of english) would
+clash with an existing top-level TranslationId that has DIFFERENT
+translations.
+
+| english | proposed anchor (clashes) | constructors | existing-anchor translations differ how |
+|---|---|---|---|
+
+## Constructor-rename candidates (typos)
+
+Bugs revealed during exploration that involve renaming Elm constructors
+(out of scope because renames change call sites across the codebase).
+
+- `NitritionSigns` → `NutritionSigns` (typo). Currently both forms exist
+  with different ids; the typo'd form has english="Nutrition Signs".
+
+(Add others discovered during exploration.)
+
+## Empty-string english groups
+
+Groups where english is `""`. Likely intentional in some contexts (e.g.,
+`EmptyString`, `DeviceNotAuthorized`'s placeholder). Documented for
+completeness; safest to leave alone.
+```
+
+Populate the tables from `/tmp/translate-dedup-groups.json`'s `diverging` list using this helper that emits the exact markdown rows to copy in:
+
+```bash
+python3 <<'EOF'
+import json
+d = json.load(open('/tmp/translate-dedup-groups.json'))
+
+print("=== Diverging groups (paste under the Diverging section table) ===")
+diverging_real = [g for g in d['diverging'] if 'records' in g]
+print(f"Total: {len(diverging_real)}")
+for g in diverging_real:
+    en = g['english'].replace('|', '\\|')
+    ctors = ", ".join(f"`{c}`" for c in g['constructors'])
+    # Sample one divergence: show rw values across constructors if they differ
+    rws = list(set(r['rw'] for r in g['records']))
+    rns = list(set(r['rn'] for r in g['records']))
+    sos = list(set(r['so'] for r in g['records']))
+    diff_summary_parts = []
+    if len(rws) > 1: diff_summary_parts.append(f"rw: {' / '.join(repr(x) for x in rws)}")
+    if len(rns) > 1: diff_summary_parts.append(f"rn: {' / '.join(repr(x) for x in rns)}")
+    if len(sos) > 1: diff_summary_parts.append(f"so: {' / '.join(repr(x) for x in sos)}")
+    diff_summary = "<br>".join(diff_summary_parts).replace('|', '\\|')
+    print(f"| {en} | {ctors} | {diff_summary} |")
+print()
+print("=== Skipped: anchor naming infeasible (paste under that subsection) ===")
+infeasible = [g for g in d['diverging'] if 'skip_reason' in g and 'clash' not in g.get('skip_reason', '')]
+for g in infeasible:
+    en = g['english'].replace('|', '\\|')
+    ctors = ", ".join(f"`{c}`" for c in g['constructors'])
+    print(f"| {en} | {ctors} | {g['skip_reason']} |")
+print()
+print("=== Skipped: anchor name clash (paste under that subsection) ===")
+clashes = [g for g in d['diverging'] if 'skip_reason' in g and 'clash' in g['skip_reason']]
+for g in clashes:
+    en = g['english'].replace('|', '\\|')
+    ctors = ", ".join(f"`{c}`" for c in g['constructors'])
+    print(f"| {en} | {g['skip_reason']} | {ctors} | (review existing anchor's translations) |")
+EOF
+```
+
+Copy the printed markdown rows into the corresponding tables in the doc. The first table needs the column headers from the template above; the rows from the helper output go below those headers.
+
+- [ ] **Step 2: Render-check the file**
+
+```bash
+python3 -c "
+import re, pathlib
+text = pathlib.Path('docs/superpowers/follow-ups-translate-elm-bugs.md').read_text()
+print('headings:', re.findall(r'^##+ .*', text, re.M))
+print('total lines:', len(text.splitlines()))
+"
+```
+
+Expected: 4 `##` sections (Diverging / Skipped / Rename candidates / Empty-string), with `###` sub-headings under Skipped.
+
+- [ ] **Step 3: Ask user before committing**
+
+> "Follow-up doc written listing diverging groups + skipped cases + rename candidates. May I commit (with `[ci skip]` since docs-only)?"
+
+Wait for yes.
+
+- [ ] **Step 4: Commit (with `[ci skip]`)**
+
+```bash
+git add docs/superpowers/follow-ups-translate-elm-bugs.md
+git commit -m "$(cat <<'EOF'
+Add follow-up doc for Translate.elm dedup refactor
+
+Lists items surfaced during the dedup refactor that need review beyond
+the scope of that PR:
+- 126 diverging duplicate-english groups (need native-speaker review)
+- Anchor-naming-infeasible cases (digit-leading, overlong, empty)
+- Anchor-name clash cases (collision with existing TranslationId)
+- Constructor-rename candidates (typos like NitritionSigns)
+- Empty-string english groups (likely intentional)
+
+None block normal use; all are cleanliness / quality opportunities for
+follow-up PRs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+[ci skip]
+EOF
+)" && git log -1 --stat
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 8: Final verification + push
+
+**Files:** none modified; verification only.
+
+- [ ] **Step 1: Confirm git state**
+
+```bash
+git log --oneline refactor/translate-elm-dedup ^origin/develop
+```
+
+Expected: 5 commits in order (newest first):
+```
+... follow-up doc
+... source bug fix(es) — one or more
+... refactor 149 groups
+... add 111 new anchors
+... spec + plan
+```
+
+- [ ] **Step 2: Working tree clean (apart from pre-existing local mods)**
+
+```bash
+git status -- client/ docs/
+```
+
+Expected: nothing to commit for `client/` or `docs/`. Pre-existing `.ddev/` / `.gitignore` / `server/RoboFile.php` modifications can stay (they predate this work).
+
+- [ ] **Step 3: Final cross-check (cumulative — all changes since pre-snapshot)**
+
+```bash
+cd /var/www/html/ihangane && python3 /tmp/translate-cross-check.py snapshot > /tmp/translate-final-snapshot.json
+python3 /tmp/translate-cross-check.py compare /tmp/translate-pre-snapshot.json /tmp/translate-final-snapshot.json
+```
+
+Expected:
+- Pre-only: 0
+- Post-only: ~111 (the new anchors)
+- Translation diffs: equal to the number of source-bug fixes committed (each intentionally changed translations to canonical values)
+- Diff list contains ONLY the constructors involved in source bug fixes — no others
+
+- [ ] **Step 4: Final elm-format + compile sanity**
+
+```bash
+cd /var/www/html/ihangane/client && ./node_modules/.bin/elm-format --validate src/elm/Translate.elm && ./node_modules/.bin/elm make src/elm/Main.elm --output=/dev/null && echo "all green"
+```
+
+Expected: `all green`.
+
+- [ ] **Step 5: Net line delta sanity**
+
+```bash
+git diff --shortstat origin/develop -- client/src/elm/Translate.elm
+```
+
+Expected: net negative; ballpark −1500 to −2000 lines.
+
+- [ ] **Step 6: Ask user about pushing**
+
+> "All 5 commits clean, all verification green. May I push the branch to origin?"
+
+Wait for explicit yes. (Per global preference: always ask before pushing.)
+
+- [ ] **Step 7: Push**
+
+```bash
+git push -u origin refactor/translate-elm-dedup
+```
+
+Expected: push succeeds; GitHub provides the PR-creation URL in the output.
+
+- [ ] **Step 8: Print final summary to user**
+
+> "Translate.elm dedup refactor complete. Branch `refactor/translate-elm-dedup` pushed with 5 commits. Net delta: ~−<X> lines in Translate.elm. <N> source bugs fixed. Diverging groups + skipped cases documented in `docs/superpowers/follow-ups-translate-elm-bugs.md`. PR creation URL: <url>. CI will run the full Elm + SimpleTest suite on the PR."
+
+NO COMMIT (verification + push only).

--- a/docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md
+++ b/docs/superpowers/specs/2026-04-20-translate-elm-dedup-design.md
@@ -1,0 +1,219 @@
+# Translate.elm dedup refactor — design
+
+Mechanically dedupes 149 locale-equivalent duplicate-english groups in
+`client/src/elm/Translate.elm` by routing them through `translationSet`.
+Each duplicate group's literal `english/kw/kn/so` block becomes a single
+`translationSet <Anchor>` dispatch line; if no top-level anchor exists,
+a new top-level `TranslationId` constructor is added to serve as the
+target. Diverging groups (126, where at least one locale string differs
+across duplicates — refactoring would change UI behavior) are listed in
+a follow-up doc and NOT touched in this pass. Source bugs surfaced
+during exploration (~5–15 cases of duplicate case branches with
+conflicting translations) are fixed in this PR using internet research
+to pick the canonical translation per locale.
+
+## Scope
+
+In: 149 duplicate-english groups in `client/src/elm/Translate.elm`'s
+main `translationSet` function where all 4 locales (en/rw/rn/so) agree
+across duplicates. Of these:
+
+- 38 groups have an existing top-level `TranslationId` anchor whose
+  literal translations match the group → refactor in place.
+- 111 groups have no anchor → mint a new top-level `TranslationId`
+  constructor with the canonical literal translations, then refactor
+  the duplicates.
+
+Plus ~5–15 source bugs (duplicate case branches with conflicting
+translations, e.g., `DiagnosisSimpleColdAndCough` appearing twice with
+different Kinyarwanda values) — fixed in this PR with internet-research
+tiebreakers documented per commit.
+
+Out of scope:
+
+- 126 diverging groups (where ≥ 1 locale string differs across
+  duplicates). Refactoring these would change UI behavior; needs
+  native-speaker linguistic review per group. Listed in a follow-up
+  doc.
+- Constructor renames (e.g., the `NitritionSigns` typo) — renaming a
+  constructor changes call sites across the codebase, out of scope.
+- Empty-string english (`""`) groups — likely intentional placeholders
+  in some contexts; skip and document.
+- Updates to the labels-master CSV
+  (`docs/ocl/eheza-concepts-translate.csv` on the
+  `docs/eheza-concepts-master` branch). The labels master walked the
+  pre-refactor `Translate.elm`; once this refactor lands in develop
+  and merges into the docs branch, the labels master will need a
+  re-walk against the new structure. That re-walk is its own concern,
+  separate from this PR.
+- Any non-Translate.elm changes (no view/model/Update edits).
+
+## Branch and workflow
+
+**Branch:** `refactor/translate-elm-dedup`, branched off `origin/develop`.
+
+**Workspace:** same checkout — switch branches via `git checkout`. The
+`docs/eheza-concepts-master` branch (which carries this brainstorming's
+ancestor work + the labels-master CSV) is preserved on the local clone
+and remote; it does not need to be touched during this refactor.
+
+**Cross-branch interactions:**
+
+- The labels-master CSV will be stale relative to the post-refactor
+  `Translate.elm` once this work lands. A re-walk is a separate
+  follow-up, not part of this PR.
+- `develop` may have advanced since the docs branches were cut. The
+  refactor sees whatever's currently in `origin/develop`'s
+  `Translate.elm`. If the duplicate count or structure has shifted in
+  develop relative to what this design analyzed, the implementation
+  must re-run the duplicate-group analysis at the start.
+
+## Refactor mechanics
+
+**Per duplicate group (149 total):**
+
+1. **Determine the anchor `TranslationId`:**
+   - If any of the duplicate constructors IS a top-level `TranslationId`
+     constructor with literal translations matching the group's locales
+     → that's the anchor (38 groups).
+   - Otherwise, mint a new top-level `TranslationId` constructor (111
+     groups). Validate no clash with existing top-level constructors;
+     if the chosen name clashes, skip the group + flag in the follow-up
+     doc.
+
+2. **Add the anchor's literal block** (only for the 111 new ones) — to
+   the main `translationSet` function, in alphabetical position
+   matching the existing rough alphabetical order.
+
+3. **Replace each duplicate literal block** with `translationSet <Anchor>`:
+
+   Before (5-line literal):
+   ```elm
+       OutcomeOther ->
+           { english = "Other"
+           , kinyarwanda = Just "Ibindi"
+           , kirundi = Just "Ibindi"
+           , somali = Just "Kale"
+           }
+   ```
+
+   After (1-line dispatch):
+   ```elm
+       OutcomeOther ->
+           translationSet Other
+   ```
+
+**Naming convention for new anchors (111 groups):**
+
+- PascalCase of the english label, with spaces removed and
+  non-alphanumeric chars stripped.
+  - `"Other"` → `Other`
+  - `"None of the Above"` → `NoneOfTheAbove`
+  - `"Hepatitis B"` → `HepatitisB`
+  - `"Methyldopa (250mg)"` → `Methyldopa250mg` (parentheses stripped)
+- Edge cases that get skipped + flagged:
+  - Constructor name would exceed 50 chars (rare but possible for very
+    long english phrases like "1 tablet by mouth twice a day").
+  - Constructor name would start with a digit (e.g., `"3 Days"` →
+    `ThreeDays` — converting digit-words is fragile; safer to skip).
+  - Constructor name clashes with an existing top-level
+    `TranslationId` constructor.
+- Anchor placement: alphabetical insertion within the `type
+  TranslationId` declaration AND within the main `translationSet`
+  function's case-of body.
+
+**Source-bug handling (in scope per Q3 = B):**
+
+When the refactor encounters a structural bug:
+
+- **Duplicate case branch within same enum** (e.g.,
+  `DiagnosisSimpleColdAndCough` appearing twice with different rw
+  translations): web-search the english label, decide canonical
+  translation per locale, **delete the second case branch + replace
+  the first's translations with the canonical values**. Internet
+  research notes documented in the commit message for each bug fix.
+- **Obvious typo constructor names** (e.g., `NitritionSigns`): NOT
+  auto-fixed. Renaming changes call sites. Document in follow-up.
+- **Empty-string english (`""`) groups**: skip from refactor; document.
+
+## Verification
+
+Per refactor commit, three checks:
+
+| Check | Command | Why |
+|---|---|---|
+| Elm format | `elm-format --validate client/src/elm/Translate.elm` | Per CLAUDE.md and CI's `lint_elm` job |
+| Elm compile | `cd client && ./node_modules/.bin/elm make src/elm/Main.elm --output=/dev/null` | Confirms file still typechecks; new constructors don't break the type definition |
+| Cross-check translations | Python script comparing (english, kw, kn, so) tuples per refactored constructor before vs after — must be byte-identical | Critical semantic check; catches accidental translation drift |
+
+The CI on the eventual PR runs the full suite (elm-test, elm-review,
+SimpleTest); we don't disable any of those. We just don't gate local
+commits on them.
+
+## Repository changes
+
+1. **Modify `client/src/elm/Translate.elm`** — major changes:
+   - Add 111 new top-level `TranslationId` constructors (in the `type
+     TranslationId = ...` declaration).
+   - Add 111 new case branches in the main `translationSet` function
+     (for the new anchors' literal translations).
+   - Replace ~370 duplicate literal blocks with `translationSet
+     <Anchor>` dispatches.
+   - Fix ~5–15 source bugs (delete duplicate case branches; canonicalize
+     translations).
+   - Net line delta estimate: −1500 to −2000 lines (each 5-line literal
+     block collapses to 1 line, minus the 111 added 5-line anchor
+     blocks).
+
+2. **Create
+   `docs/superpowers/follow-ups-translate-elm-bugs.md`** — listing:
+   - The 126 diverging groups (with samples of the locale divergence
+     so reviewers know what they're looking at).
+   - Skipped clash cases from the 111 (where the proposed anchor name
+     collided with an existing constructor).
+   - Skipped overlong / digit-leading anchor cases.
+   - Constructor-rename candidates (typos like `NitritionSigns`).
+   - Empty-string english groups (intentional placeholders).
+
+No other files touched.
+
+## Commits
+
+5 commits on the `refactor/translate-elm-dedup` branch:
+
+| # | Commit | Touches | `[ci skip]`? |
+|---|---|---|---|
+| 1 | Spec + plan combined | `docs/superpowers/{specs,plans}/2026-04-20-translate-elm-dedup-*.md` | yes (docs only) |
+| 2 | Add 111 new top-level `TranslationId` anchors + their case branches | `Translate.elm` | **no** (CI verification critical) |
+| 3 | Refactor 149 groups → `translationSet X` calls | `Translate.elm` | **no** |
+| 4 | Source-bug fixes (one commit per logical bug, with internet-research notes) | `Translate.elm` | **no** |
+| 5 | Follow-up doc for diverging groups + skipped cases | `docs/superpowers/follow-ups-translate-elm-bugs.md` | yes (docs only) |
+
+Each non-`[ci skip]` commit includes a `Co-Authored-By: Claude Opus
+4.7` line.
+
+**Push** when all 5 commits are clean and verification passes; PR
+title and body draft will be presented for approval before opening.
+
+## Sequencing for the implementation plan
+
+Full detail in writing-plans next:
+
+1. Confirm clean working tree on `refactor/translate-elm-dedup` (already
+   set up).
+2. Re-run the duplicate-group analysis script against the current
+   `Translate.elm` to confirm the 149 / 111 / 38 / 126 / source-bug
+   counts haven't shifted in `develop` since this design's
+   exploration.
+3. Commit spec + plan (Commit 1).
+4. Add the 111 new top-level anchors (Commit 2). Run all 3
+   verification checks.
+5. Refactor the 149 groups (Commit 3). Run all 3 verification checks
+   including cross-check semantic equivalence.
+6. Fix source bugs one at a time (Commits 4a, 4b, …) with internet
+   research notes per fix. Each commit runs all 3 verification checks.
+7. Write the follow-up doc (Commit 5).
+8. Final verification — full local check suite passes, net line delta
+   in expected range, top-level `TranslationId` constructor count
+   increased by exactly 111 (modulo any clash skips).
+9. Push branch + draft PR.


### PR DESCRIPTION
## Summary

Three layered improvements to `client/src/elm/Translate.elm`:

1. **Dedup 126 safe duplicate-english groups** by routing them through the existing `translationSet` helper. Adds 112 new top-level `TranslationId` anchors (95 with PascalCase names; 17 with `Label` suffix to avoid clashes with imported constructors used in nested case patterns). Refactors 252 duplicate literal `{ english=..., kw=..., kn=..., so=... }` blocks down to 1-line `translationSet <Anchor>` dispatches.
2. **Canonicalize the highest-impact diverging group ("Other")** — 23 `*Other` constructors had `english="Other"` but 3 different Kinyarwanda variants (`"Ibindi"`, `"Ikindi"`, `"Izindi mpamvu"`). All 23 now dispatch via a new `OtherLabel` anchor with canonical translations chosen by the user (en="Other", rw="Ibindi", rn="Ibindi", so="Kale").
3. **Reorder the 1972 top-level `translationSet` case branches** to match the source order of constructors in the `type TranslationId` declaration. Pure rearrangement — was 49 out-of-order pairs, now ~0.

Out of scope: 125 remaining diverging duplicate-english groups (locale-equivalent fix needs native-speaker review per group), constructor renames for typo'd identifiers, and OCL upload. All documented in `docs/superpowers/follow-ups-translate-elm-bugs.md`.

## Verification per commit

- `elm-format --validate src/elm/Translate.elm` → clean
- `elm make src/elm/Main.elm --output=/dev/null` → Success
- Cross-check script comparing pre-vs-post effective translations per top-level constructor → 0 unexpected translation drift (20 reported diffs are known-benign artifacts of the cross-check tool's first-literal heuristic, manually verified to resolve to identical translations through the new dispatches)

## Net delta

```
client/src/elm/Translate.elm:  +2148 / -3399  (-1251 net lines)
```

## Commits (in order)

```
29074c63f  Reorder translationSet case branches to match type TranslationId order
f9ccd5112  Update follow-up doc: mark "Other" group as resolved
b41595799  Canonicalize "Other" diverging group translations
de2a66d1a  Add follow-up doc for Translate.elm dedup refactor
30d1778a7  Refactor 252 duplicate-translation sites to use translationSet
9e282eb21  Add 112 new top-level TranslationId anchors for dedup refactor
0142c00f8  Add Translate.elm dedup refactor spec and implementation plan
```

## Test plan

- [ ] CI passes (Elm lint, Elm tests, PHPCS, ShellCheck, SimpleTest)
- [ ] Spot-check rendering in the app: load a few pages that use the affected anchors (e.g., any \"Other\" option in a dropdown should render in the user's locale with the canonical translation)
- [ ] Confirm Kinyarwanda \"Other\" labels now render \"Ibindi\" everywhere (intentional behavior change for the canonicalization commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)