### PR TITLE
E2E: feature-flag toggle verification across all SiteFeature flags

### DIFF
--- a/client/e2e/acute-illness-encounter-chw.spec.ts
+++ b/client/e2e/acute-illness-encounter-chw.spec.ts
@@ -7,6 +7,7 @@ import {
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { WAIT, syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultAndStartEncounter,
   completeSymptoms,
@@ -38,6 +39,8 @@ test.describe('CHW: Acute Illness Initial Encounter — Uncomplicated Pneumonia'
   });
 
   test('complete CHW initial encounter with respiratory symptoms, verify backend sync', async ({ page }) => {
+    // Verify FeatureAcuteIllness flag gates the "Acute Illness" button.
+    await verifyFeatureGatesEncounterButton(page, 'acute_illness', 'Acute Illness');
 
     const { fullName } = await createAdultAndStartEncounter(page, {
       isChw: true,

--- a/client/e2e/acute-illness-encounter-nurse.spec.ts
+++ b/client/e2e/acute-illness-encounter-nurse.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { WAIT, syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultAndStartEncounter,
   createChildAndStartEncounter,
@@ -36,6 +37,8 @@ test.describe('Nurse: Acute Illness Initial + Subsequent Encounter — Malaria U
   });
 
   test('complete initial and subsequent encounters, verify backend sync', async ({ page }) => {
+    // Verify FeatureAcuteIllness flag gates the "Acute Illness" button.
+    await verifyFeatureGatesEncounterButton(page, 'acute_illness', 'Acute Illness');
 
     // =====================================================================
     // PART 1: Nurse Initial Encounter — Malaria Uncomplicated

--- a/client/e2e/child-scoreboard-encounter-chw.spec.ts
+++ b/client/e2e/child-scoreboard-encounter-chw.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createChildAndStartEncounter,
   completeNCDA,
@@ -38,6 +39,9 @@ test.describe('CHW: Child Scoreboard Encounter — First NCDA + Vaccination Hist
   // Backend: Verifies child_scoreboard_ncda + 7 vaccination nodes created,
   //          confirms child_scoreboard_dtp_sa_iz absent (Burundi-only).
   test('complete NCDA and vaccination history, verify backend sync', async ({ page }) => {
+    // Verify FeatureNCDA flag gates the "Child Scorecard" button.
+    await verifyFeatureGatesEncounterButton(page, 'ncda', 'Child Scorecard');
+
     // 1. Register a 10-month-old child and start the encounter.
     const { fullName } = await createChildAndStartEncounter(page, {
       ageMonths: 10,

--- a/client/e2e/education-session-chw.spec.ts
+++ b/client/e2e/education-session-chw.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesGroupEncounterButton } from './helpers/feature-flags';
 import {
   navigateToEducationSession,
   selectTopics,
@@ -36,6 +37,10 @@ test.describe('CHW: Group Education Session', () => {
     // Flow: GroupEncounterTypesPage → Topics → Attendance → Record → Sync.
     // Backend: Verifies education_session node exists with correct topics,
     //   participants, and end date set.
+
+    // Verify FeatureGroupEducation flag gates the "Health Education" button on Group Encounter Types.
+    // (Keep nutrition_group ON so the Group Assessment entry button on Clinical stays reachable.)
+    await verifyFeatureGatesGroupEncounterButton(page, 'group_education', 'Health Education', 'nutrition_group');
 
     // 1. Navigate to GroupEncounterTypesPage → click "Health Education".
     await navigateToEducationSession(page);

--- a/client/e2e/family-nutrition-encounter-chw.spec.ts
+++ b/client/e2e/family-nutrition-encounter-chw.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { WAIT, syncAndWait } from './helpers/common';
+import { verifyFeatureGatesClinicalAssessmentButton } from './helpers/feature-flags';
 import {
   createMotherAndNavigateToPersonPage,
   addChild,
@@ -40,6 +41,9 @@ test.describe('CHW: Family Nutrition Encounter', () => {
     //   family_nutrition_encounter exist.
     //   Confirms aheza_child, family_nutrition_muac_child,
     //   family_nutrition_photo absent (no children).
+
+    // Verify FeatureFamilyNutrition flag gates the "Family Assessment" button on Clinical (CHW only).
+    await verifyFeatureGatesClinicalAssessmentButton(page, 'family_nutrition', 'family-assessment');
 
     // 1. Register mother, skip adding children, go straight to participant page.
     const mother = await createMotherAndNavigateToPersonPage(page);

--- a/client/e2e/feature-gps-coordinates.spec.ts
+++ b/client/e2e/feature-gps-coordinates.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { click, setupDevice } from './helpers/auth';
+import { installCursorScript } from './helpers/cursor';
+import { resetDevice } from './helpers/device';
+import { syncAndWait } from './helpers/common';
+import { setFeatureFlag } from './helpers/feature-flags';
+
+// Standalone spec — verifies that the FeatureGPSCoordinates flag actually
+// gates the "GPS Info" section on the patient registration form. Kept
+// separate from the encounter specs so the toggle dance does not run on
+// every patient registration.
+
+test.describe('Feature: GPS Coordinates gating on registration form', () => {
+  if (process.env.RECORD) {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(installCursorScript());
+    });
+  }
+
+  // Login as nurse (registration form is similar across roles; nurse has
+  // the cascading address dropdowns but those are separate from the GPS
+  // section).
+  test.beforeEach(async ({ page }) => {
+    resetDevice();
+    await setupDevice(page, '1234', 'Nyange Health Center');
+  });
+
+  test('GPS Info section appears and disappears with the flag', async ({ page }) => {
+    // Navigate to a registration form. We use the Antenatal Care flow
+    // because the form is shared across encounter types and Antenatal
+    // is enabled by default for nurse.
+    await click(page.locator('.icon-task-clinical'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('button.individual-assessment'), page);
+    await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
+    await click(
+      page.locator('button.encounter-type', { hasText: 'Antenatal Care' }),
+      page,
+    );
+    await page.locator('div.page-participants').waitFor({ timeout: 10000 });
+    await click(
+      page.locator('button.ui.primary.button.fluid', {
+        hasText: 'Register a new participant',
+      }),
+      page,
+    );
+    await page
+      .locator('.ui.grid .column', { hasText: 'First Name:' })
+      .waitFor({ timeout: 10000 });
+
+    // gpsInfoSection in Pages/Person/View.elm renders a fieldset with
+    // class "registration-form gps-info" iff gpsCoordinatesEnabled.
+    const gpsSection = page.locator('fieldset.gps-info');
+
+    // Force flag OFF and sync; goBack from device status returns to the
+    // registration form (Elm preserves the form state across page nav).
+    setFeatureFlag('gps_coordinates', false);
+    await syncAndWait(page);
+    await expect(
+      gpsSection,
+      'fieldset.gps-info must be hidden when feature gps_coordinates is off',
+    ).toBeHidden();
+
+    // Force flag ON and sync.
+    setFeatureFlag('gps_coordinates', true);
+    await syncAndWait(page);
+    await expect(
+      gpsSection,
+      'fieldset.gps-info must be visible when feature gps_coordinates is on',
+    ).toBeVisible();
+  });
+});

--- a/client/e2e/group-session-chw.spec.ts
+++ b/client/e2e/group-session-chw.spec.ts
@@ -3,6 +3,7 @@ import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesGroupEncounterButton } from './helpers/feature-flags';
 import {
   navigateToChwGroupSession,
   createMotherOnAttendancePage,
@@ -51,6 +52,10 @@ test.describe('CHW: Group Nutrition Session', () => {
     // Backend: Verifies 6 node types created (attendance, height, weight,
     //   muac, nutrition, family_planning).
     //   Confirms child_fbf, mother_fbf, lactation absent.
+
+    // Verify FeatureNutritionGroup flag gates the "Child Nutrition" button on Group Encounter Types.
+    // (Keep group_education ON so the Group Assessment entry button on Clinical stays reachable.)
+    await verifyFeatureGatesGroupEncounterButton(page, 'nutrition_group', 'Child Nutrition', 'group_education');
 
     // 1. Navigate to CHW group session.
     await navigateToChwGroupSession(page);

--- a/client/e2e/group-session-nurse.spec.ts
+++ b/client/e2e/group-session-nurse.spec.ts
@@ -3,6 +3,7 @@ import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesClinicalAssessmentButton } from './helpers/feature-flags';
 import {
   navigateToNurseGroupSession,
   createMotherOnAttendancePage,
@@ -56,6 +57,10 @@ test.describe('Nurse: FBF Group Nutrition Session', () => {
     //   SendToHC, FollowUp.
     // Mother activities: FamilyPlanning, Lactation, MotherFbf.
     // Backend: Verifies 14 node types (all group session content types).
+
+    // Verify FeatureNutritionGroup flag gates the "Group Assessment" button on Clinical (nurse only).
+    // (On nurse the gate is unambiguous: group_education isn't part of the compound for non-CHW.)
+    await verifyFeatureGatesClinicalAssessmentButton(page, 'nutrition_group', 'group-assessment');
 
     // 1. Navigate to FBF group session.
     await navigateToNurseGroupSession(page, 'FBF', 'Nyange I');

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -1,0 +1,34 @@
+import { execSync } from 'child_process';
+import { drushEnv } from './device';
+
+/**
+ * Toggle a `hedley_admin_feature_<name>_enabled` Drupal variable.
+ *
+ * After changing a flag, the device must sync (via the sync icon /
+ * `syncAndWait`) for the new value to reach the Elm SyncManager
+ * `features` set; only then will gated UI re-render.
+ *
+ * @param name - Short feature name, e.g. 'antenatal', 'gps_coordinates',
+ *               'stock_management_hc'. The full variable name is built
+ *               by prepending 'hedley_admin_feature_' and appending
+ *               '_enabled'.
+ * @param enabled - true sets the variable to 1, false sets it to 0.
+ *
+ * Note: execSync with a hardcoded variable-name pattern — `name` is
+ * validated as snake_case to prevent injection. Same pattern as
+ * ensureStockManagementHCFeatureEnabled in stock-management.ts.
+ */
+export function setFeatureFlag(name: string, enabled: boolean) {
+  if (!/^[a-z][a-z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid feature flag name: "${name}"`);
+  }
+
+  const { drushCmd, cwd } = drushEnv();
+  const value = enabled ? '1' : '0';
+  execSync(`${drushCmd} vset hedley_admin_feature_${name}_enabled ${value}`, {
+    cwd,
+    timeout: 15000,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+}

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -98,3 +98,141 @@ export async function verifyFeatureGatesEncounterButton(
   await click(page.locator('.link-back .icon-back'), page);
   await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
 }
+
+/**
+ * Verify that a SiteFeature flag gates one of the assessment buttons
+ * on the Clinical page (Individual / Group / Family Assessment).
+ *
+ * Used for:
+ *  - FeatureFamilyNutrition gates `button.family-assessment` (CHW only)
+ *  - FeatureNutritionGroup gates `button.group-assessment` (NURSE only —
+ *    on CHW the gate is compound with FeatureGroupEducation, so test
+ *    that one via verifyFeatureGatesGroupEncounterButton instead)
+ *
+ * Pre/Post: device is on PinCode dashboard.
+ *
+ * @param page        - Playwright page.
+ * @param flagName    - Feature flag short name.
+ * @param buttonClass - CSS class of the button on Clinical page,
+ *                      e.g. 'family-assessment', 'group-assessment'.
+ */
+export async function verifyFeatureGatesClinicalAssessmentButton(
+  page: Page,
+  flagName: string,
+  buttonClass: string,
+) {
+  setFeatureFlag(flagName, false);
+  await syncAndWait(page);
+
+  await click(page.locator('.icon-task-clinical'), page);
+  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+
+  const button = page.locator(`button.${buttonClass}`);
+  await expect(
+    button,
+    `button.${buttonClass} must be hidden when feature ${flagName} is off`,
+  ).toBeHidden();
+
+  setFeatureFlag(flagName, true);
+  await syncAndWait(page);
+
+  await expect(
+    button,
+    `button.${buttonClass} must be visible when feature ${flagName} is on`,
+  ).toBeVisible();
+
+  await click(page.locator('.link-back .icon-back'), page);
+  await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+}
+
+/**
+ * Verify that a SiteFeature flag gates a button on the Group Encounter
+ * Types page. Used for CHW where the entry button on Clinical is
+ * compound-gated by FeatureNutritionGroup OR FeatureGroupEducation.
+ *
+ * The caller must specify `partnerFlag` — the OTHER group flag — which
+ * the helper sets to ON so the Group Assessment entry button on
+ * Clinical remains visible while we toggle the target flag.
+ *
+ * Pre/Post: device is on PinCode dashboard.
+ *
+ * @param page         - Playwright page.
+ * @param flagName     - Target feature flag (e.g. 'nutrition_group').
+ * @param buttonText   - Button label inside Group Encounter Types,
+ *                       e.g. 'Child Nutrition' or 'Health Education'.
+ * @param partnerFlag  - The other group flag to keep ON for navigation
+ *                       (e.g. 'group_education' when testing
+ *                       'nutrition_group').
+ */
+export async function verifyFeatureGatesGroupEncounterButton(
+  page: Page,
+  flagName: string,
+  buttonText: string,
+  partnerFlag: string,
+) {
+  setFeatureFlag(partnerFlag, true);
+  setFeatureFlag(flagName, false);
+  await syncAndWait(page);
+
+  // Navigate Clinical → Group Assessment → Group Encounter Types.
+  await click(page.locator('.icon-task-clinical'), page);
+  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+  await click(page.locator('button.group-assessment'), page);
+  await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
+
+  const button = page.locator('button.encounter-type', { hasText: buttonText });
+  await expect(
+    button,
+    `"${buttonText}" button must be hidden when feature ${flagName} is off`,
+  ).toBeHidden();
+
+  setFeatureFlag(flagName, true);
+  await syncAndWait(page);
+
+  await expect(
+    button,
+    `"${buttonText}" button must be visible when feature ${flagName} is on`,
+  ).toBeVisible();
+
+  // Back: Group Encounter Types → Clinical → PinCode.
+  await click(page.locator('.link-back .icon-back'), page);
+  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+  await click(page.locator('.link-back .icon-back'), page);
+  await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+}
+
+/**
+ * Verify that a SiteFeature flag gates an activity-card icon on the
+ * PinCode dashboard. Used for FeatureStockManagementHC (nurse) and
+ * FeatureStockManagementVillage (CHW) — both gate `.icon-task-stock-
+ * management`.
+ *
+ * Pre/Post: device is on PinCode dashboard.
+ *
+ * @param page     - Playwright page.
+ * @param flagName - Feature flag short name.
+ * @param iconKey  - Icon class suffix, e.g. 'stock-management' for
+ *                   `.icon-task-stock-management`.
+ */
+export async function verifyFeatureGatesPinCodeMenuIcon(
+  page: Page,
+  flagName: string,
+  iconKey: string,
+) {
+  setFeatureFlag(flagName, false);
+  await syncAndWait(page);
+
+  const icon = page.locator(`.icon-task-${iconKey}`);
+  await expect(
+    icon,
+    `.icon-task-${iconKey} must be hidden when feature ${flagName} is off`,
+  ).toBeHidden();
+
+  setFeatureFlag(flagName, true);
+  await syncAndWait(page);
+
+  await expect(
+    icon,
+    `.icon-task-${iconKey} must be visible when feature ${flagName} is on`,
+  ).toBeVisible();
+}

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -1,4 +1,7 @@
+import { Page, expect } from '@playwright/test';
 import { execSync } from 'child_process';
+import { click } from './auth';
+import { syncAndWait } from './common';
 import { drushEnv } from './device';
 
 /**
@@ -31,4 +34,67 @@ export function setFeatureFlag(name: string, enabled: boolean) {
     encoding: 'utf-8',
     stdio: 'pipe',
   });
+}
+
+/**
+ * Verify that a SiteFeature flag actually gates an encounter-type
+ * button on the Individual Encounter Types page.
+ *
+ * Pre: device is logged in and sitting on the PinCode dashboard.
+ * Post: device is back on the PinCode dashboard with the flag ON, ready
+ *       for the existing register-and-encounter flow to take over.
+ *
+ * Steps:
+ *  1. Set flag OFF on backend, sync; device pulls OFF state.
+ *  2. Navigate Dashboard → Clinical → Individual Assessment.
+ *  3. Assert the button is hidden.
+ *  4. Set flag ON, sync.
+ *  5. Assert the button is visible.
+ *  6. Navigate back to PinCode (two `link-back` clicks).
+ *
+ * @param page         - Playwright page (logged in, on PinCode).
+ * @param flagName     - Feature flag short name, e.g. 'antenatal'.
+ * @param buttonText   - Visible label of the encounter-type button,
+ *                       e.g. 'Antenatal Care'. Role-dependent for some
+ *                       (Well Child = 'Standard Pediatric Visit' for
+ *                       nurse, 'Well Child Visit' for CHW).
+ */
+export async function verifyFeatureGatesEncounterButton(
+  page: Page,
+  flagName: string,
+  buttonText: string,
+) {
+  // 1. Force feature OFF on backend, sync.
+  setFeatureFlag(flagName, false);
+  await syncAndWait(page);
+
+  // 2. Navigate Dashboard → Clinical → Individual Assessment.
+  await click(page.locator('.icon-task-clinical'), page);
+  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+  await click(page.locator('button.individual-assessment'), page);
+  await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
+
+  // 3. Button must be hidden.
+  const button = page.locator('button.encounter-type', { hasText: buttonText });
+  await expect(
+    button,
+    `"${buttonText}" button must be hidden when feature ${flagName} is off`,
+  ).toBeHidden();
+
+  // 4. Re-enable feature and sync. After syncAndWait we land back on
+  //    the encounter-types page (page.goBack from device status).
+  setFeatureFlag(flagName, true);
+  await syncAndWait(page);
+
+  // 5. Button must now be visible.
+  await expect(
+    button,
+    `"${buttonText}" button must be visible when feature ${flagName} is on`,
+  ).toBeVisible();
+
+  // 6. Navigate back to PinCode so callers can resume from the dashboard.
+  await click(page.locator('.link-back .icon-back'), page);
+  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+  await click(page.locator('.link-back .icon-back'), page);
+  await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
 }

--- a/client/e2e/hiv-encounter-chw.spec.ts
+++ b/client/e2e/hiv-encounter-chw.spec.ts
@@ -7,6 +7,7 @@ import {
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultAndStartHIVEncounter,
   completeDiagnostics,
@@ -44,6 +45,9 @@ test.describe('CHW: HIV Initial Encounter — Positive Diagnosis', () => {
   // Backend: Verifies 5 node types created (diagnostics, medication, treatment_review, health_education, follow_up),
   //          confirms hiv_referral and hiv_symptom_review absent.
   test('complete initial HIV encounter with positive diagnosis, verify backend sync', async ({ page }) => {
+    // Verify FeatureHIVManagement flag gates the "HIV Management" button.
+    await verifyFeatureGatesEncounterButton(page, 'hiv_management', 'HIV Management');
+
     const { fullName } = await createAdultAndStartHIVEncounter(page, {
       isFemale: false,
     });

--- a/client/e2e/ncd-encounter-nurse.spec.ts
+++ b/client/e2e/ncd-encounter-nurse.spec.ts
@@ -4,6 +4,7 @@ import { verifyCaseManagementEntry } from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultAndStartNCDEncounter,
   completeDangerSigns,
@@ -43,6 +44,9 @@ test.describe('Nurse: NCD First Encounter — Male, Stage 1 Hypertension', () =>
   });
 
   test('complete first NCD encounter with Stage 1 hypertension, verify backend sync', async ({ page }) => {
+    // Verify FeatureNCD flag gates the "Noncommunicable Diseases" button.
+    await verifyFeatureGatesEncounterButton(page, 'ncd', 'Noncommunicable Diseases');
+
     const { fullName } = await createAdultAndStartNCDEncounter(page, {
       isFemale: false,
     });

--- a/client/e2e/nutrition-encounter-chw.spec.ts
+++ b/client/e2e/nutrition-encounter-chw.spec.ts
@@ -8,6 +8,7 @@ import {
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { WAIT, syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createChildAndStartEncounter,
   enterWeight,
@@ -38,6 +39,9 @@ test.describe('CHW: Individual Nutrition Encounter', () => {
   test('normal encounter without height (optional for CHW) and backend sync', async ({
     page,
   }) => {
+    // Verify FeatureNutritionIndividual flag gates the "Child Nutrition" button.
+    await verifyFeatureGatesEncounterButton(page, 'nutrition_individual', 'Child Nutrition');
+
     const { fullName } = await createChildAndStartEncounter(page, {
       ageMonths: 24,
       isChw: true,

--- a/client/e2e/nutrition-encounter.spec.ts
+++ b/client/e2e/nutrition-encounter.spec.ts
@@ -3,6 +3,7 @@ import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { WAIT, syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createChildAndStartEncounter,
   completeNCDA,
@@ -35,6 +36,9 @@ test.describe('Nurse: Individual Nutrition Encounter', () => {
   test('complete normal encounter with NCDA and verify backend sync', async ({
     page,
   }) => {
+    // Verify FeatureNutritionIndividual flag gates the "Child Nutrition" button.
+    await verifyFeatureGatesEncounterButton(page, 'nutrition_individual', 'Child Nutrition');
+
     // Use age 10 months (< 24) so NCDA activity appears for nurse.
     const { fullName } = await createChildAndStartEncounter(page, {
       ageMonths: 10,

--- a/client/e2e/prenatal-encounter-chw.spec.ts
+++ b/client/e2e/prenatal-encounter-chw.spec.ts
@@ -7,6 +7,7 @@ import {
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultFemaleAndStartEncounter,
   startPrenatalEncounter,
@@ -36,6 +37,9 @@ test.describe('CHW: Prenatal First Encounter', () => {
   });
 
   test('complete all activities and verify backend sync', async ({ page }) => {
+    // Verify FeatureAntenatal flag gates the "Antenatal Care" button.
+    await verifyFeatureGatesEncounterButton(page, 'antenatal', 'Antenatal Care');
+
     // LMP date ~30 weeks ago.
     const lmpDate = new Date();
     lmpDate.setDate(lmpDate.getDate() - 30 * 7);

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { setupDevice } from './helpers/auth';
+import { click, setupDevice } from './helpers/auth';
 import { verifyCaseManagementEntry } from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { setFeatureFlag } from './helpers/feature-flags';
 import {
   createAdultFemaleAndStartEncounter,
   startPrenatalEncounter,
@@ -50,6 +51,46 @@ test.describe('Nurse: Prenatal Initial Encounter', () => {
   test('complete all activities and verify backend sync', async ({ page }) => {
     // Nurse initial encounter completes 12+ activities; needs more than the default 2m.
     test.setTimeout(600000);
+
+    // --- FeatureAntenatal toggle verification (pilot for feature-flag testing pattern) ---
+    // 1. Force feature OFF on backend, sync so device pulls the OFF state.
+    setFeatureFlag('antenatal', false);
+    await syncAndWait(page);
+
+    // 2. Navigate Dashboard -> Clinical -> Individual Assessment.
+    await click(page.locator('.icon-task-clinical'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('button.individual-assessment'), page);
+    await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
+
+    // 3. Antenatal Care button must be absent when FeatureAntenatal is off.
+    const antenatalBtn = page.locator('button.encounter-type', {
+      hasText: 'Antenatal Care',
+    });
+    await expect(
+      antenatalBtn,
+      'Antenatal Care button must be hidden when FeatureAntenatal is off',
+    ).toBeHidden();
+
+    // 4. Re-enable feature and sync. After syncAndWait we land back on
+    //    the encounter-types page (page.goBack from device status).
+    setFeatureFlag('antenatal', true);
+    await syncAndWait(page);
+
+    // 5. Antenatal Care button must now appear.
+    await expect(
+      antenatalBtn,
+      'Antenatal Care button must be visible when FeatureAntenatal is on',
+    ).toBeVisible();
+
+    // 6. Navigate back to PinCode (dashboard) so the existing helper can
+    //    drive the full register-and-start flow from its expected starting point.
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+    // --- end feature-toggle pilot ---
+
     // LMP date ~30 weeks ago — ensures EGA >= 28w for MentalHealth,
     // >= 13w for MalariaPrevention, and triggers all Medication tabs.
     const lmpDate = new Date();

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { click, setupDevice } from './helpers/auth';
+import { setupDevice } from './helpers/auth';
 import { verifyCaseManagementEntry } from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
-import { setFeatureFlag } from './helpers/feature-flags';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultFemaleAndStartEncounter,
   startPrenatalEncounter,
@@ -52,44 +52,8 @@ test.describe('Nurse: Prenatal Initial Encounter', () => {
     // Nurse initial encounter completes 12+ activities; needs more than the default 2m.
     test.setTimeout(600000);
 
-    // --- FeatureAntenatal toggle verification (pilot for feature-flag testing pattern) ---
-    // 1. Force feature OFF on backend, sync so device pulls the OFF state.
-    setFeatureFlag('antenatal', false);
-    await syncAndWait(page);
-
-    // 2. Navigate Dashboard -> Clinical -> Individual Assessment.
-    await click(page.locator('.icon-task-clinical'), page);
-    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
-    await click(page.locator('button.individual-assessment'), page);
-    await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
-
-    // 3. Antenatal Care button must be absent when FeatureAntenatal is off.
-    const antenatalBtn = page.locator('button.encounter-type', {
-      hasText: 'Antenatal Care',
-    });
-    await expect(
-      antenatalBtn,
-      'Antenatal Care button must be hidden when FeatureAntenatal is off',
-    ).toBeHidden();
-
-    // 4. Re-enable feature and sync. After syncAndWait we land back on
-    //    the encounter-types page (page.goBack from device status).
-    setFeatureFlag('antenatal', true);
-    await syncAndWait(page);
-
-    // 5. Antenatal Care button must now appear.
-    await expect(
-      antenatalBtn,
-      'Antenatal Care button must be visible when FeatureAntenatal is on',
-    ).toBeVisible();
-
-    // 6. Navigate back to PinCode (dashboard) so the existing helper can
-    //    drive the full register-and-start flow from its expected starting point.
-    await click(page.locator('.link-back .icon-back'), page);
-    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
-    await click(page.locator('.link-back .icon-back'), page);
-    await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
-    // --- end feature-toggle pilot ---
+    // Verify FeatureAntenatal flag gates the "Antenatal Care" button.
+    await verifyFeatureGatesEncounterButton(page, 'antenatal', 'Antenatal Care');
 
     // LMP date ~30 weeks ago — ensures EGA >= 28w for MentalHealth,
     // >= 13w for MalariaPrevention, and triggers all Medication tabs.

--- a/client/e2e/stock-management-chw.spec.ts
+++ b/client/e2e/stock-management-chw.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice, click } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesPinCodeMenuIcon } from './helpers/feature-flags';
 import {
   navigateToStockManagement,
   completeReceiveStock,
@@ -46,6 +47,9 @@ test.describe('CHW: Stock Management — Full Flow', () => {
   });
 
   test('receive stock, correct entries, view details, verify backend (village-filtered)', async ({ page }) => {
+    // Verify FeatureStockManagementVillage flag gates the Stock Management menu icon on PinCode (CHW).
+    await verifyFeatureGatesPinCodeMenuIcon(page, 'stock_management_village', 'stock-management');
+
     // Get baseline count of village-scoped stock_update nodes before test.
     const baseline = queryStockUpdateNodes(
       'Nyange Health Center',

--- a/client/e2e/stock-management-nurse.spec.ts
+++ b/client/e2e/stock-management-nurse.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesPinCodeMenuIcon } from './helpers/feature-flags';
 import {
   navigateToStockManagement,
   completeReceiveStock,
@@ -45,6 +46,9 @@ test.describe('Nurse: Stock Management — Full Flow', () => {
   });
 
   test('receive stock, correct entry (subtraction + addition), view details, verify backend', async ({ page }) => {
+    // Verify FeatureStockManagementHC flag gates the Stock Management menu icon on PinCode (nurse).
+    await verifyFeatureGatesPinCodeMenuIcon(page, 'stock_management_hc', 'stock-management');
+
     // Get baseline count of stock_update nodes before test.
     const baseline = queryStockUpdateNodes('Nyange Health Center');
     const initialCount = baseline.count;

--- a/client/e2e/tuberculosis-encounter-chw.spec.ts
+++ b/client/e2e/tuberculosis-encounter-chw.spec.ts
@@ -7,6 +7,7 @@ import {
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createAdultAndStartTBEncounter,
   completeDiagnostics,
@@ -46,6 +47,9 @@ test.describe('CHW: Tuberculosis Initial Encounter — Positive Diagnosis', () =
   // Backend: Verifies 6 node types created (diagnostics, medication, dot, treatment_review,
   //          health_education, follow_up), confirms symptom_review and referral absent.
   test('complete initial TB encounter with positive pulmonary diagnosis, verify backend sync', async ({ page }) => {
+    // Verify FeatureTuberculosisManagement flag gates the "TB Management" button.
+    await verifyFeatureGatesEncounterButton(page, 'tuberculosis_management', 'TB Management');
+
     const { fullName } = await createAdultAndStartTBEncounter(page, {
       isFemale: false,
     });

--- a/client/e2e/well-child-encounter-chw.spec.ts
+++ b/client/e2e/well-child-encounter-chw.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createChildAndStartWellChildEncounter,
   completePregnancySummary,
@@ -34,6 +35,8 @@ test.describe('CHW: Well Child NewbornExam Encounter', () => {
   });
 
   test('complete newborn exam with PregnancySummary, NutritionAssessment, Immunisation, verify backend sync', async ({ page }) => {
+    // Verify FeatureWellChild flag gates the "Well Child Visit" button (CHW-side).
+    await verifyFeatureGatesEncounterButton(page, 'well_child', 'Well Child Visit');
 
     const { fullName } = await createChildAndStartWellChildEncounter(page, {
       ageMonths: 1,

--- a/client/e2e/well-child-encounter-nurse.spec.ts
+++ b/client/e2e/well-child-encounter-nurse.spec.ts
@@ -3,6 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
+import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createChildAndStartWellChildEncounter,
   completeDangerSigns,
@@ -35,6 +36,8 @@ test.describe('Nurse: Well Child PediatricCare — Normal Encounter', () => {
   });
 
   test('complete normal encounter with all mandatory activities and verify backend sync', async ({ page }) => {
+    // Verify FeatureWellChild flag gates the "Standard Pediatric Visit" button (nurse-side).
+    await verifyFeatureGatesEncounterButton(page, 'well_child', 'Standard Pediatric Visit');
 
     // Use 23 months (< 24) so NCDA activity appears for nurse.
     const { fullName } = await createChildAndStartWellChildEncounter(page, {


### PR DESCRIPTION
## Summary

Adds automated visual verification that each `SiteFeature` flag in
`SyncManager.Model` actually gates its corresponding UI element. The
pattern integrates into existing E2E tests (one per flag) with a small
toggle-dance helper, plus one standalone spec for the registration-form
gating that doesn't fit the encounter-button pattern.

For each flag the test does: drush vset OFF → sync → assert UI hidden →
drush vset ON → sync → assert UI visible → continue with the existing
test body. After the dance the device is back on PinCode dashboard so
the existing `createXxxAndStartEncounter` flow takes over unchanged.

## Coverage (14 of 16 flags)

| Flag | Spec | Verified element |
|---|---|---|
| `FeatureAcuteIllness` | `acute-illness-encounter-{nurse,chw}` | "Acute Illness" button on Individual Enc Types |
| `FeatureAntenatal` | `prenatal-encounter-{nurse,chw}` | "Antenatal Care" button on Individual Enc Types |
| `FeatureNCD` | `ncd-encounter-nurse` | "Noncommunicable Diseases" button |
| `FeatureNCDA` | `child-scoreboard-encounter-chw` | "Child Scorecard" button |
| `FeatureNutritionIndividual` | `nutrition-encounter`, `nutrition-encounter-chw` | "Child Nutrition" button on Individual Enc Types |
| `FeatureWellChild` | `well-child-encounter-{nurse,chw}` | "Standard Pediatric Visit" / "Well Child Visit" |
| `FeatureHIVManagement` | `hiv-encounter-chw` | "HIV Management" button |
| `FeatureTuberculosisManagement` | `tuberculosis-encounter-chw` | "TB Management" button |
| `FeatureFamilyNutrition` | `family-nutrition-encounter-chw` | `button.family-assessment` on Clinical |
| `FeatureGroupEducation` | `education-session-chw` | "Health Education" on Group Enc Types |
| `FeatureNutritionGroup` | `group-session-{nurse,chw}` | `button.group-assessment` (nurse) + "Child Nutrition" on Group Enc Types (CHW) |
| `FeatureStockManagementHC` | `stock-management-nurse` | `.icon-task-stock-management` on PinCode |
| `FeatureStockManagementVillage` | `stock-management-chw` | `.icon-task-stock-management` on PinCode |
| `FeatureGPSCoordinates` | **standalone** `feature-gps-coordinates.spec.ts` | `fieldset.gps-info` on registration form |

## Excluded

- `FeatureReportToWhatsApp` — out of scope for this round.
- `FeatureHealthyStart` — sub-feature that tweaks Prenatal flow content (adds Ultrasound activity, changes pre-pregnancy classification, GWG curves, weight chart) rather than gating a single UI element. Easier to verify manually or as a future dedicated test.

## How it's wired

Four small helpers in `client/e2e/helpers/feature-flags.ts`:

- `setFeatureFlag(name, enabled)` — `drush vset hedley_admin_feature_<name>_enabled <0|1>`. Validates `name` against snake_case to prevent injection. Same pattern as `ensureStockManagementHCFeatureEnabled` in `stock-management.ts`.
- `verifyFeatureGatesEncounterButton(page, flag, buttonText)` — Individual Encounter Types page.
- `verifyFeatureGatesClinicalAssessmentButton(page, flag, buttonClass)` — Clinical page (Family Assessment, Group Assessment).
- `verifyFeatureGatesGroupEncounterButton(page, flag, buttonText, partnerFlag)` — Group Encounter Types page; `partnerFlag` is set ON to keep the entry button on Clinical reachable when the gate there is compound.
- `verifyFeatureGatesPinCodeMenuIcon(page, flag, iconKey)` — activity-card icon on PinCode dashboard.

For the standalone GPS spec (`feature-gps-coordinates.spec.ts`) the helper is reused inline because the gated element is a `fieldset` on the registration form, not a navigation button.

## Test plan

- [x] CI: `lint_elm`, `lint_elm_review`, `lint_phpcs`, `lint_shellcheck`, `test_simpletest_linux` all pass
- [x] CI: `e2e_playwright_1` and `e2e_playwright_2` — exercise the toggle dance on every covered spec
- [x] CI: `e2e_reporting` — unaffected by this change but should remain green
- Local pilot already verified: `prenatal-encounter-nurse.spec.ts` "complete all activities" test passed in 1.6m end-to-end with the toggle dance in place.
- Local standalone verified: `feature-gps-coordinates.spec.ts` passed in 21.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)