### PR TITLE
Skip Vitals measurements on Well Child encounters (CHW)

### DIFF
--- a/client/e2e/helpers/well-child.ts
+++ b/client/e2e/helpers/well-child.ts
@@ -1,5 +1,8 @@
+import { execSync } from 'child_process';
+
 import { Page } from '@playwright/test';
 import { click } from './auth';
+import { drushEnv } from './device';
 import {
   WAIT,
   answerYesNo,
@@ -203,11 +206,22 @@ export async function completeDangerSigns(
     symptoms?: string[];
     respiratoryRate?: string;
     bodyTemp?: string;
+    /** When true, click the RR "Unable to take measurement" checkbox instead of filling. */
+    respiratoryRateNotTaken?: boolean;
+    /** When true, click the BT "Unable to take measurement" checkbox instead of filling. */
+    bodyTemperatureNotTaken?: boolean;
+    /** When true, after switching to the Vitals tab, asserts that no
+     *  ".ui.checkbox.activity" elements appear in the Vitals form section
+     *  (negative gate — used by nurse / non-CHW tests). */
+    expectNoSkipCheckboxes?: boolean;
   },
 ) {
   const symptoms = options?.symptoms ?? [];
   const respiratoryRate = options?.respiratoryRate ?? '20';
   const bodyTemp = options?.bodyTemp ?? '36.5';
+  const respiratoryRateNotTaken = options?.respiratoryRateNotTaken ?? false;
+  const bodyTemperatureNotTaken = options?.bodyTemperatureNotTaken ?? false;
+  const expectNoSkipCheckboxes = options?.expectNoSkipCheckboxes ?? false;
 
   await openActivity(page, 'danger-signs');
 
@@ -224,8 +238,40 @@ export async function completeDangerSigns(
 
   // --- Vitals tab ---
   await clickSubTaskTab(page, 'vitals');
-  await fillMeasurement(page, 'respiratory-rate', respiratoryRate);
-  await fillMeasurement(page, 'body-temperature', bodyTemp);
+
+  const vitalsForm = page.locator('.ui.form.vitals');
+  await vitalsForm.waitFor({ timeout: 5000 });
+
+  if (expectNoSkipCheckboxes) {
+    // Negative gate: in non-CHW Well Child Vitals, no skip checkboxes render.
+    const skipCheckboxCount = await vitalsForm.locator('.ui.checkbox.activity').count();
+    if (skipCheckboxCount !== 0) {
+      throw new Error(
+        `expectNoSkipCheckboxes: expected 0 ".ui.checkbox.activity" inside ".ui.form.vitals", found ${skipCheckboxCount}`,
+      );
+    }
+  }
+
+  // The two skip checkboxes are siblings inside .ui.form.vitals and render
+  // only when allowSkipping is on (CHW Well Child). In DOM order:
+  //   index 0 = Respiratory Rate, index 1 = Body Temperature.
+  const skipCheckboxes = vitalsForm.locator('.ui.checkbox.activity');
+
+  if (respiratoryRateNotTaken) {
+    // Click the outer div: onClick is on .ui.checkbox.activity, not the label.
+    await click(skipCheckboxes.nth(0), page);
+    await page.waitForTimeout(WAIT.formInteraction);
+  } else {
+    await fillMeasurement(page, 'respiratory-rate', respiratoryRate);
+  }
+
+  if (bodyTemperatureNotTaken) {
+    await click(skipCheckboxes.nth(1), page);
+    await page.waitForTimeout(WAIT.formInteraction);
+  } else {
+    await fillMeasurement(page, 'body-temperature', bodyTemp);
+  }
+
   await saveSubTask(page);
 
   // Wait for return to encounter page.
@@ -893,4 +939,91 @@ export function queryWellChildNodes(
     'well_child_pregnancy_summary',
     'well_child_ncda',
   ], expectedTypes);
+}
+
+/**
+ * Query the most recent `well_child_vitals` row for `personName`, returning
+ * the `field_respiratory_rate` and `field_body_temperature` values. A field
+ * with no value (skipped at form-save time) is reported as `null`.
+ *
+ * Drupal stores person titles reversed: `"secondName firstName"`.
+ *
+ * Retries up to `expectedAttempts` times (5-second delay) until either:
+ *  - The vitals node exists AND `expected` (if supplied) matches; or
+ *  - Attempts are exhausted (returns whatever was last read).
+ *
+ * The retry is needed because writes flow through service-worker shardChanges
+ * → Advanced Queue → node_save asynchronously after `syncAndWait` reports
+ * "Status: Success".
+ */
+export function queryWellChildVitalsValues(
+  personName: string,
+  expected?: { rr: number | null; temp: number | null },
+): { rr: number | null; temp: number | null } {
+  const { drushCmd, cwd } = drushEnv();
+  const personNameB64 = Buffer.from(personName, 'utf8').toString('base64');
+
+  const php = `
+    \\$name = base64_decode('${personNameB64}');
+    \\$q = new EntityFieldQuery();
+    \\$r = \\$q->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'person')
+      ->propertyCondition('title', \\$name)
+      ->execute();
+    if (empty(\\$r['node'])) { echo json_encode(['error' => 'Person not found']); return; }
+    \\$pid = key(\\$r['node']);
+
+    \\$vq = new EntityFieldQuery();
+    \\$vr = \\$vq->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'well_child_vitals')
+      ->fieldCondition('field_person', 'target_id', \\$pid)
+      ->propertyOrderBy('nid', 'DESC')
+      ->range(0, 1)
+      ->execute();
+    if (empty(\\$vr['node'])) { echo json_encode(['error' => 'No well_child_vitals row']); return; }
+
+    \\$vid = key(\\$vr['node']);
+    \\$node = node_load(\\$vid);
+    \\$rrItems = field_get_items('node', \\$node, 'field_respiratory_rate');
+    \\$tempItems = field_get_items('node', \\$node, 'field_body_temperature');
+    \\$rr = (\\$rrItems && isset(\\$rrItems[0]['value']) && \\$rrItems[0]['value'] !== '' && \\$rrItems[0]['value'] !== null)
+      ? \\$rrItems[0]['value']
+      : null;
+    \\$temp = (\\$tempItems && isset(\\$tempItems[0]['value']) && \\$tempItems[0]['value'] !== '' && \\$tempItems[0]['value'] !== null)
+      ? \\$tempItems[0]['value']
+      : null;
+    echo json_encode(['rr' => \\$rr, 'temp' => \\$temp]);
+  `;
+
+  const matches = (got: { rr: number | null; temp: number | null }) => {
+    if (!expected) return true;
+    return got.rr === expected.rr && got.temp === expected.temp;
+  };
+
+  let last: { rr: number | null; temp: number | null } = { rr: null, temp: null };
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      const output = execSync(`${drushCmd} eval "${php}"`, {
+        cwd, timeout: 30000, encoding: 'utf-8', stdio: 'pipe',
+      }).trim();
+      const parsed = JSON.parse(output);
+      if (parsed.error) {
+        console.log(`queryWellChildVitalsValues attempt ${attempt + 1}: ${parsed.error}`);
+        if (attempt < 9) { execSync('sleep 5'); continue; }
+        return last;
+      }
+      const rr = parsed.rr === null ? null : Number(parsed.rr);
+      const temp = parsed.temp === null ? null : Number(parsed.temp);
+      last = { rr, temp };
+      if (matches(last)) return last;
+      console.log(
+        `queryWellChildVitalsValues attempt ${attempt + 1}: got ${JSON.stringify(last)}, expected ${JSON.stringify(expected)}`,
+      );
+      if (attempt < 9) execSync('sleep 5');
+    } catch (err) {
+      console.log(`queryWellChildVitalsValues attempt ${attempt + 1}: error`, err);
+      if (attempt < 9) execSync('sleep 5');
+    }
+  }
+  return last;
 }

--- a/client/e2e/well-child-encounter-chw.spec.ts
+++ b/client/e2e/well-child-encounter-chw.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect } from '@playwright/test';
-import { setupDevice } from './helpers/auth';
+import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
-import { syncAndWait } from './helpers/common';
+import {
+  WAIT,
+  clickSubTaskTab,
+  fillMeasurement,
+  saveSubTask,
+  syncAndWait,
+} from './helpers/common';
 import {
   createChildAndStartWellChildEncounter,
   completePregnancySummary,
@@ -13,6 +19,7 @@ import {
   completeNextSteps,
   endWellChildEncounter,
   queryWellChildNodes,
+  queryWellChildVitalsValues,
 } from './helpers/well-child';
 
 // =========================================================================
@@ -183,5 +190,233 @@ test.describe('CHW: Well Child PediatricCareChw Encounter with HomeVisit', () =>
     expect(nodes['well_child_health_education'], 'well_child_health_education should exist').toBe(true);
     expect(nodes['well_child_send_to_hc'], 'well_child_send_to_hc should exist').toBe(true);
     expect(nodes['well_child_next_visit'], 'well_child_next_visit should exist').toBe(true);
+  });
+});
+
+// =========================================================================
+// Test 3: CHW PediatricCareChw — Vitals "Unable to take measurement" round-trip
+// =========================================================================
+
+test.describe('CHW: Well Child PediatricCareChw — Vitals skip round-trip', () => {
+  test.describe.configure({ timeout: 600000 });
+
+  if (process.env.RECORD) {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(installCursorScript());
+    });
+  }
+
+  test.beforeEach(async ({ page }) => {
+    resetDevice();
+    await setupDevice(page, '2345', 'Akanduga');
+  });
+
+  // Scenario: Single CHW Well Child encounter where the user cycles
+  // through the four states of the per-measurement skip (option B):
+  //   (1) Both skipped     — RR=null, BT=null on the saved row.
+  //   (2) RR skipped only  — RR=null, BT=36.
+  //   (3) Neither skipped  — RR=30, BT=36.
+  //   (4) BT skipped again — RR=30, BT=null.
+  // Each cycle re-opens the SAME encounter's Vitals tab without ending
+  // the encounter, syncs, and verifies the well_child_vitals row's null
+  // / non-null state on the backend. After all four cycles, the rest of
+  // the activities (Nutrition, Home Visit, Immunisation, Next Steps) are
+  // completed and the encounter is ended.
+  test('Vitals skip round-trip: skip-both -> skip-RR -> none -> skip-BT, end encounter', async ({ page }) => {
+
+    const { fullName } = await createChildAndStartWellChildEncounter(page, {
+      ageMonths: 24,
+      isChw: true,
+    });
+
+    // ---------- Cycle 1: both skipped ----------
+    // SymptomsReview: "None of these". Vitals: tick both skip checkboxes.
+    await completeDangerSigns(page, {
+      respiratoryRateNotTaken: true,
+      bodyTemperatureNotTaken: true,
+    });
+    await syncAndWait(page);
+    {
+      const vitals = queryWellChildVitalsValues(fullName, { rr: null, temp: null });
+      expect(vitals.rr, 'cycle 1: RR should be null (skipped)').toBeNull();
+      expect(vitals.temp, 'cycle 1: BT should be null (skipped)').toBeNull();
+    }
+
+    // ---------- Cycle 2: untick BT, type 36; RR stays skipped ----------
+    await page.locator('div.page-encounter.well-child').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+    // Danger Signs is now on the Completed tab — switch to it.
+    await click(page.locator('#completed-tab'), page);
+    await page.waitForTimeout(WAIT.elmRerender);
+    await click(page.locator('.icon-task-danger-signs'), page);
+    await page.locator('div.page-activity.well-child').waitFor({ timeout: 10000 });
+    await clickSubTaskTab(page, 'vitals');
+
+    {
+      const vitalsForm = page.locator('.ui.form.vitals');
+      await vitalsForm.waitFor({ timeout: 5000 });
+      const skipCheckboxes = vitalsForm.locator('.ui.checkbox.activity');
+      // Both should be checked from cycle 1 (rehydrated from null fields).
+      await expect(skipCheckboxes.nth(0).locator('input[type="checkbox"]'))
+        .toHaveClass(/checked/);
+      await expect(skipCheckboxes.nth(1).locator('input[type="checkbox"]'))
+        .toHaveClass(/checked/);
+      // The numeric inputs are NOT rendered while skipped.
+      await expect(vitalsForm.locator('.form-input.measurement.respiratory-rate')).toHaveCount(0);
+      await expect(vitalsForm.locator('.form-input.measurement.body-temperature')).toHaveCount(0);
+
+      // Untick BT (click the checkbox div — onClick is on it, not the label).
+      await click(skipCheckboxes.nth(1), page);
+      await page.waitForTimeout(WAIT.formInteraction);
+      // BT input should now appear; fill 36.
+      await fillMeasurement(page, 'body-temperature', '36');
+    }
+    await saveSubTask(page);
+    await page.locator('div.page-encounter.well-child').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+    await syncAndWait(page);
+    {
+      const vitals = queryWellChildVitalsValues(fullName, { rr: null, temp: 36 });
+      expect(vitals.rr, 'cycle 2: RR should still be null (skipped)').toBeNull();
+      expect(vitals.temp, 'cycle 2: BT should be 36').toBe(36);
+    }
+
+    // ---------- Cycle 3: untick RR, type 30; BT stays at 36 ----------
+    await page.locator('div.page-encounter.well-child').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+    // Danger Signs is now on the Completed tab — switch to it.
+    await click(page.locator('#completed-tab'), page);
+    await page.waitForTimeout(WAIT.elmRerender);
+    await click(page.locator('.icon-task-danger-signs'), page);
+    await page.locator('div.page-activity.well-child').waitFor({ timeout: 10000 });
+    await clickSubTaskTab(page, 'vitals');
+
+    {
+      const vitalsForm = page.locator('.ui.form.vitals');
+      await vitalsForm.waitFor({ timeout: 5000 });
+      const skipCheckboxes = vitalsForm.locator('.ui.checkbox.activity');
+      // RR still checked; BT no longer checked.
+      await expect(skipCheckboxes.nth(0).locator('input[type="checkbox"]'))
+        .toHaveClass(/checked/);
+      await expect(skipCheckboxes.nth(1).locator('input[type="checkbox"]'))
+        .not.toHaveClass(/checked/);
+
+      // Untick RR (click the checkbox div — onClick is on it, not the label).
+      await click(skipCheckboxes.nth(0), page);
+      await page.waitForTimeout(WAIT.formInteraction);
+      // 30 is between recessed (<24) and elevated (>=40) thresholds for 12–60mo,
+      // so the danger-sign alert modal won't fire and block the sync flow.
+      await fillMeasurement(page, 'respiratory-rate', '30');
+    }
+    await saveSubTask(page);
+    await page.locator('div.page-encounter.well-child').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+    await syncAndWait(page);
+    {
+      const vitals = queryWellChildVitalsValues(fullName, { rr: 30, temp: 36 });
+      expect(vitals.rr, 'cycle 3: RR should be 30').toBe(30);
+      expect(vitals.temp, 'cycle 3: BT should still be 36').toBe(36);
+    }
+
+    // ---------- Cycle 4: re-tick BT (skip again); RR stays at 30 ----------
+    await page.locator('div.page-encounter.well-child').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+    // Danger Signs is now on the Completed tab — switch to it.
+    await click(page.locator('#completed-tab'), page);
+    await page.waitForTimeout(WAIT.elmRerender);
+    await click(page.locator('.icon-task-danger-signs'), page);
+    await page.locator('div.page-activity.well-child').waitFor({ timeout: 10000 });
+    await clickSubTaskTab(page, 'vitals');
+
+    {
+      const vitalsForm = page.locator('.ui.form.vitals');
+      await vitalsForm.waitFor({ timeout: 5000 });
+      const skipCheckboxes = vitalsForm.locator('.ui.checkbox.activity');
+      // Neither checked; both inputs visible.
+      await expect(skipCheckboxes.nth(0).locator('input[type="checkbox"]'))
+        .not.toHaveClass(/checked/);
+      await expect(skipCheckboxes.nth(1).locator('input[type="checkbox"]'))
+        .not.toHaveClass(/checked/);
+
+      // Re-tick BT (click the checkbox div — onClick is on it, not the label).
+      await click(skipCheckboxes.nth(1), page);
+      await page.waitForTimeout(WAIT.formInteraction);
+    }
+    await saveSubTask(page);
+    await page.locator('div.page-encounter.well-child').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+    await syncAndWait(page);
+    {
+      const vitals = queryWellChildVitalsValues(fullName, { rr: 30, temp: null });
+      expect(vitals.rr, 'cycle 4: RR should be 30').toBe(30);
+      expect(vitals.temp, 'cycle 4: BT should be null (re-skipped)').toBeNull();
+    }
+
+    // ---------- Complete remaining activities, end encounter ----------
+    // Cycle 4 left us on the Completed tab; switch back to To Do so the
+    // remaining activity icons are reachable.
+    await click(page.locator('#pending-tab'), page);
+    await page.waitForTimeout(WAIT.elmRerender);
+
+    await completeNutritionAssessment(page, {
+      height: '85',
+      headCircumference: '48',
+      muac: '14',
+      weight: '12',
+      nutritionSigns: [],
+    });
+
+    await completeHomeVisit(page);
+
+    await completeImmunisation(page, { isChw: true });
+
+    await completeNextSteps(page, {
+      hasContributingFactors: false,
+      hasHealthEducation: true,
+      hasSendToHC: true,
+      hasFollowUp: false,
+    });
+
+    await endWellChildEncounter(page);
+    await syncAndWait(page);
+
+    // Final-state verification.
+    const expectedTypes = [
+      'well_child_symptoms_review',
+      'well_child_vitals',
+      'well_child_height',
+      'well_child_head_circumference',
+      'well_child_muac',
+      'well_child_nutrition',
+      'well_child_weight',
+      'well_child_feeding',
+      'well_child_caring',
+      'well_child_hygiene',
+      'well_child_food_security',
+      'well_child_health_education',
+      'well_child_send_to_hc',
+      'well_child_next_visit',
+    ];
+    const nodes = queryWellChildNodes(fullName, expectedTypes);
+
+    expect(nodes['well_child_symptoms_review'], 'well_child_symptoms_review should exist').toBe(true);
+    expect(nodes['well_child_vitals'], 'well_child_vitals should exist').toBe(true);
+    expect(nodes['well_child_height'], 'well_child_height should exist').toBe(true);
+    expect(nodes['well_child_head_circumference'], 'well_child_head_circumference should exist').toBe(true);
+    expect(nodes['well_child_muac'], 'well_child_muac should exist').toBe(true);
+    expect(nodes['well_child_nutrition'], 'well_child_nutrition should exist').toBe(true);
+    expect(nodes['well_child_weight'], 'well_child_weight should exist').toBe(true);
+    expect(nodes['well_child_feeding'], 'well_child_feeding should exist').toBe(true);
+    expect(nodes['well_child_caring'], 'well_child_caring should exist').toBe(true);
+    expect(nodes['well_child_hygiene'], 'well_child_hygiene should exist').toBe(true);
+    expect(nodes['well_child_food_security'], 'well_child_food_security should exist').toBe(true);
+    expect(nodes['well_child_health_education'], 'well_child_health_education should exist').toBe(true);
+    expect(nodes['well_child_send_to_hc'], 'well_child_send_to_hc should exist').toBe(true);
+    expect(nodes['well_child_next_visit'], 'well_child_next_visit should exist').toBe(true);
+
+    // Final vitals row state: RR=30, BT=null.
+    const finalVitals = queryWellChildVitalsValues(fullName, { rr: 30, temp: null });
+    expect(finalVitals.rr, 'final RR should be 30').toBe(30);
+    expect(finalVitals.temp, 'final BT should be null').toBeNull();
   });
 });

--- a/client/e2e/well-child-encounter-nurse.spec.ts
+++ b/client/e2e/well-child-encounter-nurse.spec.ts
@@ -43,9 +43,12 @@ test.describe('Nurse: Well Child PediatricCare — Normal Encounter', () => {
     });
 
     // 1. Danger Signs: no symptoms, normal vitals.
+    // Negative gate: Well Child PediatricCare nurse encounters do NOT show
+    // the per-measurement "Unable to take measurement" checkboxes on Vitals.
     await completeDangerSigns(page, {
       respiratoryRate: '20',
       bodyTemp: '36.5',
+      expectNoSkipCheckboxes: true,
     });
 
     // 2. Nutrition Assessment: normal values for 23-month child.

--- a/client/src/elm/Backend/Measurement/Decoder.elm
+++ b/client/src/elm/Backend/Measurement/Decoder.elm
@@ -2305,8 +2305,8 @@ decodeVitalsValue =
         |> optional "sys" (nullable decodeFloat) Nothing
         |> optional "dia" (nullable decodeFloat) Nothing
         |> optional "heart_rate" (nullable decodeInt) Nothing
-        |> required "respiratory_rate" decodeInt
-        |> required "body_temperature" decodeFloat
+        |> optional "respiratory_rate" (nullable decodeInt) Nothing
+        |> optional "body_temperature" (nullable decodeFloat) Nothing
         |> optional "sys_repeated" (nullable decodeFloat) Nothing
         |> optional "dia_repeated" (nullable decodeFloat) Nothing
 

--- a/client/src/elm/Backend/Measurement/Encoder.elm
+++ b/client/src/elm/Backend/Measurement/Encoder.elm
@@ -1918,8 +1918,8 @@ encodeVitals =
 
 encodeVitalsValueWithType : String -> VitalsValue -> List ( String, Value )
 encodeVitalsValueWithType type_ value =
-    [ ( "respiratory_rate", int value.respiratoryRate )
-    , ( "body_temperature", float value.bodyTemperature )
+    [ ( "respiratory_rate", maybe int value.respiratoryRate )
+    , ( "body_temperature", maybe float value.bodyTemperature )
     ]
         -- Not all Vitals CTs got the sys, dia, sys_repeated,
         -- dia_repeated and  heart_rate fields. Therefore we use

--- a/client/src/elm/Backend/Measurement/Model.elm
+++ b/client/src/elm/Backend/Measurement/Model.elm
@@ -978,8 +978,8 @@ type alias VitalsValue =
     { sys : Maybe Float
     , dia : Maybe Float
     , heartRate : Maybe Int
-    , respiratoryRate : Int
-    , bodyTemperature : Float
+    , respiratoryRate : Maybe Int
+    , bodyTemperature : Maybe Float
     , sysRepeated : Maybe Float
     , diaRepeated : Maybe Float
     }

--- a/client/src/elm/Backend/PrenatalActivity/Utils.elm
+++ b/client/src/elm/Backend/PrenatalActivity/Utils.elm
@@ -275,24 +275,26 @@ generateHighSeverityAlertData language currentDate isChw data alert =
             data.measurements.vitals
                 |> Maybe.andThen
                     (\measurement ->
-                        let
-                            value =
-                                Tuple.second measurement |> .value |> .bodyTemperature
-                        in
-                        if value >= 38.5 then
-                            Just
-                                ( trans Translate.High ++ " " ++ transAlert alert
-                                , String.fromFloat value ++ "°C"
-                                )
+                        Tuple.second measurement
+                            |> .value
+                            |> .bodyTemperature
+                            |> Maybe.andThen
+                                (\value ->
+                                    if value >= 38.5 then
+                                        Just
+                                            ( trans Translate.High ++ " " ++ transAlert alert
+                                            , String.fromFloat value ++ "°C"
+                                            )
 
-                        else if value < 35 then
-                            Just
-                                ( trans Translate.Low ++ " " ++ transAlert alert
-                                , String.fromFloat value ++ "°C"
-                                )
+                                    else if value < 35 then
+                                        Just
+                                            ( trans Translate.Low ++ " " ++ transAlert alert
+                                            , String.fromFloat value ++ "°C"
+                                            )
 
-                        else
-                            Nothing
+                                    else
+                                        Nothing
+                                )
                     )
 
         FetalHeartRate ->
@@ -399,24 +401,26 @@ generateHighSeverityAlertData language currentDate isChw data alert =
             data.measurements.vitals
                 |> Maybe.andThen
                     (\measurement ->
-                        let
-                            value =
-                                Tuple.second measurement |> .value |> .respiratoryRate
-                        in
-                        if value > 30 then
-                            Just
-                                ( trans Translate.High ++ " " ++ transAlert alert
-                                , trans <| Translate.BpmUnit value
-                                )
+                        Tuple.second measurement
+                            |> .value
+                            |> .respiratoryRate
+                            |> Maybe.andThen
+                                (\value ->
+                                    if value > 30 then
+                                        Just
+                                            ( trans Translate.High ++ " " ++ transAlert alert
+                                            , trans <| Translate.BpmUnit value
+                                            )
 
-                        else if value < 12 then
-                            Just
-                                ( trans Translate.Low ++ " " ++ transAlert alert
-                                , trans <| Translate.BpmUnit value
-                                )
+                                    else if value < 12 then
+                                        Just
+                                            ( trans Translate.Low ++ " " ++ transAlert alert
+                                            , trans <| Translate.BpmUnit value
+                                            )
 
-                        else
-                            Nothing
+                                    else
+                                        Nothing
+                                )
                     )
 
 

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -2340,14 +2340,20 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
                 processWellChildVitalsRevision participantId encounterId value =
                     let
                         bodyTemperatureAlert =
-                            value.bodyTemperature < 35 || value.bodyTemperature >= 37.5
+                            Maybe.map (\t -> t < 35 || t >= 37.5) value.bodyTemperature
+                                |> Maybe.withDefault False
 
                         respiratoryRateAlert =
-                            Dict.get participantId model.people
-                                |> Maybe.withDefault NotAsked
-                                |> RemoteData.toMaybe
-                                |> Maybe.andThen (ageInMonths currentDate)
-                                |> (\ageMonths -> respiratoryRateAbnormalForAge ageMonths value.respiratoryRate)
+                            Maybe.map
+                                (\rate ->
+                                    Dict.get participantId model.people
+                                        |> Maybe.withDefault NotAsked
+                                        |> RemoteData.toMaybe
+                                        |> Maybe.andThen (ageInMonths currentDate)
+                                        |> (\ageMonths -> respiratoryRateAbnormalForAge ageMonths rate)
+                                )
+                                value.respiratoryRate
+                                |> Maybe.withDefault False
                     in
                     if bodyTemperatureAlert || respiratoryRateAlert then
                         generateWellChildDangerSignsAlertMsgs encounterId

--- a/client/src/elm/Measurement/Model.elm
+++ b/client/src/elm/Measurement/Model.elm
@@ -395,8 +395,10 @@ type alias VitalsForm =
     , heartRateDirty : Bool
     , respiratoryRate : Maybe Int
     , respiratoryRateDirty : Bool
+    , respiratoryRateNotTaken : Maybe Bool
     , bodyTemperature : Maybe Float
     , bodyTemperatureDirty : Bool
+    , bodyTemperatureNotTaken : Maybe Bool
     , sysRepeated : Maybe Float
     , sysRepeatedDirty : Bool
     , diaRepeated : Maybe Float
@@ -414,8 +416,10 @@ emptyVitalsForm =
     , heartRateDirty = False
     , respiratoryRate = Nothing
     , respiratoryRateDirty = False
+    , respiratoryRateNotTaken = Nothing
     , bodyTemperature = Nothing
     , bodyTemperatureDirty = False
+    , bodyTemperatureNotTaken = Nothing
     , sysRepeated = Nothing
     , sysRepeatedDirty = False
     , diaRepeated = Nothing
@@ -426,6 +430,8 @@ emptyVitalsForm =
 type alias VitalsFormConfig msg =
     { setIntInputMsg : (Maybe Int -> VitalsForm -> VitalsForm) -> String -> msg
     , setFloatInputMsg : (Maybe Float -> VitalsForm -> VitalsForm) -> String -> msg
+    , setRespiratoryRateNotTakenMsg : Bool -> msg
+    , setBodyTemperatureNotTakenMsg : Bool -> msg
     , sysBloodPressurePreviousValue : Maybe Float
     , diaBloodPressurePreviousValue : Maybe Float
     , heartRatePreviousValue : Maybe Float
@@ -435,6 +441,7 @@ type alias VitalsFormConfig msg =
     , formClass : String
     , mode : VitalsFormMode
     , invokationModule : InvokationModule
+    , allowSkipping : Bool
     }
 
 

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -756,10 +756,16 @@ toVitalsValue form =
             else
                 form.bodyTemperature
 
-        anyContent =
-            isJust rrField || isJust tempField || rrSkipped || tempSkipped
+        -- Each field must be either explicitly skipped OR have a value.
+        -- Refuses partial input regardless of whether the view's task
+        -- tracker would have allowed save.
+        rrResolved =
+            rrSkipped || isJust form.respiratoryRate
+
+        tempResolved =
+            tempSkipped || isJust form.bodyTemperature
     in
-    if anyContent then
+    if rrResolved && tempResolved then
         Just
             (VitalsValue form.sysBloodPressure
                 form.diaBloodPressure

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -693,9 +693,9 @@ vitalsFormWithDefault form saved =
                 , diaBloodPressureDirty = form.diaBloodPressureDirty
                 , heartRate = maybeValueConsideringIsDirtyField form.heartRateDirty form.heartRate value.heartRate
                 , heartRateDirty = form.heartRateDirty
-                , respiratoryRate = valueConsideringIsDirtyField form.respiratoryRateDirty form.respiratoryRate value.respiratoryRate
+                , respiratoryRate = maybeValueConsideringIsDirtyField form.respiratoryRateDirty form.respiratoryRate value.respiratoryRate
                 , respiratoryRateDirty = form.respiratoryRateDirty
-                , bodyTemperature = valueConsideringIsDirtyField form.bodyTemperatureDirty form.bodyTemperature value.bodyTemperature
+                , bodyTemperature = maybeValueConsideringIsDirtyField form.bodyTemperatureDirty form.bodyTemperature value.bodyTemperature
                 , bodyTemperatureDirty = form.bodyTemperatureDirty
                 , sysRepeated = maybeValueConsideringIsDirtyField form.sysRepeatedDirty form.sysRepeated value.sysRepeated
                 , sysRepeatedDirty = form.sysRepeatedDirty
@@ -713,18 +713,19 @@ toVitalsValueWithDefault saved form =
 
 toVitalsValue : VitalsForm -> Maybe VitalsValue
 toVitalsValue form =
-    Maybe.map2
-        (\respiratoryRate bodyTemperature ->
-            VitalsValue form.sysBloodPressure
+    if isJust form.respiratoryRate || isJust form.bodyTemperature then
+        Just
+            (VitalsValue form.sysBloodPressure
                 form.diaBloodPressure
                 form.heartRate
-                respiratoryRate
-                bodyTemperature
+                form.respiratoryRate
+                form.bodyTemperature
                 form.sysRepeated
                 form.diaRepeated
-        )
-        form.respiratoryRate
-        form.bodyTemperature
+            )
+
+    else
+        Nothing
 
 
 resolveMedicationsNonAdministrationReasons :

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -736,27 +736,28 @@ toVitalsValueWithDefault saved form =
 toVitalsValue : VitalsForm -> Maybe VitalsValue
 toVitalsValue form =
     let
+        rrSkipped =
+            form.respiratoryRateNotTaken == Just True
+
+        tempSkipped =
+            form.bodyTemperatureNotTaken == Just True
+
         rrField =
-            if form.respiratoryRateNotTaken == Just True then
+            if rrSkipped then
                 Nothing
 
             else
                 form.respiratoryRate
 
         tempField =
-            if form.bodyTemperatureNotTaken == Just True then
+            if tempSkipped then
                 Nothing
 
             else
                 form.bodyTemperature
 
         anyContent =
-            isJust rrField
-                || isJust tempField
-                || form.respiratoryRateNotTaken
-                == Just True
-                || form.bodyTemperatureNotTaken
-                == Just True
+            isJust rrField || isJust tempField || rrSkipped || tempSkipped
     in
     if anyContent then
         Just

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -695,8 +695,30 @@ vitalsFormWithDefault form saved =
                 , heartRateDirty = form.heartRateDirty
                 , respiratoryRate = maybeValueConsideringIsDirtyField form.respiratoryRateDirty form.respiratoryRate value.respiratoryRate
                 , respiratoryRateDirty = form.respiratoryRateDirty
+                , respiratoryRateNotTaken =
+                    if form.respiratoryRateDirty then
+                        form.respiratoryRateNotTaken
+
+                    else
+                        case value.respiratoryRate of
+                            Just _ ->
+                                Just False
+
+                            Nothing ->
+                                Just True
                 , bodyTemperature = maybeValueConsideringIsDirtyField form.bodyTemperatureDirty form.bodyTemperature value.bodyTemperature
                 , bodyTemperatureDirty = form.bodyTemperatureDirty
+                , bodyTemperatureNotTaken =
+                    if form.bodyTemperatureDirty then
+                        form.bodyTemperatureNotTaken
+
+                    else
+                        case value.bodyTemperature of
+                            Just _ ->
+                                Just False
+
+                            Nothing ->
+                                Just True
                 , sysRepeated = maybeValueConsideringIsDirtyField form.sysRepeatedDirty form.sysRepeated value.sysRepeated
                 , sysRepeatedDirty = form.sysRepeatedDirty
                 , diaRepeated = maybeValueConsideringIsDirtyField form.diaRepeatedDirty form.diaRepeated value.diaRepeated
@@ -713,13 +735,36 @@ toVitalsValueWithDefault saved form =
 
 toVitalsValue : VitalsForm -> Maybe VitalsValue
 toVitalsValue form =
-    if isJust form.respiratoryRate || isJust form.bodyTemperature then
+    let
+        rrField =
+            if form.respiratoryRateNotTaken == Just True then
+                Nothing
+
+            else
+                form.respiratoryRate
+
+        tempField =
+            if form.bodyTemperatureNotTaken == Just True then
+                Nothing
+
+            else
+                form.bodyTemperature
+
+        anyContent =
+            isJust rrField
+                || isJust tempField
+                || form.respiratoryRateNotTaken
+                == Just True
+                || form.bodyTemperatureNotTaken
+                == Just True
+    in
+    if anyContent then
         Just
             (VitalsValue form.sysBloodPressure
                 form.diaBloodPressure
                 form.heartRate
-                form.respiratoryRate
-                form.bodyTemperature
+                rrField
+                tempField
                 form.sysRepeated
                 form.diaRepeated
             )

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -742,20 +742,6 @@ toVitalsValue form =
         tempSkipped =
             form.bodyTemperatureNotTaken == Just True
 
-        rrField =
-            if rrSkipped then
-                Nothing
-
-            else
-                form.respiratoryRate
-
-        tempField =
-            if tempSkipped then
-                Nothing
-
-            else
-                form.bodyTemperature
-
         -- Each field must be either explicitly skipped OR have a value.
         -- Refuses partial input regardless of whether the view's task
         -- tracker would have allowed save.
@@ -766,6 +752,21 @@ toVitalsValue form =
             tempSkipped || isJust form.bodyTemperature
     in
     if rrResolved && tempResolved then
+        let
+            rrField =
+                if rrSkipped then
+                    Nothing
+
+                else
+                    form.respiratoryRate
+
+            tempField =
+                if tempSkipped then
+                    Nothing
+
+                else
+                    form.bodyTemperature
+        in
         Just
             (VitalsValue form.sysBloodPressure
                 form.diaBloodPressure

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -1405,12 +1405,6 @@ viewVitalsForm language currentDate config form =
 vitalsFormInputsAndTasks : Language -> NominalDate -> VitalsFormConfig msg -> VitalsForm -> ( List (Html msg), List (Maybe Bool) )
 vitalsFormInputsAndTasks language currentDate config form =
     let
-        respiratoryRateSkipped =
-            form.respiratoryRateNotTaken == Just True
-
-        bodyTemperatureSkipped =
-            form.bodyTemperatureNotTaken == Just True
-
         sysBloodPressureUpdateFunc value form_ =
             { form_ | sysBloodPressure = value, sysBloodPressureDirty = True }
 
@@ -1508,75 +1502,43 @@ vitalsFormInputsAndTasks language currentDate config form =
                 ageInYears
                 |> Maybe.withDefault ( [], [] )
 
-        respiratoryRateCheckbox =
-            if config.allowSkipping then
-                div
-                    [ class "ui checkbox activity"
-                    , onClick <| config.setRespiratoryRateNotTakenMsg <| not respiratoryRateSkipped
-                    ]
-                    [ input
-                        [ type_ "checkbox"
-                        , checked respiratoryRateSkipped
-                        , classList [ ( "checked", respiratoryRateSkipped ) ]
-                        ]
-                        []
-                    , label [] [ text <| translate language Translate.UnableToTakeMeasurement ]
-                    ]
-
-            else
-                emptyNode
-
-        bodyTemperatureCheckbox =
-            if config.allowSkipping then
-                div
-                    [ class "ui checkbox activity"
-                    , onClick <| config.setBodyTemperatureNotTakenMsg <| not bodyTemperatureSkipped
-                    ]
-                    [ input
-                        [ type_ "checkbox"
-                        , checked bodyTemperatureSkipped
-                        , classList [ ( "checked", bodyTemperatureSkipped ) ]
-                        ]
-                        []
-                    , label [] [ text <| translate language Translate.UnableToTakeMeasurement ]
-                    ]
-
-            else
-                emptyNode
-
         respiratoryRateSection =
             let
-                ( redAlerts, yellowAlerts ) =
-                    case config.invokationModule of
-                        InvokationModulePrenatal ->
-                            ( [ [ (>) 12 ], [ (<) 30 ] ]
-                            , [ [ (<=) 21, (>=) 30 ] ]
-                            )
-
-                        _ ->
-                            Maybe.map
-                                (\ageYears ->
-                                    let
-                                        ( redAlertMinValue, redAlertMaxValue ) =
-                                            if ageYears < 1 then
-                                                ( 30, 49 )
-
-                                            else if ageYears < 5 then
-                                                ( 24, 39 )
-
-                                            else
-                                                ( 18, 30 )
-                                    in
-                                    ( [ [ (>) redAlertMinValue ], [ (<) redAlertMaxValue ] ], [] )
-                                )
-                                ageInYears
-                                |> Maybe.withDefault ( [], [] )
+                respiratoryRateSkipped =
+                    form.respiratoryRateNotTaken == Just True
 
                 inputRows =
                     if respiratoryRateSkipped then
                         []
 
                     else
+                        let
+                            ( redAlerts, yellowAlerts ) =
+                                case config.invokationModule of
+                                    InvokationModulePrenatal ->
+                                        ( [ [ (>) 12 ], [ (<) 30 ] ]
+                                        , [ [ (<=) 21, (>=) 30 ] ]
+                                        )
+
+                                    _ ->
+                                        Maybe.map
+                                            (\ageYears ->
+                                                let
+                                                    ( redAlertMinValue, redAlertMaxValue ) =
+                                                        if ageYears < 1 then
+                                                            ( 30, 49 )
+
+                                                        else if ageYears < 5 then
+                                                            ( 24, 39 )
+
+                                                        else
+                                                            ( 18, 30 )
+                                                in
+                                                ( [ [ (>) redAlertMinValue ], [ (<) redAlertMaxValue ] ], [] )
+                                            )
+                                            ageInYears
+                                            |> Maybe.withDefault ( [], [] )
+                        in
                         [ div [ class "ui grid" ]
                             [ div [ class "twelve wide column" ]
                                 [ viewLabel language Translate.RespiratoryRate ]
@@ -1594,6 +1556,24 @@ vitalsFormInputsAndTasks language currentDate config form =
                             Translate.BreathsPerMinuteUnitLabel
                         , Pages.Utils.viewPreviousMeasurement language config.respiratoryRatePreviousValue Translate.BreathsPerMinuteUnitLabel
                         ]
+
+                respiratoryRateCheckbox =
+                    if config.allowSkipping then
+                        div
+                            [ class "ui checkbox activity"
+                            , onClick <| config.setRespiratoryRateNotTakenMsg <| not respiratoryRateSkipped
+                            ]
+                            [ input
+                                [ type_ "checkbox"
+                                , checked respiratoryRateSkipped
+                                , classList [ ( "checked", respiratoryRateSkipped ) ]
+                                ]
+                                []
+                            , label [] [ text <| translate language Translate.UnableToTakeMeasurement ]
+                            ]
+
+                    else
+                        emptyNode
             in
             ( inputRows ++ [ respiratoryRateCheckbox, separator ]
             , [ if respiratoryRateSkipped then
@@ -1606,6 +1586,9 @@ vitalsFormInputsAndTasks language currentDate config form =
 
         bodyTemperatureSection =
             let
+                bodyTemperatureSkipped =
+                    form.bodyTemperatureNotTaken == Just True
+
                 inputRows =
                     if bodyTemperatureSkipped then
                         []
@@ -1628,6 +1611,24 @@ vitalsFormInputsAndTasks language currentDate config form =
                             Translate.Celsius
                         , Pages.Utils.viewPreviousMeasurement language config.bodyTemperaturePreviousValue Translate.Celsius
                         ]
+
+                bodyTemperatureCheckbox =
+                    if config.allowSkipping then
+                        div
+                            [ class "ui checkbox activity"
+                            , onClick <| config.setBodyTemperatureNotTakenMsg <| not bodyTemperatureSkipped
+                            ]
+                            [ input
+                                [ type_ "checkbox"
+                                , checked bodyTemperatureSkipped
+                                , classList [ ( "checked", bodyTemperatureSkipped ) ]
+                                ]
+                                []
+                            , label [] [ text <| translate language Translate.UnableToTakeMeasurement ]
+                            ]
+
+                    else
+                        emptyNode
             in
             ( inputRows ++ [ bodyTemperatureCheckbox ]
             , [ if bodyTemperatureSkipped then

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -1504,8 +1504,10 @@ vitalsFormInputsAndTasks language currentDate config form =
 
         respiratoryRateSection =
             let
+                -- Gate on allowSkipping so non-skipping pages don't end up
+                -- with a hidden input + no checkbox when a saved row has null.
                 respiratoryRateSkipped =
-                    form.respiratoryRateNotTaken == Just True
+                    config.allowSkipping && (form.respiratoryRateNotTaken == Just True)
 
                 inputRows =
                     if respiratoryRateSkipped then
@@ -1586,8 +1588,10 @@ vitalsFormInputsAndTasks language currentDate config form =
 
         bodyTemperatureSection =
             let
+                -- Gate on allowSkipping so non-skipping pages don't end up
+                -- with a hidden input + no checkbox when a saved row has null.
                 bodyTemperatureSkipped =
-                    form.bodyTemperatureNotTaken == Just True
+                    config.allowSkipping && (form.bodyTemperatureNotTaken == Just True)
 
                 inputRows =
                     if bodyTemperatureSkipped then

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -1509,48 +1509,52 @@ vitalsFormInputsAndTasks language currentDate config form =
                 respiratoryRateSkipped =
                     config.allowSkipping && (form.respiratoryRateNotTaken == Just True)
 
+                -- Label row is always shown so it's clear which measurement
+                -- a checked "Unable to take" checkbox refers to.
+                labelRow =
+                    let
+                        ( redAlerts, yellowAlerts ) =
+                            case config.invokationModule of
+                                InvokationModulePrenatal ->
+                                    ( [ [ (>) 12 ], [ (<) 30 ] ]
+                                    , [ [ (<=) 21, (>=) 30 ] ]
+                                    )
+
+                                _ ->
+                                    Maybe.map
+                                        (\ageYears ->
+                                            let
+                                                ( redAlertMinValue, redAlertMaxValue ) =
+                                                    if ageYears < 1 then
+                                                        ( 30, 49 )
+
+                                                    else if ageYears < 5 then
+                                                        ( 24, 39 )
+
+                                                    else
+                                                        ( 18, 30 )
+                                            in
+                                            ( [ [ (>) redAlertMinValue ], [ (<) redAlertMaxValue ] ], [] )
+                                        )
+                                        ageInYears
+                                        |> Maybe.withDefault ( [], [] )
+                    in
+                    div [ class "ui grid" ]
+                        [ div [ class "twelve wide column" ]
+                            [ viewLabel language Translate.RespiratoryRate ]
+                        , div [ class "four wide column" ]
+                            [ viewConditionalAlert form.respiratoryRate
+                                redAlerts
+                                yellowAlerts
+                            ]
+                        ]
+
                 inputRows =
                     if respiratoryRateSkipped then
                         []
 
                     else
-                        let
-                            ( redAlerts, yellowAlerts ) =
-                                case config.invokationModule of
-                                    InvokationModulePrenatal ->
-                                        ( [ [ (>) 12 ], [ (<) 30 ] ]
-                                        , [ [ (<=) 21, (>=) 30 ] ]
-                                        )
-
-                                    _ ->
-                                        Maybe.map
-                                            (\ageYears ->
-                                                let
-                                                    ( redAlertMinValue, redAlertMaxValue ) =
-                                                        if ageYears < 1 then
-                                                            ( 30, 49 )
-
-                                                        else if ageYears < 5 then
-                                                            ( 24, 39 )
-
-                                                        else
-                                                            ( 18, 30 )
-                                                in
-                                                ( [ [ (>) redAlertMinValue ], [ (<) redAlertMaxValue ] ], [] )
-                                            )
-                                            ageInYears
-                                            |> Maybe.withDefault ( [], [] )
-                        in
-                        [ div [ class "ui grid" ]
-                            [ div [ class "twelve wide column" ]
-                                [ viewLabel language Translate.RespiratoryRate ]
-                            , div [ class "four wide column" ]
-                                [ viewConditionalAlert form.respiratoryRate
-                                    redAlerts
-                                    yellowAlerts
-                                ]
-                            ]
-                        , viewMeasurementInput
+                        [ viewMeasurementInput
                             language
                             (Maybe.map toFloat form.respiratoryRate)
                             (config.setIntInputMsg respiratoryRateUpdateFunc)
@@ -1577,7 +1581,7 @@ vitalsFormInputsAndTasks language currentDate config form =
                     else
                         emptyNode
             in
-            ( inputRows ++ [ respiratoryRateCheckbox, separator ]
+            ( labelRow :: inputRows ++ [ respiratoryRateCheckbox, separator ]
             , [ if respiratoryRateSkipped then
                     maybeToBoolTask form.respiratoryRateNotTaken
 
@@ -1593,21 +1597,25 @@ vitalsFormInputsAndTasks language currentDate config form =
                 bodyTemperatureSkipped =
                     config.allowSkipping && (form.bodyTemperatureNotTaken == Just True)
 
+                -- Label row is always shown so it's clear which measurement
+                -- a checked "Unable to take" checkbox refers to.
+                labelRow =
+                    div [ class "ui grid" ]
+                        [ div [ class "twelve wide column" ]
+                            [ viewLabel language Translate.BodyTemperature ]
+                        , div [ class "four wide column" ]
+                            [ viewConditionalAlert form.bodyTemperature
+                                [ [ (>) 35 ], [ (<=) 37.5 ] ]
+                                []
+                            ]
+                        ]
+
                 inputRows =
                     if bodyTemperatureSkipped then
                         []
 
                     else
-                        [ div [ class "ui grid" ]
-                            [ div [ class "twelve wide column" ]
-                                [ viewLabel language Translate.BodyTemperature ]
-                            , div [ class "four wide column" ]
-                                [ viewConditionalAlert form.bodyTemperature
-                                    [ [ (>) 35 ], [ (<=) 37.5 ] ]
-                                    []
-                                ]
-                            ]
-                        , viewMeasurementInput
+                        [ viewMeasurementInput
                             language
                             form.bodyTemperature
                             (config.setFloatInputMsg bodyTemperatureUpdateFunc)
@@ -1634,7 +1642,7 @@ vitalsFormInputsAndTasks language currentDate config form =
                     else
                         emptyNode
             in
-            ( inputRows ++ [ bodyTemperatureCheckbox ]
+            ( labelRow :: inputRows ++ [ bodyTemperatureCheckbox ]
             , [ if bodyTemperatureSkipped then
                     maybeToBoolTask form.bodyTemperatureNotTaken
 

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -1405,6 +1405,12 @@ viewVitalsForm language currentDate config form =
 vitalsFormInputsAndTasks : Language -> NominalDate -> VitalsFormConfig msg -> VitalsForm -> ( List (Html msg), List (Maybe Bool) )
 vitalsFormInputsAndTasks language currentDate config form =
     let
+        respiratoryRateSkipped =
+            form.respiratoryRateNotTaken == Just True
+
+        bodyTemperatureSkipped =
+            form.bodyTemperatureNotTaken == Just True
+
         sysBloodPressureUpdateFunc value form_ =
             { form_ | sysBloodPressure = value, sysBloodPressureDirty = True }
 
@@ -1502,6 +1508,42 @@ vitalsFormInputsAndTasks language currentDate config form =
                 ageInYears
                 |> Maybe.withDefault ( [], [] )
 
+        respiratoryRateCheckbox =
+            if config.allowSkipping then
+                div
+                    [ class "ui checkbox activity"
+                    , onClick <| config.setRespiratoryRateNotTakenMsg <| not respiratoryRateSkipped
+                    ]
+                    [ input
+                        [ type_ "checkbox"
+                        , checked respiratoryRateSkipped
+                        , classList [ ( "checked", respiratoryRateSkipped ) ]
+                        ]
+                        []
+                    , label [] [ text <| translate language Translate.UnableToTakeMeasurement ]
+                    ]
+
+            else
+                emptyNode
+
+        bodyTemperatureCheckbox =
+            if config.allowSkipping then
+                div
+                    [ class "ui checkbox activity"
+                    , onClick <| config.setBodyTemperatureNotTakenMsg <| not bodyTemperatureSkipped
+                    ]
+                    [ input
+                        [ type_ "checkbox"
+                        , checked bodyTemperatureSkipped
+                        , classList [ ( "checked", bodyTemperatureSkipped ) ]
+                        ]
+                        []
+                    , label [] [ text <| translate language Translate.UnableToTakeMeasurement ]
+                    ]
+
+            else
+                emptyNode
+
         respiratoryRateSection =
             let
                 ( redAlerts, yellowAlerts ) =
@@ -1529,47 +1571,71 @@ vitalsFormInputsAndTasks language currentDate config form =
                                 )
                                 ageInYears
                                 |> Maybe.withDefault ( [], [] )
-            in
-            ( [ div [ class "ui grid" ]
-                    [ div [ class "twelve wide column" ]
-                        [ viewLabel language Translate.RespiratoryRate ]
-                    , div [ class "four wide column" ]
-                        [ viewConditionalAlert form.respiratoryRate
-                            redAlerts
-                            yellowAlerts
+
+                inputRows =
+                    if respiratoryRateSkipped then
+                        []
+
+                    else
+                        [ div [ class "ui grid" ]
+                            [ div [ class "twelve wide column" ]
+                                [ viewLabel language Translate.RespiratoryRate ]
+                            , div [ class "four wide column" ]
+                                [ viewConditionalAlert form.respiratoryRate
+                                    redAlerts
+                                    yellowAlerts
+                                ]
+                            ]
+                        , viewMeasurementInput
+                            language
+                            (Maybe.map toFloat form.respiratoryRate)
+                            (config.setIntInputMsg respiratoryRateUpdateFunc)
+                            "respiratory-rate"
+                            Translate.BreathsPerMinuteUnitLabel
+                        , Pages.Utils.viewPreviousMeasurement language config.respiratoryRatePreviousValue Translate.BreathsPerMinuteUnitLabel
                         ]
-                    ]
-              , viewMeasurementInput
-                    language
-                    (Maybe.map toFloat form.respiratoryRate)
-                    (config.setIntInputMsg respiratoryRateUpdateFunc)
-                    "respiratory-rate"
-                    Translate.BreathsPerMinuteUnitLabel
-              , Pages.Utils.viewPreviousMeasurement language config.respiratoryRatePreviousValue Translate.BreathsPerMinuteUnitLabel
-              , separator
+            in
+            ( inputRows ++ [ respiratoryRateCheckbox, separator ]
+            , [ if respiratoryRateSkipped then
+                    maybeToBoolTask form.respiratoryRateNotTaken
+
+                else
+                    maybeToBoolTask form.respiratoryRate
               ]
-            , [ maybeToBoolTask form.respiratoryRate ]
             )
 
         bodyTemperatureSection =
-            ( [ div [ class "ui grid" ]
-                    [ div [ class "twelve wide column" ]
-                        [ viewLabel language Translate.BodyTemperature ]
-                    , div [ class "four wide column" ]
-                        [ viewConditionalAlert form.bodyTemperature
-                            [ [ (>) 35 ], [ (<=) 37.5 ] ]
-                            []
+            let
+                inputRows =
+                    if bodyTemperatureSkipped then
+                        []
+
+                    else
+                        [ div [ class "ui grid" ]
+                            [ div [ class "twelve wide column" ]
+                                [ viewLabel language Translate.BodyTemperature ]
+                            , div [ class "four wide column" ]
+                                [ viewConditionalAlert form.bodyTemperature
+                                    [ [ (>) 35 ], [ (<=) 37.5 ] ]
+                                    []
+                                ]
+                            ]
+                        , viewMeasurementInput
+                            language
+                            form.bodyTemperature
+                            (config.setFloatInputMsg bodyTemperatureUpdateFunc)
+                            "body-temperature"
+                            Translate.Celsius
+                        , Pages.Utils.viewPreviousMeasurement language config.bodyTemperaturePreviousValue Translate.Celsius
                         ]
-                    ]
-              , viewMeasurementInput
-                    language
-                    form.bodyTemperature
-                    (config.setFloatInputMsg bodyTemperatureUpdateFunc)
-                    "body-temperature"
-                    Translate.Celsius
-              , Pages.Utils.viewPreviousMeasurement language config.bodyTemperaturePreviousValue Translate.Celsius
+            in
+            ( inputRows ++ [ bodyTemperatureCheckbox ]
+            , [ if bodyTemperatureSkipped then
+                    maybeToBoolTask form.bodyTemperatureNotTaken
+
+                else
+                    maybeToBoolTask form.bodyTemperature
               ]
-            , [ maybeToBoolTask form.bodyTemperature ]
             )
 
         separator =

--- a/client/src/elm/Pages/AcuteIllness/Activity/Model.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Model.elm
@@ -18,7 +18,8 @@ import SyncManager.Model exposing (Site)
 
 
 type Msg
-    = SetActivePage Page
+    = NoOp
+    | SetActivePage Page
     | SetAlertsDialogState Bool
     | SetWarningPopupState (Maybe AcuteIllnessDiagnosis)
     | SetPertinentSymptomsPopupState Bool

--- a/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
@@ -100,6 +100,9 @@ update site selectedHealthCenter id db msg model =
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| AcuteIllnessEncounterPage id ]
     in
     case msg of
+        NoOp ->
+            ( model, Cmd.none, [] )
+
         SetActivePage page ->
             ( model
             , Cmd.none

--- a/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
@@ -371,9 +371,9 @@ generateVitalsFormConfig isChw assembled =
         resolvePreviousMaybeValue assembled .vitals .heartRate
             |> Maybe.map toFloat
     , respiratoryRatePreviousValue =
-        resolvePreviousValue assembled .vitals .respiratoryRate
+        resolvePreviousMaybeValue assembled .vitals .respiratoryRate
             |> Maybe.map toFloat
-    , bodyTemperaturePreviousValue = resolvePreviousValue assembled .vitals .bodyTemperature
+    , bodyTemperaturePreviousValue = resolvePreviousMaybeValue assembled .vitals .bodyTemperature
     , birthDate = assembled.person.birthDate
     , formClass = "vitals"
     , mode =
@@ -2716,34 +2716,32 @@ feverAtPhysicalExam measurements =
     measurements.vitals
         |> Maybe.andThen
             (\measurement ->
-                let
-                    bodyTemperature =
-                        Tuple.second measurement
-                            |> .value
-                            |> .bodyTemperature
-                in
-                if bodyTemperature >= 37.5 then
-                    Just bodyTemperature
+                Tuple.second measurement
+                    |> .value
+                    |> .bodyTemperature
+                    |> Maybe.andThen
+                        (\bodyTemperature ->
+                            if bodyTemperature >= 37.5 then
+                                Just bodyTemperature
 
-                else
-                    Nothing
+                            else
+                                Nothing
+                        )
             )
 
 
 respiratoryRateElevated : NominalDate -> Person -> AcuteIllnessMeasurements -> Bool
 respiratoryRateElevated currentDate person measurements =
-    Maybe.map
+    Maybe.andThen
         (\measurement ->
             let
                 maybeAgeMonths =
                     ageInMonths currentDate person
-
-                respiratoryRate =
-                    Tuple.second measurement
-                        |> .value
-                        |> .respiratoryRate
             in
-            respiratoryRateElevatedByAge maybeAgeMonths respiratoryRate
+            Tuple.second measurement
+                |> .value
+                |> .respiratoryRate
+                |> Maybe.map (respiratoryRateElevatedByAge maybeAgeMonths)
         )
         measurements.vitals
         |> Maybe.withDefault False
@@ -2751,18 +2749,16 @@ respiratoryRateElevated currentDate person measurements =
 
 respiratoryRateElevatedForCovid19 : NominalDate -> Person -> AcuteIllnessMeasurements -> Bool
 respiratoryRateElevatedForCovid19 currentDate person measurements =
-    Maybe.map
+    Maybe.andThen
         (\measurement ->
             let
                 maybeAgeMonths =
                     ageInMonths currentDate person
-
-                respiratoryRate =
-                    Tuple.second measurement
-                        |> .value
-                        |> .respiratoryRate
             in
-            respiratoryRateElevatedByAgeForCovid19 maybeAgeMonths respiratoryRate
+            Tuple.second measurement
+                |> .value
+                |> .respiratoryRate
+                |> Maybe.map (respiratoryRateElevatedByAgeForCovid19 maybeAgeMonths)
         )
         measurements.vitals
         |> Maybe.withDefault False

--- a/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
@@ -365,6 +365,8 @@ generateVitalsFormConfig : Bool -> AssembledData -> VitalsFormConfig Msg
 generateVitalsFormConfig isChw assembled =
     { setIntInputMsg = SetVitalsIntInput
     , setFloatInputMsg = SetVitalsFloatInput
+    , setRespiratoryRateNotTakenMsg = always NoOp
+    , setBodyTemperatureNotTakenMsg = always NoOp
     , sysBloodPressurePreviousValue = resolvePreviousMaybeValue assembled .vitals .sys
     , diaBloodPressurePreviousValue = resolvePreviousMaybeValue assembled .vitals .dia
     , heartRatePreviousValue =
@@ -383,6 +385,7 @@ generateVitalsFormConfig isChw assembled =
         else
             VitalsFormFull
     , invokationModule = InvokationModuleAcuteIllness
+    , allowSkipping = False
     }
 
 

--- a/client/src/elm/Pages/AcuteIllness/Activity/View.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/View.elm
@@ -176,24 +176,26 @@ pertinentSymptomsPopup language isOpen closeMsg measurements =
 
             viewBodyTemperature =
                 vitalsValue
-                    |> Maybe.map
+                    |> Maybe.andThen
                         (.bodyTemperature
-                            >> (\bodyTemperature ->
+                            >> Maybe.map
+                                (\bodyTemperature ->
                                     viewLabelValuePopupItem
                                         Translate.BodyTemperature
                                         (String.fromFloat bodyTemperature ++ " " ++ translate language Translate.CelsiusAbbrev)
-                               )
+                                )
                         )
 
             viewRespiratoryRate =
                 vitalsValue
-                    |> Maybe.map
+                    |> Maybe.andThen
                         (.respiratoryRate
-                            >> (\respiratoryRate ->
+                            >> Maybe.map
+                                (\respiratoryRate ->
                                     viewLabelValuePopupItem
                                         Translate.RespiratoryRate
                                         (String.fromInt respiratoryRate ++ " " ++ translate language Translate.BreathsPerMinuteUnitLabel)
-                               )
+                                )
                         )
 
             travelHistory =

--- a/client/src/elm/Pages/AcuteIllness/ProgressReport/View.elm
+++ b/client/src/elm/Pages/AcuteIllness/ProgressReport/View.elm
@@ -463,7 +463,7 @@ viewPhysicalExamPane language currentDate firstInitialWithSubsequent secondIniti
                             bodyTemperature =
                                 encounterData.measurements.vitals
                                     |> getMeasurementValueFunc
-                                    |> Maybe.map .bodyTemperature
+                                    |> Maybe.andThen .bodyTemperature
 
                             bodyTemperatureValue =
                                 Maybe.map
@@ -486,7 +486,7 @@ viewPhysicalExamPane language currentDate firstInitialWithSubsequent secondIniti
                             respiratoryRate =
                                 encounterData.measurements.vitals
                                     |> getMeasurementValueFunc
-                                    |> Maybe.map .respiratoryRate
+                                    |> Maybe.andThen .respiratoryRate
 
                             respiratoryRateValue =
                                 Maybe.map

--- a/client/src/elm/Pages/NCD/Activity/Utils.elm
+++ b/client/src/elm/Pages/NCD/Activity/Utils.elm
@@ -199,18 +199,6 @@ mandatoryActivitiesForNextStepsCompleted currentDate assembled =
         |> List.all (activityCompleted currentDate assembled)
 
 
-resolvePreviousValue : AssembledData -> (NCDMeasurements -> Maybe ( id, NCDMeasurement a )) -> (a -> b) -> Maybe b
-resolvePreviousValue assembled measurementFunc valueFunc =
-    assembled.previousEncountersData
-        |> List.filterMap
-            (.measurements
-                >> measurementFunc
-                >> Maybe.map (Tuple.second >> .value >> valueFunc)
-            )
-        |> List.reverse
-        |> List.head
-
-
 resolvePreviousMaybeValue : AssembledData -> (NCDMeasurements -> Maybe ( id, NCDMeasurement a )) -> (a -> Maybe b) -> Maybe b
 resolvePreviousMaybeValue assembled measurementFunc valueFunc =
     assembled.previousEncountersData

--- a/client/src/elm/Pages/NCD/Activity/Utils.elm
+++ b/client/src/elm/Pages/NCD/Activity/Utils.elm
@@ -333,9 +333,9 @@ generateVitalsFormConfig assembled =
         resolvePreviousMaybeValue assembled .vitals .heartRate
             |> Maybe.map toFloat
     , respiratoryRatePreviousValue =
-        resolvePreviousValue assembled .vitals .respiratoryRate
+        resolvePreviousMaybeValue assembled .vitals .respiratoryRate
             |> Maybe.map toFloat
-    , bodyTemperaturePreviousValue = resolvePreviousValue assembled .vitals .bodyTemperature
+    , bodyTemperaturePreviousValue = resolvePreviousMaybeValue assembled .vitals .bodyTemperature
     , birthDate = assembled.person.birthDate
     , formClass = "vitals"
     , mode = VitalsFormFull

--- a/client/src/elm/Pages/NCD/Activity/Utils.elm
+++ b/client/src/elm/Pages/NCD/Activity/Utils.elm
@@ -327,6 +327,8 @@ generateVitalsFormConfig : AssembledData -> VitalsFormConfig Msg
 generateVitalsFormConfig assembled =
     { setIntInputMsg = SetVitalsIntInput
     , setFloatInputMsg = SetVitalsFloatInput
+    , setRespiratoryRateNotTakenMsg = always NoOp
+    , setBodyTemperatureNotTakenMsg = always NoOp
     , sysBloodPressurePreviousValue = resolvePreviousMaybeValue assembled .vitals .sys
     , diaBloodPressurePreviousValue = resolvePreviousMaybeValue assembled .vitals .dia
     , heartRatePreviousValue =
@@ -340,6 +342,7 @@ generateVitalsFormConfig assembled =
     , formClass = "vitals"
     , mode = VitalsFormFull
     , invokationModule = InvokationModuleNCD
+    , allowSkipping = False
     }
 
 

--- a/client/src/elm/Pages/Prenatal/Activity/Utils.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Utils.elm
@@ -5239,6 +5239,8 @@ generateVitalsFormConfig : AssembledData -> VitalsFormConfig Msg
 generateVitalsFormConfig assembled =
     { setIntInputMsg = SetVitalsIntInput
     , setFloatInputMsg = SetVitalsFloatInput
+    , setRespiratoryRateNotTakenMsg = always NoOp
+    , setBodyTemperatureNotTakenMsg = always NoOp
     , sysBloodPressurePreviousValue = resolvePreviousMaybeValue assembled .vitals .sys
     , diaBloodPressurePreviousValue = resolvePreviousMaybeValue assembled .vitals .dia
     , heartRatePreviousValue =
@@ -5252,6 +5254,7 @@ generateVitalsFormConfig assembled =
     , formClass = "examination vitals"
     , mode = VitalsFormFull
     , invokationModule = InvokationModulePrenatal
+    , allowSkipping = False
     }
 
 

--- a/client/src/elm/Pages/Prenatal/Activity/Utils.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Utils.elm
@@ -3415,7 +3415,7 @@ highUrineProteinInitialPhase measurements =
 respiratoryRateElevated : PrenatalMeasurements -> Bool
 respiratoryRateElevated measurements =
     getMeasurementValueFunc measurements.vitals
-        |> Maybe.map (\value -> value.respiratoryRate > 30)
+        |> Maybe.andThen (\value -> Maybe.map (\rr -> rr > 30) value.respiratoryRate)
         |> Maybe.withDefault False
 
 
@@ -5245,9 +5245,9 @@ generateVitalsFormConfig assembled =
         resolvePreviousMaybeValue assembled .vitals .heartRate
             |> Maybe.map toFloat
     , respiratoryRatePreviousValue =
-        resolvePreviousValue assembled .vitals .respiratoryRate
+        resolvePreviousMaybeValue assembled .vitals .respiratoryRate
             |> Maybe.map toFloat
-    , bodyTemperaturePreviousValue = resolvePreviousValue assembled .vitals .bodyTemperature
+    , bodyTemperaturePreviousValue = resolvePreviousMaybeValue assembled .vitals .bodyTemperature
     , birthDate = assembled.person.birthDate
     , formClass = "examination vitals"
     , mode = VitalsFormFull

--- a/client/src/elm/Pages/Prenatal/RecurrentActivity/Utils.elm
+++ b/client/src/elm/Pages/Prenatal/RecurrentActivity/Utils.elm
@@ -565,6 +565,8 @@ generateVitalsFormConfig : AssembledData -> VitalsForm -> VitalsFormConfig Msg
 generateVitalsFormConfig assembled form =
     { setIntInputMsg = \_ _ -> NoOp
     , setFloatInputMsg = SetVitalsFloatInput
+    , setRespiratoryRateNotTakenMsg = always NoOp
+    , setBodyTemperatureNotTakenMsg = always NoOp
     , sysBloodPressurePreviousValue = form.sysBloodPressure
     , diaBloodPressurePreviousValue = form.diaBloodPressure
     , heartRatePreviousValue = Nothing
@@ -574,6 +576,7 @@ generateVitalsFormConfig assembled form =
     , formClass = "examination vitals"
     , mode = VitalsFormRepeated
     , invokationModule = InvokationModulePrenatal
+    , allowSkipping = False
     }
 
 

--- a/client/src/elm/Pages/WellChild/Activity/Model.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Model.elm
@@ -29,6 +29,8 @@ type Msg
     | SaveSymptomsReview PersonId (Maybe ( WellChildSymptomsReviewId, WellChildSymptomsReview )) (Maybe DangerSignsTask)
     | SetVitalsIntInput (Maybe Int -> VitalsForm -> VitalsForm) String
     | SetVitalsFloatInput (Maybe Float -> VitalsForm -> VitalsForm) String
+    | SetBodyTemperatureNotTaken Bool
+    | SetRespiratoryRateNotTaken Bool
     | SaveVitals PersonId (Maybe ( WellChildVitalsId, WellChildVitals )) (Maybe DangerSignsTask)
       -- NUTRITION ASSESMENT
     | SetActiveNutritionAssessmentTask NutritionAssessmentTask

--- a/client/src/elm/Pages/WellChild/Activity/Update.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Update.elm
@@ -298,6 +298,50 @@ update currentDate site id db msg model =
             , []
             )
 
+        SetBodyTemperatureNotTaken value ->
+            let
+                updatedData =
+                    let
+                        updatedForm =
+                            model.dangerSignsData.vitalsForm
+                                |> (\form ->
+                                        { form
+                                            | bodyTemperature = Nothing
+                                            , bodyTemperatureDirty = True
+                                            , bodyTemperatureNotTaken = Just value
+                                        }
+                                   )
+                    in
+                    model.dangerSignsData
+                        |> (\data -> { data | vitalsForm = updatedForm })
+            in
+            ( { model | dangerSignsData = updatedData }
+            , Cmd.none
+            , []
+            )
+
+        SetRespiratoryRateNotTaken value ->
+            let
+                updatedData =
+                    let
+                        updatedForm =
+                            model.dangerSignsData.vitalsForm
+                                |> (\form ->
+                                        { form
+                                            | respiratoryRate = Nothing
+                                            , respiratoryRateDirty = True
+                                            , respiratoryRateNotTaken = Just value
+                                        }
+                                   )
+                    in
+                    model.dangerSignsData
+                        |> (\data -> { data | vitalsForm = updatedForm })
+            in
+            ( { model | dangerSignsData = updatedData }
+            , Cmd.none
+            , []
+            )
+
         SaveVitals personId saved nextTask ->
             let
                 measurementId =

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -720,18 +720,8 @@ dangerSignsTasksCompletedFromTotal currentDate isChw assembled data task =
 
 mandatoryDangerSignsTasksCompleted : AssembledData -> Bool
 mandatoryDangerSignsTasksCompleted assembled =
-    resolvedMandatoryDangerSignsTasksCompleted assembled
-        |> List.all (dangerSignsTaskCompleted assembled)
-
-
-resolvedMandatoryDangerSignsTasksCompleted : AssembledData -> List DangerSignsTask
-resolvedMandatoryDangerSignsTasksCompleted assembled =
-    case assembled.encounter.encounterType of
-        PediatricCare ->
-            [ TaskSymptomsReview, TaskVitals ]
-
-        _ ->
-            [ TaskSymptomsReview, TaskVitals ]
+    dangerSignsTaskCompleted assembled TaskSymptomsReview
+        && dangerSignsTaskCompleted assembled TaskVitals
 
 
 symptomsReviewFormInputsAndTasks : Language -> SymptomsReviewForm -> ( List (Html Msg), List (Maybe Bool) )

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -779,8 +779,11 @@ generateVitalsFormConfig assembled =
     , heartRatePreviousValue = Nothing
     , respiratoryRatePreviousValue =
         resolvePreviousValue assembled .vitals .respiratoryRate
+            |> Maybe.andThen identity
             |> Maybe.map toFloat
-    , bodyTemperaturePreviousValue = resolvePreviousValue assembled .vitals .bodyTemperature
+    , bodyTemperaturePreviousValue =
+        resolvePreviousValue assembled .vitals .bodyTemperature
+            |> Maybe.andThen identity
     , birthDate = assembled.person.birthDate
     , formClass = "vitals"
     , mode = VitalsFormBasic

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -693,8 +693,8 @@ dangerSignsTaskCompleted assembled task =
             isJust measurements.vitals
 
 
-dangerSignsTasksCompletedFromTotal : NominalDate -> AssembledData -> DangerSignsData -> DangerSignsTask -> ( Int, Int )
-dangerSignsTasksCompletedFromTotal currentDate assembled data task =
+dangerSignsTasksCompletedFromTotal : NominalDate -> Bool -> AssembledData -> DangerSignsData -> DangerSignsTask -> ( Int, Int )
+dangerSignsTasksCompletedFromTotal currentDate isChw assembled data task =
     let
         measurements =
             assembled.measurements
@@ -709,7 +709,7 @@ dangerSignsTasksCompletedFromTotal currentDate assembled data task =
                 TaskVitals ->
                     let
                         formConfig =
-                            generateVitalsFormConfig assembled
+                            generateVitalsFormConfig isChw assembled
                     in
                     getMeasurementValueFunc measurements.vitals
                         |> vitalsFormWithDefault data.vitalsForm
@@ -718,26 +718,20 @@ dangerSignsTasksCompletedFromTotal currentDate assembled data task =
     resolveTasksCompletedFromTotal tasks
 
 
-mandatoryDangerSignsTasksCompleted : Site -> AssembledData -> Bool
-mandatoryDangerSignsTasksCompleted site assembled =
-    resolvedMandatoryDangerSignsTasksCompleted site assembled
+mandatoryDangerSignsTasksCompleted : AssembledData -> Bool
+mandatoryDangerSignsTasksCompleted assembled =
+    resolvedMandatoryDangerSignsTasksCompleted assembled
         |> List.all (dangerSignsTaskCompleted assembled)
 
 
-resolvedMandatoryDangerSignsTasksCompleted : Site -> AssembledData -> List DangerSignsTask
-resolvedMandatoryDangerSignsTasksCompleted site assembled =
+resolvedMandatoryDangerSignsTasksCompleted : AssembledData -> List DangerSignsTask
+resolvedMandatoryDangerSignsTasksCompleted assembled =
     case assembled.encounter.encounterType of
         PediatricCare ->
             [ TaskSymptomsReview, TaskVitals ]
 
-        -- CHW encounter types.
         _ ->
-            if site == SiteBurundi then
-                -- Vitals are optional for CHW in Burundi.
-                [ TaskSymptomsReview ]
-
-            else
-                [ TaskSymptomsReview, TaskVitals ]
+            [ TaskSymptomsReview, TaskVitals ]
 
 
 symptomsReviewFormInputsAndTasks : Language -> SymptomsReviewForm -> ( List (Html Msg), List (Maybe Bool) )
@@ -770,10 +764,12 @@ symptomsReviewFormInputsAndTasks language form =
     )
 
 
-generateVitalsFormConfig : AssembledData -> VitalsFormConfig Msg
-generateVitalsFormConfig assembled =
+generateVitalsFormConfig : Bool -> AssembledData -> VitalsFormConfig Msg
+generateVitalsFormConfig isChw assembled =
     { setIntInputMsg = SetVitalsIntInput
     , setFloatInputMsg = SetVitalsFloatInput
+    , setRespiratoryRateNotTakenMsg = SetRespiratoryRateNotTaken
+    , setBodyTemperatureNotTakenMsg = SetBodyTemperatureNotTaken
     , sysBloodPressurePreviousValue = Nothing
     , diaBloodPressurePreviousValue = Nothing
     , heartRatePreviousValue = Nothing
@@ -788,6 +784,7 @@ generateVitalsFormConfig assembled =
     , formClass = "vitals"
     , mode = VitalsFormBasic
     , invokationModule = InvokationModuleWellChild
+    , allowSkipping = isChw
     }
 
 

--- a/client/src/elm/Pages/WellChild/Activity/View.elm
+++ b/client/src/elm/Pages/WellChild/Activity/View.elm
@@ -231,7 +231,7 @@ viewActivity language currentDate zscores site features isChw activity assembled
             viewPregnancySummaryForm language currentDate assembled model.pregnancySummaryForm
 
         WellChildDangerSigns ->
-            viewDangerSignsContent language currentDate assembled model.dangerSignsData
+            viewDangerSignsContent language currentDate isChw assembled model.dangerSignsData
 
         WellChildNutritionAssessment ->
             viewNutritionAssessmenContent language currentDate site zscores isChw assembled db model.nutritionAssessmentData
@@ -581,10 +581,11 @@ viewPregnancySummaryForm language currentDate assembled form_ =
 viewDangerSignsContent :
     Language
     -> NominalDate
+    -> Bool
     -> AssembledData
     -> DangerSignsData
     -> List (Html Msg)
-viewDangerSignsContent language currentDate assembled data =
+viewDangerSignsContent language currentDate isChw assembled data =
     let
         measurements =
             assembled.measurements
@@ -630,7 +631,7 @@ viewDangerSignsContent language currentDate assembled data =
 
         tasksCompletedFromTotalDict =
             tasks
-                |> List.map (\task -> ( task, dangerSignsTasksCompletedFromTotal currentDate assembled data task ))
+                |> List.map (\task -> ( task, dangerSignsTasksCompletedFromTotal currentDate isChw assembled data task ))
                 |> Dict.fromList
 
         ( tasksCompleted, totalTasks ) =
@@ -652,6 +653,7 @@ viewDangerSignsContent language currentDate assembled data =
                         |> vitalsFormWithDefault data.vitalsForm
                         |> viewVitalsForm language
                             currentDate
+                            isChw
                             assembled
                         |> List.singleton
 
@@ -695,11 +697,11 @@ viewDangerSignsContent language currentDate assembled data =
     ]
 
 
-viewVitalsForm : Language -> NominalDate -> AssembledData -> VitalsForm -> Html Msg
-viewVitalsForm language currentDate assembled form =
+viewVitalsForm : Language -> NominalDate -> Bool -> AssembledData -> VitalsForm -> Html Msg
+viewVitalsForm language currentDate isChw assembled form =
     let
         formConfig =
-            generateVitalsFormConfig assembled
+            generateVitalsFormConfig isChw assembled
     in
     Measurement.View.viewVitalsForm language currentDate formConfig form
 

--- a/client/src/elm/Pages/WellChild/Encounter/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Encounter/Utils.elm
@@ -131,8 +131,8 @@ pediatricCareMilestoneToComparable milestone =
             10
 
 
-allowEndingEncounter : NominalDate -> Site -> List WellChildActivity -> AssembledData -> Bool
-allowEndingEncounter currentDate site pendingActivities assembled =
+allowEndingEncounter : NominalDate -> List WellChildActivity -> AssembledData -> Bool
+allowEndingEncounter currentDate pendingActivities assembled =
     List.filter (\activity -> not <| List.member activity [ WellChildNCDA, WellChildPhoto ]) pendingActivities
         |> (\pending ->
                 case pending of
@@ -144,7 +144,7 @@ allowEndingEncounter currentDate site pendingActivities assembled =
                             False
 
                         else
-                            mandatoryDangerSignsTasksCompleted site assembled
+                            mandatoryDangerSignsTasksCompleted assembled
 
                     [ WellChildNutritionAssessment ] ->
                         if assembled.encounter.encounterType == PediatricCare then
@@ -158,7 +158,7 @@ allowEndingEncounter currentDate site pendingActivities assembled =
                             False
 
                         else
-                            mandatoryDangerSignsTasksCompleted site assembled
+                            mandatoryDangerSignsTasksCompleted assembled
                                 && mandatoryNutritionAssessmentTasksCompleted currentDate assembled
 
                     [ WellChildNutritionAssessment, WellChildDangerSigns ] ->
@@ -166,7 +166,7 @@ allowEndingEncounter currentDate site pendingActivities assembled =
                             False
 
                         else
-                            mandatoryDangerSignsTasksCompleted site assembled
+                            mandatoryDangerSignsTasksCompleted assembled
                                 && mandatoryNutritionAssessmentTasksCompleted currentDate assembled
 
                     _ ->

--- a/client/src/elm/Pages/WellChild/Encounter/View.elm
+++ b/client/src/elm/Pages/WellChild/Encounter/View.elm
@@ -238,7 +238,7 @@ viewMainPageContent language currentDate zscores site features id isChw db assem
                 action
 
         allowEndEncounter =
-            allowEndingEncounter currentDate site pendingActivities assembled
+            allowEndingEncounter currentDate pendingActivities assembled
 
         content =
             div [ class "ui full segment" ]

--- a/client/src/elm/Pages/WellChild/ProgressReport/View.elm
+++ b/client/src/elm/Pages/WellChild/ProgressReport/View.elm
@@ -162,7 +162,7 @@ view language currentDate zscores site features id isChw db model =
                     in
                     ( Just
                         { showEndEncounterDialog = model.showEndEncounterDialog
-                        , allowEndEncounter = allowEndingEncounter currentDate site pendingActivities assembled
+                        , allowEndEncounter = allowEndingEncounter currentDate pendingActivities assembled
                         , closeEncounterMsg = CloseEncounter id
                         , setEndEncounterDialogStateMsg = SetEndEncounterDialogState
                         , startEncounterMsg = NoOp

--- a/docs/superpowers/specs/2026-04-28-vitals-skip-nulls-design.md
+++ b/docs/superpowers/specs/2026-04-28-vitals-skip-nulls-design.md
@@ -1,0 +1,621 @@
+# "Unable to take measurement" for Well Child Vitals (CHW) — null-field design
+
+**Date:** 2026-04-28
+**Issue:** [#1471](https://github.com/TIP-Global-Health/eheza-app/issues/1471)
+**Stacked on:** [PR #1653](https://github.com/TIP-Global-Health/eheza-app/pull/1653) (branch `revert-1641-restore-issue-1448`)
+
+## Background
+
+PR #1653 (unmerged) introduced an "Unable to take measurement" checkbox for
+Height and Weight in CHW Nutrition / Well Child encounters. The pattern PR
+#1653 established for **single-measurement** forms is:
+
+- New Elm type `SkippedForm = SkippedHeight | SkippedWeight`.
+- An `EverySet SkippedForm` field on `NutritionEncounter` and
+  `WellChildEncounter` records, persisted as Drupal multi-value field
+  `field_skipped_forms` with allowed values `height`, `weight`.
+- When a measurement is skipped: **no measurement node saved**. The
+  encounter records the skip in its `skipped_forms` set so the activity
+  still counts as complete.
+- When a measurement is entered: the measurement node is saved, and the
+  encounter's skip set has the entry removed if it was previously set.
+
+This works for Height/Weight because each form has exactly one measurement;
+"no row saved" is a natural way to represent skipping. The encounter-level
+skip set distinguishes "deliberately skipped" from "not yet entered."
+
+## Requirement
+
+A CHW (Burundi or Rwanda in practice — gated only by `isChw`) must be
+able to skip Vitals measurements on Well Child encounters. The Vitals form
+in CHW mode (`VitalsFormBasic`) carries **two** measurements — respiratory
+rate and body temperature — that must be skippable **independently**.
+
+## Why a different design from PR #1653's
+
+The encounter-level skip set works cleanly for single-measurement forms,
+but creates a redundancy and a source-of-truth conflict for
+multi-measurement forms with nullable value fields:
+
+> Scenario: User saves Vitals with RR=20, Temp=37 → `well_child_vitals`
+> row exists with both values. User re-edits, marks both as "unable to
+> take", saves. With encounter-level skips, only the encounter's
+> `skipped_forms` is updated; the existing measurement row is left alone.
+> The encounter's set says "both skipped" while the row says "both have
+> values" — two layers contradicting each other.
+
+For Vitals — and for any future multi-measurement form — the cleaner
+design is to push the skip indicator down onto the measurement node itself
+via nullable value fields. The measurement node becomes the single source
+of truth: a null field on a saved row means "we tried to take this
+measurement but couldn't."
+
+This spec adopts that approach **for Vitals only**. PR #1653's existing
+`field_skipped_forms` mechanism for Height and Weight is unchanged.
+
+## Non-goals
+
+- **No changes to PR #1653's Height/Weight skip mechanism.** The
+  `SkippedForm` type, the `field_skipped_forms` Drupal field, the
+  encounter records' `skippedForms` field, and the
+  `Add/RemoveSkippedForm` msgs all stay exactly as PR #1653 has them. We
+  do not retroactively migrate Height/Weight to null-based skipping.
+- No skip support for AcuteIllness CHW Vitals (also `VitalsFormBasic`
+  but outside the requirement).
+- No skip support for Vitals fields beyond RR / temp (BP, heart rate,
+  repeated readings — never relevant in `VitalsFormBasic`).
+- No progress-report UI distinguishing "skipped" from "missing."
+  Consistent with PR #1653's Height/Weight precedent.
+- No reporting/stats updates: the only server-side reads of these fields
+  are on `acute_illness_vitals`, which is unaffected.
+- No retroactive backfill of existing `well_child_vitals` rows.
+
+## Architecture overview
+
+```
+                     CLIENT (Elm)                                 SERVER (Drupal)
+┌───────────────────────────────────────────┐    ┌──────────────────────────────────────────┐
+│ VitalsValue                               │    │ well_child_vitals (bundle)               │
+│   { respiratoryRate : Maybe Int           │    │   field_respiratory_rate                 │
+│   , bodyTemperature : Maybe Float         │    │     required => 0                        │
+│   , ...other fields...                    │    │   field_body_temperature                 │
+│   }                                       │ ◄──┤     required => 0                        │
+└───────────────────────────────────────────┘    │                                          │
+                                                 │ Other 3 Vitals bundles                   │
+                                                 │ (vitals, acute_illness_vitals,           │
+┌───────────────────────────────────────────┐    │  ncd_vitals): unchanged.                 │
+│ Skip indication: a `well_child_vitals`    │    │ Their bundles' field_respiratory_rate /  │
+│ row's null field IS the skip indicator.   │    │ field_body_temperature stay              │
+│ Row exists, RR=null → CHW skipped RR.     │    │ required => 1.                           │
+│ Row exists, RR=Just _ → CHW entered RR.   │    └──────────────────────────────────────────┘
+│ Row never exists → form never saved.      │
+└───────────────────────────────────────────┘
+
+NO encounter-level field for Vitals skips. PR #1653's field_skipped_forms
+on well_child_encounter and nutrition_encounter remains unchanged and
+still serves Height/Weight.
+```
+
+**Single source of truth for Vitals skip state**: the `well_child_vitals`
+node itself. The form's transient `*NotTaken` flags exist only to drive
+UI rendering; on save, they translate to nulls in the persisted row.
+
+## Naming
+
+No new type, no rename. PR #1653's `SkippedForm = SkippedHeight |
+SkippedWeight` stays untouched. The skip semantics for Vitals live in
+the `VitalsValue` value type itself — no domain type for "vitals skip"
+is introduced.
+
+The form-side flags follow the convention PR #1653 set with
+`HeightForm.measurementNotTaken : Maybe Bool`, but per measurement:
+`VitalsForm.respiratoryRateNotTaken : Maybe Bool` and
+`VitalsForm.bodyTemperatureNotTaken : Maybe Bool`. Same `Maybe Bool`
+shape; per-measurement names because Vitals carries two skippable
+measurements per form.
+
+## Data model
+
+### `VitalsValue` nullability
+
+```elm
+type alias VitalsValue =
+    { sys : Maybe Float
+    , dia : Maybe Float
+    , heartRate : Maybe Int
+    , respiratoryRate : Maybe Int   -- was Int
+    , bodyTemperature : Maybe Float -- was Float
+    , sysRepeated : Maybe Float
+    , diaRepeated : Maybe Float
+    }
+```
+
+Decoder: `optional "respiratory_rate" (nullable int) Nothing` and
+analogous for body temperature. Encoder:
+`( "respiratory_rate", maybe int v.respiratoryRate )`.
+
+The four encounter types (`Vitals` for Prenatal, `AcuteIllnessVitals`,
+`WellChildVitals`, `NCDVitals`) all alias `VitalsValue`. The decoder is
+shared; the change is one place. Existing rows in any bundle have non-null
+values at the DB level — the new decoder reads them as `Just _`. New
+`Nothing` writes happen only on Well Child CHW Vitals saves.
+
+### Drupal schema
+
+Only `well_child_vitals`'s field instances need permissive (`required =>
+0`) settings to accept null writes. As of the current branch HEAD, both
+`node-well_child_vitals-field_respiratory_rate` and
+`node-well_child_vitals-field_body_temperature` are already
+`'required' => 0` in source (set in commit `bdfd30c97 "Introduce 2 new
+CTs"`). No source change is required, only confirmation via `drush fra`
+that the live DB matches.
+
+`vitals` (Prenatal), `acute_illness_vitals`, and `ncd_vitals` field
+instances keep `required => 1`. Server-side validation still rejects
+null on those bundles. Their forms always populate values before save.
+
+### Encounter records
+
+`WellChildEncounter` and `NutritionEncounter` are **unchanged from PR
+#1653**. The `skippedForms : EverySet SkippedForm` field stays. The
+`Add/RemoveSkippedForm` msgs stay. Vitals does not interact with this
+mechanism.
+
+## Form/UX layer
+
+### `VitalsForm`
+
+```elm
+type alias VitalsForm =
+    { sysBloodPressure : Maybe Float
+    , sysBloodPressureDirty : Bool
+    , diaBloodPressure : Maybe Float
+    , diaBloodPressureDirty : Bool
+    , heartRate : Maybe Int
+    , heartRateDirty : Bool
+    , respiratoryRate : Maybe Int
+    , respiratoryRateDirty : Bool
+    , respiratoryRateNotTaken : Maybe Bool      -- NEW
+    , bodyTemperature : Maybe Float
+    , bodyTemperatureDirty : Bool
+    , bodyTemperatureNotTaken : Maybe Bool      -- NEW
+    , sysRepeated : Maybe Float
+    , sysRepeatedDirty : Bool
+    , diaRepeated : Maybe Float
+    , diaRepeatedDirty : Bool
+    }
+```
+
+Per-measurement transient flags. They drive the UI checkbox state and
+get translated to null fields on the saved `VitalsValue` at save time.
+
+### `VitalsFormConfig`
+
+```elm
+type alias VitalsFormConfig msg =
+    { -- ... existing fields ...
+    , setRespiratoryRateNotTakenMsg : Bool -> msg     -- NEW
+    , setBodyTemperatureNotTakenMsg : Bool -> msg     -- NEW
+    , allowSkipping : Bool                            -- NEW
+    }
+```
+
+`allowSkipping` is a single boolean — both checkboxes appear together or
+neither does. YAGNI on per-measurement gates: there is no requirement to
+allow skipping one but not the other.
+
+### `allowSkipping` is set per encounter type
+
+| Page | Mode | `allowSkipping` |
+|---|---|---|
+| Prenatal | `VitalsFormFull` | `False` |
+| NCD | `VitalsFormFull` | `False` |
+| AcuteIllness (nurse) | `VitalsFormFull` | `False` |
+| AcuteIllness (CHW) | `VitalsFormBasic` | `False` |
+| WellChild | `VitalsFormBasic` | `isChw` |
+
+`Pages/WellChild/Activity/Utils.elm` `generateVitalsFormConfig` gains
+an `isChw : Bool` parameter (matching AcuteIllness's signature) so the
+gate can be set without re-deriving from `assembled.encounter.encounterType`.
+
+The other three pages (Prenatal, Prenatal Recurrent, NCD, AcuteIllness)
+each get their `VitalsFormConfig` constructor updated with
+`allowSkipping = False` and no-op msgs for `setRespiratoryRateNotTakenMsg`
+and `setBodyTemperatureNotTakenMsg`. AcuteIllness gets a private
+`IgnoreSkipMsg Bool` no-op msg added to its `Msg` type since it lacks
+a `NoOp`; the others reuse existing `NoOp`.
+
+### View rendering
+
+In `vitalsFormInputsAndTasks` (`Measurement/View.elm`): when
+`config.allowSkipping`, render an "Unable to take measurement" checkbox
+under each of the RR and temp inputs. When a checkbox is checked, the
+corresponding numeric input is hidden. Task tracker accepts the checked
+box in lieu of a numeric value. The two checkboxes are independent.
+
+`UnableToTakeMeasurement` translation already exists from PR #1653.
+
+## Form ↔ value plumbing
+
+### `vitalsFormWithDefault`
+
+```elm
+vitalsFormWithDefault : VitalsForm -> Maybe VitalsValue -> VitalsForm
+vitalsFormWithDefault form saved =
+    saved
+        |> unwrap
+            -- No saved value: use form as is.
+            form
+            (\value ->
+                { -- ... blood pressure / heart rate / repeated fields, unchanged ...
+                , respiratoryRate = maybeValueConsideringIsDirtyField form.respiratoryRateDirty form.respiratoryRate value.respiratoryRate
+                , respiratoryRateDirty = form.respiratoryRateDirty
+                , respiratoryRateNotTaken =
+                    if form.respiratoryRateDirty then
+                        form.respiratoryRateNotTaken
+
+                    else
+                        -- Derive from saved row: null = skipped.
+                        case value.respiratoryRate of
+                            Just _ ->
+                                Just False
+
+                            Nothing ->
+                                Just True
+                , bodyTemperature = maybeValueConsideringIsDirtyField form.bodyTemperatureDirty form.bodyTemperature value.bodyTemperature
+                , bodyTemperatureDirty = form.bodyTemperatureDirty
+                , bodyTemperatureNotTaken =
+                    if form.bodyTemperatureDirty then
+                        form.bodyTemperatureNotTaken
+
+                    else
+                        case value.bodyTemperature of
+                            Just _ ->
+                                Just False
+
+                            Nothing ->
+                                Just True
+                -- ... other fields ...
+                }
+            )
+```
+
+Note: **no `EverySet SkippedMeasurement` parameter**. The form's
+checkbox state is derived purely from the saved row's null fields. If
+the row's RR is null, the form's `respiratoryRateNotTaken` defaults to
+`Just True` (checkbox shows checked).
+
+### `toVitalsValue` and `toVitalsValueWithDefault`
+
+```elm
+toVitalsValue : VitalsForm -> Maybe VitalsValue
+toVitalsValue form =
+    let
+        rrField =
+            if form.respiratoryRateNotTaken == Just True then
+                Nothing
+
+            else
+                form.respiratoryRate
+
+        tempField =
+            if form.bodyTemperatureNotTaken == Just True then
+                Nothing
+
+            else
+                form.bodyTemperature
+
+        anyContent =
+            isJust rrField
+                || isJust tempField
+                || form.respiratoryRateNotTaken == Just True
+                || form.bodyTemperatureNotTaken == Just True
+    in
+    if anyContent then
+        Just
+            (VitalsValue form.sysBloodPressure
+                form.diaBloodPressure
+                form.heartRate
+                rrField
+                tempField
+                form.sysRepeated
+                form.diaRepeated
+            )
+
+    else
+        Nothing
+
+
+toVitalsValueWithDefault : Maybe VitalsValue -> VitalsForm -> Maybe VitalsValue
+toVitalsValueWithDefault saved form =
+    vitalsFormWithDefault form saved
+        |> toVitalsValue
+```
+
+`toVitalsValue` returns `Just` whenever the user has interacted with at
+least one of RR or temp (entered or marked skipped). The constructed
+`VitalsValue` carries nulls for skipped fields. This means that for
+**both-skipped**, `toVitalsValue` still returns `Just (VitalsValue ...
+respiratoryRate=Nothing bodyTemperature=Nothing ...)` — a row IS saved,
+with both relevant fields as null. There is no "no row saved" case for
+Vitals on save.
+
+For non-CHW pages, the form always populates real values before save
+(the form's task tracker enforces it), so `toVitalsValue` returns `Just`
+with both fields populated.
+
+## Save flow
+
+`Pages/WellChild/Activity/Update.elm`. The `SaveVitals` msg has its
+existing PR #1653 signature (no `EverySet SkippedMeasurement` parameter):
+
+```elm
+SaveVitals PersonId (Maybe ( WellChildVitalsId, WellChildVitals )) (Maybe DangerSignsTask)
+```
+
+Handler:
+
+```elm
+SaveVitals personId saved nextTask ->
+    let
+        form_ =
+            model.dangerSignsData.vitalsForm
+
+        measurementId =
+            Maybe.map Tuple.first saved
+
+        measurement =
+            getMeasurementValueFunc saved
+
+        appMsgs =
+            toVitalsValueWithDefault measurement form_
+                |> Maybe.map
+                    (\value ->
+                        [ Backend.WellChildEncounter.Model.SaveVitals personId measurementId value
+                            |> Backend.Model.MsgWellChildEncounter id
+                            |> App.Model.MsgIndexedDb
+                        ]
+                    )
+                |> Maybe.withDefault []
+
+        extraMsgs =
+            generateDangerSignsMsgs nextTask
+    in
+    ( model, Cmd.none, appMsgs )
+        |> sequenceExtra (update currentDate site id db) extraMsgs
+```
+
+Single code path. No `if rrSkip && tempSkip then ...` branching. No
+`Add/RemoveSkippedMeasurement` msgs (because we don't have those —
+PR #1653's encounter-level skip set is unchanged and only used for
+Height/Weight).
+
+The constructed `VitalsValue` carries the skip semantics via its null
+fields. The save dispatches a single PATCH/POST to the
+`well_child_vitals` shard endpoint, which the service worker intercepts
+and writes to local IndexedDB plus the `shardChanges` outgoing queue.
+On reopen, the form rehydrates from that row's null fields.
+
+## `Maybe` propagation through read-sites
+
+Phase 2 of the prior branch already audited these sites; the work
+carries over identically. Full list:
+
+| Site | Pattern | Change |
+|---|---|---|
+| `Backend/Update.elm:2342-2350` | `value.bodyTemperature < 35 \|\| value.bodyTemperature >= 37.5` (Well Child danger signs) | Wrap each comparison in `Maybe.map (\t -> ...) \|> Maybe.withDefault False`. Semantic: missing measurement → no alert. |
+| `Backend/PrenatalActivity/Utils.elm:280,404` | `value \|> .bodyTemperature` / `.respiratoryRate` inside an outer `Maybe.andThen` | Inner becomes nested `Maybe.andThen`. |
+| `Pages/AcuteIllness/ProgressReport/View.elm:466,489` | `Maybe.map .bodyTemperature` | Becomes `Maybe.andThen .bodyTemperature` to flatten. |
+| `Pages/AcuteIllness/Activity/Utils.elm:2723` (`feverAtPhysicalExam`) | `.bodyTemperature` direct read inside `Maybe.andThen` | `Maybe.andThen` chain on the inner field. |
+| `Pages/AcuteIllness/Activity/Utils.elm:2744,2763` (`respiratoryRateElevated`, `respiratoryRateElevatedForCovid19`) | `.respiratoryRate` direct read inside `Maybe.map` | `Maybe.andThen` and `Maybe.withDefault False`. |
+| `Pages/AcuteIllness/Activity/View.elm:180,191` | Point-free `(.bodyTemperature ...)` / `(.respiratoryRate ...)` accessors inside `Maybe.map` chains | Replace with `Maybe.andThen`. |
+| `Pages/Prenatal/Activity/Utils.elm:3418` | `Maybe.map (\value -> value.respiratoryRate > 30)` | Nested `Maybe.andThen` to flatten the now-`Maybe Int`. |
+| Four `resolvePreviousValue ... .vitals .respiratoryRate` / `.bodyTemperature` sites in WellChild, Prenatal, NCD, AcuteIllness `Activity/Utils.elm` | Passes field accessor as `(a -> b)` argument | Switch to existing `resolvePreviousMaybeValue` helper for Prenatal/NCD/AcuteIllness; for WellChild use `\|> Maybe.andThen identity` to flatten. |
+| `Measurement/Utils.elm` `vitalsFormWithDefault`, `toVitalsValueWithDefault`, `toVitalsValue` | Form ↔ value plumbing | See "Form ↔ value plumbing" section above. |
+| `Backend/Measurement/Decoder.elm` `decodeVitalsValue` | `required "respiratory_rate" int` / `"body_temperature" float` | Switch to `optional ... (nullable int) Nothing`. |
+| `Backend/Measurement/Encoder.elm` `encodeVitalsValueWithType` | `( "respiratory_rate", int v.respiratoryRate )` | `( "respiratory_rate", maybe int v.respiratoryRate )`. |
+
+### Helper-signature stance
+
+Functions like `respiratoryRateElevatedByAge : Maybe Int -> Int -> Bool`
+and `respiratoryRateAbnormalForAge` keep their `Int` second parameter.
+Callers do the `Maybe.andThen`. Rationale: helpers express clinical
+predicates on a *known* rate; "we have no rate" is a caller-side decision.
+
+## End-encounter gating
+
+Today, `Pages/WellChild/Activity/Utils.elm:727-740` has the implicit
+optionality pattern PR #1653 was designed to replace:
+
+```elm
+resolvedMandatoryDangerSignsTasksCompleted site assembled =
+    case assembled.encounter.encounterType of
+        PediatricCare ->
+            [ TaskSymptomsReview, TaskVitals ]
+        _ ->
+            if site == SiteBurundi then
+                [ TaskSymptomsReview ]   -- Vitals silently optional
+            else
+                [ TaskSymptomsReview, TaskVitals ]
+```
+
+Burundi CHWs can currently end Well Child encounters without ever
+opening Vitals.
+
+### Changes
+
+1. `TaskVitals` becomes always mandatory:
+
+   ```elm
+   resolvedMandatoryDangerSignsTasksCompleted assembled =
+       case assembled.encounter.encounterType of
+           PediatricCare ->
+               [ TaskSymptomsReview, TaskVitals ]
+           _ ->
+               [ TaskSymptomsReview, TaskVitals ]
+   ```
+
+2. `dangerSignsTaskCompleted` for `TaskVitals` returns to the simple
+   form: a row exists.
+
+   ```elm
+   TaskVitals ->
+       isJust measurements.vitals
+   ```
+
+   The row's existence is the proof of "task done" because the row
+   carries the skip state via its null fields. If the row exists with
+   one or both fields null, the user explicitly chose to skip those.
+
+3. `Site` parameter ripples out:
+   - `mandatoryDangerSignsTasksCompleted : Site -> AssembledData -> Bool`
+     → `AssembledData -> Bool`.
+   - `allowEndingEncounter : NominalDate -> Site -> List WellChildActivity -> AssembledData -> Bool`
+     → `NominalDate -> List WellChildActivity -> AssembledData -> Bool`.
+   - Callsites in `Pages/WellChild/Encounter/View.elm:241`,
+     `Pages/WellChild/Encounter/Utils.elm:147,154,161-162,169-170`,
+     `Pages/WellChild/Activity/Utils.elm:1550` lose the `site` argument.
+
+After this change, `Site` no longer appears in mandatory-task logic.
+The only remaining use of role/site for skipping is the `allowSkipping`
+flag in `generateVitalsFormConfig` — UI policy, not data semantics.
+
+## E2E coverage
+
+Extend `client/e2e/helpers/well-child.ts` with two helpers:
+
+- `skipRespiratoryRate(page)` — open Vitals tab, click the RR
+  "Unable to take measurement" checkbox.
+- `skipBodyTemperature(page)` — same for temp.
+
+The helpers do **not** include a Save action — the existing test will
+call Save once both fields are resolved (entered or skipped).
+
+Add three test variants to `client/e2e/well-child-encounter-chw.spec.ts`:
+
+1. **Partial skip — RR skipped, temp entered.** CHW Well Child encounter
+   with all mandatory activities completed. For Vitals: call
+   `skipRespiratoryRate(page)`, fill body temperature normally, save.
+   Encounter ends successfully. Backend assertion: a `well_child_vitals`
+   row exists for the encounter, with `field_respiratory_rate` NULL and
+   `field_body_temperature` populated.
+
+2. **Both skipped.** Same setup. For Vitals: call both
+   `skipRespiratoryRate(page)` and `skipBodyTemperature(page)`, save.
+   Encounter ends successfully. Backend assertion: a `well_child_vitals`
+   row exists with both `field_respiratory_rate` and
+   `field_body_temperature` NULL.
+
+3. **Negative gate — PediatricCare nurse OR AcuteIllness CHW.**
+   No skip checkboxes appear. (Pick whichever role has an existing
+   e2e flow that's quickest to extend.)
+
+Existing tests for non-skip CHW Well Child Vitals (where both values
+are entered) must continue to pass without modification.
+
+## Branching plan
+
+**Base:** `revert-1641-restore-issue-1448` (PR #1653, untouched).
+
+**Working branch:** `vitals-skip-nulls`, branched off the current HEAD
+of `revert-1641-restore-issue-1448` (commit `c0ad16351`).
+
+**Workflow:**
+1. Land the commits below on `vitals-skip-nulls`.
+2. Open a PR targeting `revert-1641-restore-issue-1448` (NOT `develop`).
+3. After approval, merge into `revert-1641-restore-issue-1448`.
+4. PR #1653 remains the single delivery vehicle to `develop` and
+   absorbs the Vitals work via this merge.
+
+`develop` only ever sees the final, coherent state when #1653 lands.
+
+## Commit structure
+
+Three commits, each independently compiles and passes existing tests.
+
+1. **Make `VitalsValue.respiratoryRate` and `.bodyTemperature` nullable;
+   propagate `Maybe` through read-sites.** Touches:
+   `Backend/Measurement/Model.elm`, `Backend/Measurement/Decoder.elm`,
+   `Backend/Measurement/Encoder.elm`, the read-sites listed above,
+   `Measurement/Utils.elm` `vitalsFormWithDefault` /
+   `toVitalsValue` / `toVitalsValueWithDefault`. No behavior change yet —
+   non-CHW pages always populate both fields; the form skip checkboxes
+   come in commit 2. Drupal: confirm `well_child_vitals` field instances
+   are already `required => 0` (no source change needed).
+
+2. **Add Vitals skip UX and end-encounter gating cleanup.** Touches:
+   `Measurement/Model.elm` (`VitalsForm` per-measurement flags;
+   `VitalsFormConfig.allowSkipping` plus the two `set*NotTakenMsg`
+   callbacks), `Measurement/View.elm` (checkbox rendering),
+   `Pages/WellChild/Activity/{Model,Update,View,Utils}.elm`
+   (`SetRespiratoryRateNotTaken` / `SetBodyTemperatureNotTaken` msgs,
+   `generateVitalsFormConfig isChw`, drop `Site` from mandatory-tasks),
+   `Pages/WellChild/Encounter/{View,Utils}.elm` (drop `Site` from
+   `allowEndingEncounter`), other `generateVitalsFormConfig` callers
+   (Prenatal, Prenatal Recurrent, NCD, AcuteIllness — set
+   `allowSkipping = False`; AcuteIllness gains a private
+   `IgnoreSkipMsg` no-op).
+
+3. **E2E helpers and tests** for Vitals skipping.
+
+## Risk register
+
+**Risks accepted (consistent with PR #1653's precedent for Height/Weight)**
+
+- Save dispatches PATCH/POST asynchronously through the service worker.
+  If the service worker fails to write to IndexedDB (offline edge,
+  storage quota), the save fails. UI doesn't currently surface this.
+  Same as every other measurement save in the app.
+
+**Risks specific to this branching strategy**
+
+- PR #1653 may receive review feedback that conflicts with this branch's
+  changes. Mitigation: rebase `vitals-skip-nulls` onto updated
+  `revert-1641-restore-issue-1448` periodically; merge before any major
+  #1653 churn.
+
+## Success criteria
+
+- Any CHW (Burundi or Rwanda in practice) can open the Vitals tab in a
+  Well Child encounter, mark either or both of RR / temp as "Unable to
+  take measurement," and end the encounter successfully.
+- A Well Child PediatricCare nurse encounter does not show the
+  checkboxes.
+- AcuteIllness CHW encounters (also `VitalsFormBasic`) do not show
+  the checkboxes — page-level gate, not mode-derived.
+- Save always writes a `well_child_vitals` row when the form is saved
+  (regardless of skip state). Skipped fields are persisted as null.
+- Reopening the form rehydrates the checkbox state from the saved
+  row's null fields. Refreshing the browser (which re-reads IndexedDB)
+  preserves the state once the service worker has written the row.
+- Activity-completion logic for `TaskVitals` is `isJust measurements.vitals`.
+  Encounter-end logic does not branch on `Site`.
+- Existing AcuteIllness, Prenatal, NCD Vitals flows are unchanged from
+  a user-visible perspective.
+- PR #1653's Height/Weight `field_skipped_forms` mechanism is untouched
+  and continues to work as before.
+- Lint (`elm-format`, `phpcs`) clean.
+
+## What this design abandons from the prior branch
+
+For traceability, listing what's **explicitly not in this design** that
+was on `vitals-skip-measurement`:
+
+- `SkippedForm → SkippedMeasurement` rename — reverted; `SkippedForm`
+  stays.
+- New `SkippedRespiratoryRate` / `SkippedBodyTemperature` variants —
+  not added.
+- Drupal `field_skipped_forms → field_skipped_measurements` rename —
+  reverted; field name stays `field_skipped_forms`.
+- Drupal `allowed_values` expansion to four entries — reverted; stays
+  `[height, weight]`.
+- `hedley_schedule_update_7001` / `_7002` install hooks — not added.
+- `Add/RemoveSkippedMeasurement` msgs in `Backend.WellChildEncounter` —
+  not added (the existing PR #1653 msgs `Add/RemoveSkippedForm` stay).
+- Encounter-level `skippedMeasurements` field — not added; PR #1653's
+  `skippedForms` stays.
+- Optimistic encounter Dict update in `Backend.Update.elm` — not added.
+- `vitalsFormWithDefault` taking `EverySet SkippedMeasurement` — does
+  not take that parameter; reads skip state from the saved row's nulls.
+
+The `vitals-skip-measurement` branch is preserved but not delivered.


### PR DESCRIPTION
Stacked on PR #1653. Closes #1471 once #1653 lands.

## Summary

- Extends the "Unable to take measurement" UX to Well Child Vitals — respiratory rate and body temperature, each independently skippable for any CHW (Burundi or Rwanda in practice; gated only by `isChw`).
- Uses a different mechanism than #1653's Height/Weight: skip state lives on the `well_child_vitals` measurement node itself via nullable value fields (`respiratoryRate : Maybe Int`, `bodyTemperature : Maybe Float`). A null field on a saved row IS the skip indicator; row existence proves the form was saved.
- No encounter-level skip set for Vitals. PR #1653's `field_skipped_forms` mechanism for Height/Weight is unchanged.

## Why a different mechanism from #1653

#1653's encounter-level `skipped_forms` works cleanly for single-measurement forms (Height, Weight) where "no row saved" is a natural skip representation.

For multi-measurement forms with nullable fields it creates a redundancy and a source-of-truth conflict: if the user first saves Vitals with values, then re-edits and marks both as skipped, the encounter-level set says "both skipped" while the existing measurement row still has values. Two layers in contradiction.

Pushing the skip state down onto the measurement node (via nulls) makes the row the single source of truth. This PR adopts that pattern for Vitals only; Height/Weight in #1653 stay as they are.

Spec: [`docs/superpowers/specs/2026-04-28-vitals-skip-nulls-design.md`](https://github.com/TIP-Global-Health/eheza-app/blob/vitals-skip-nulls/docs/superpowers/specs/2026-04-28-vitals-skip-nulls-design.md)

## Changes

**Phase 1 — Nullable `VitalsValue`** (`22f9dd2ec`):
- `VitalsValue.respiratoryRate : Int → Maybe Int`, `.bodyTemperature : Float → Maybe Float`.
- Decoder/encoder switch to `nullable`/`maybe`.
- `Maybe` propagated through ~12 read-sites: `Backend/Update.elm` Well Child danger signs, `Backend/PrenatalActivity/Utils.elm`, `AcuteIllness/{ProgressReport/View, Activity/Utils, Activity/View}.elm`, `Prenatal/Activity/Utils.elm:3418`, four `resolvePreviousValue` sites.
- Helper signatures (`respiratoryRateElevatedByAge` etc.) keep their `Int` second parameter; callers do the `Maybe.andThen`.
- `well_child_vitals` Drupal field instances are already `required => 0` (commit `bdfd30c97`); no source change needed.

**Phase 2 — Vitals skip UX + end-encounter gating cleanup** (`4fc6d4128`):
- `VitalsForm` gains `respiratoryRateNotTaken : Maybe Bool` and `bodyTemperatureNotTaken : Maybe Bool`.
- `VitalsFormConfig` gains `setRespiratoryRateNotTakenMsg`, `setBodyTemperatureNotTakenMsg`, `allowSkipping : Bool`.
- Per-measurement "Unable to take measurement" checkboxes render in `vitalsFormInputsAndTasks` when `config.allowSkipping`. Well Child CHW sets `allowSkipping = isChw`; Prenatal, NCD, AcuteIllness all keep `allowSkipping = False` (AcuteIllness CHW also uses `VitalsFormBasic` but does NOT get the checkbox — gate is page-level, not mode-derived).
- `vitalsFormWithDefault` derives the form's `*NotTaken` state from the saved row's null fields (saved RR null → checkbox checked).
- `toVitalsValue` gates on "any content" (entered or skipped) and constructs a `VitalsValue` with nulls for skipped fields. Both-skipped saves a row with both fields null.
- `Pages/WellChild/Activity/Update.elm` `SaveVitals` is unified to a single code path: `toVitalsValueWithDefault measurement form` → if `Just`, dispatch the measurement save; the skip semantics travel with the value.
- End-encounter gating: `TaskVitals` becomes always mandatory in `mandatoryDangerSignsTasksCompleted`; `dangerSignsTaskCompleted TaskVitals` returns to `isJust measurements.vitals` (row exists = task done). `Site` parameter dropped from `mandatoryDangerSignsTasksCompleted` and `allowEndingEncounter`.

**Phase 2 review feedback** (`78a4a700f`):
- `toVitalsValue`: introduce `rrSkipped` / `tempSkipped` locals so the `anyContent` expression reads cleanly instead of mixing `||` and `==`.
- `mandatoryDangerSignsTasksCompleted`: inline the wrapper now that both case branches return the same list.

**Phase 3 — E2E tests** (`108e83964`):
- New test in `client/e2e/well-child-encounter-chw.spec.ts`: round-trip exercising the full state machine within one encounter. Open Vitals, mark both as 'Unable to take', save, sync, verify both fields null. Re-open, untick body temperature, type 36, save, sync, verify RR null + BT=36. Re-open, untick respiratory rate, type 30, save, sync, verify both populated. Re-open, re-tick body temperature, save, sync, verify RR=30 + BT null again. Complete remaining activities, end encounter, final sync + verify.
- `completeDangerSigns` helper extended with `respiratoryRateNotTaken`, `bodyTemperatureNotTaken`, `expectNoSkipCheckboxes` optional flags.
- New `queryWellChildVitalsValues` helper for backend value verification (drush sqlq returning RR / BT field values, with retry-on-empty for eventual consistency).
- `expectNoSkipCheckboxes` assertion added to one existing nurse Well Child test verifying the negative gate (PediatricCare nurses do not see the checkboxes).

**elm-review cleanup** (`ecea3fce5`):
- `Measurement/View.elm` `vitalsFormInputsAndTasks`: moved per-measurement skip locals and checkbox declarations into their owning sections (NoPrematureLetComputation). Moved `(redAlerts, yellowAlerts)` inside the `inputRows` else branch where it's actually used.
- `Pages/NCD/Activity/Utils.elm`: removed the now-unused `resolvePreviousValue` helper (Phase 1 swapped its only callsites to `resolvePreviousMaybeValue`).

## Out of scope

- No changes to PR #1653's Height/Weight skip mechanism (`SkippedForm`, `field_skipped_forms`, `Add/RemoveSkippedForm` msgs all stay).
- No skip support for AcuteIllness CHW Vitals.
- No skip support for Vitals fields beyond RR / temp.
- No progress-report UI distinguishing "skipped" from "missing."
- No retroactive backfill of existing `well_child_vitals` rows.

## Test plan

- [x] elm-format clean
- [x] elm-review clean (3 remaining warnings are pre-existing wildcard-import false positives the compiler needs)
- [x] Manual smoke: CHW Burundi sees both checkboxes
- [x] Manual smoke: PediatricCare nurse does NOT see checkboxes
- [x] Manual smoke: AcuteIllness CHW does NOT see checkboxes
- [x] Manual smoke: partial skip (RR skipped, temp entered) → row saved with `respiratory_rate: null, body_temperature: <value>`; activity ends successfully
- [x] Manual smoke: both skipped → row saved with both fields null; activity ends successfully
- [x] Manual smoke: browser refresh after save preserves checkbox state
- [x] Manual smoke: re-edit untick → row updated; re-edit re-tick → row updated again
- [x] Playwright e2e: round-trip (skip-both → untick BT → untick RR → re-tick BT → end encounter); local run passes in 1.4 min
- [x] Playwright e2e: negative gate via existing nurse test
- [ ] CircleCI: lint_phpcs, lint_elm, lint_shellcheck, test_simpletest_linux, e2e_playwright (verifying on this push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
