### PR TITLE
Add patient-consolidation handlers for HIV, Tuberculosis, Family Nutrition

### DIFF
--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -7,12 +7,18 @@
 
 const HEDLEY_PATIENT_ENCOUNTER_TYPE_VALUE_MAPPING = [
   'acute_illness_encounter' => 'acute-illness',
-  'prenatal_encounter' => 'antenatal',
   'child_scoreboard_encounter' => 'child-scoreboard',
+  'hiv_encounter' => 'hiv',
   'home_visit_encounter' => 'home-visit',
   'ncd_encounter' => 'ncd',
   'nutrition_encounter' => 'nutrition',
+  'prenatal_encounter' => 'antenatal',
+  'tuberculosis_encounter' => 'tuberculosis',
   'well_child_encounter' => 'well-child',
+];
+
+const HEDLEY_PATIENT_FAMILY_ENCOUNTER_TYPE_VALUE_MAPPING = [
+  'family_nutrition_encounter' => 'nutrition',
 ];
 
 /**
@@ -649,6 +655,90 @@ function _consolidate_child_scoreboard_encounter_content_execute(array $measurem
 }
 
 /**
+ * Performs validations before consolidation of HIV encounters content.
+ *
+ * @param array $measurements
+ *   A list of HIV measurements that belong to the 'duplicate' patient.
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @see _consolidate_single_participant_content_validate()
+ *
+ * @return array
+ *   Result and corresponding messages.
+ *
+ * @throws \EntityMetadataWrapperException
+ */
+function _consolidate_hiv_encounter_content_validate(array $measurements, $original, $duplicate) {
+  return _consolidate_single_participant_content_validate($measurements, $original, $duplicate, 'hiv_encounter');
+}
+
+/**
+ * Performs consolidation of HIV encounters content.
+ *
+ * @param array $measurements
+ *   A list of HIV measurements belonging to the 'duplicate' patient.
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @see _consolidate_single_participant_content_execute()
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_hiv_encounter_content_execute(array $measurements, $original, $duplicate) {
+  return _consolidate_single_participant_content_execute($measurements, $original, $duplicate, 'hiv_encounter');
+}
+
+/**
+ * Performs validations before consolidation of Tuberculosis encounters content.
+ *
+ * @param array $measurements
+ *   A list of Tuberculosis measurements that belong to the 'duplicate' patient.
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @see _consolidate_single_participant_content_validate()
+ *
+ * @return array
+ *   Result and corresponding messages.
+ *
+ * @throws \EntityMetadataWrapperException
+ */
+function _consolidate_tuberculosis_encounter_content_validate(array $measurements, $original, $duplicate) {
+  return _consolidate_single_participant_content_validate($measurements, $original, $duplicate, 'tuberculosis_encounter');
+}
+
+/**
+ * Performs consolidation of Tuberculosis encounters content.
+ *
+ * @param array $measurements
+ *   A list of Tuberculosis measurements belonging to the 'duplicate' patient.
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @see _consolidate_single_participant_content_execute()
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_tuberculosis_encounter_content_execute(array $measurements, $original, $duplicate) {
+  return _consolidate_single_participant_content_execute($measurements, $original, $duplicate, 'tuberculosis_encounter');
+}
+
+/**
  * Performs validations before consolidation for single participant use cases.
  *
  * This is a case where we have single participant, with multiple encounters.
@@ -836,17 +926,127 @@ function _consolidate_acute_illness_encounter_content_execute(array $measurement
 }
 
 /**
+ * Performs validations before consolidation of Family Nutrition content.
+ *
+ * Family encounters are special: a family_participant references the adult,
+ * but measurements may target the adult OR a child. The duplicate patient
+ * may be the adult of one or more families, a child within a family, or
+ * both. We require the original to have at most one matching
+ * family_participant, so we know where to repoint encounters when both
+ * sides have one.
+ *
+ * @param array $measurements
+ *   Family Nutrition measurements that belong to the 'duplicate' patient.
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return array
+ *   Result and corresponding messages.
+ *
+ * @throws \EntityMetadataWrapperException
+ */
+function _consolidate_family_nutrition_encounter_content_validate(array $measurements, $original, $duplicate) {
+  $return = [
+    'success' => FALSE,
+    'messages' => [],
+  ];
+
+  $type_value = HEDLEY_PATIENT_FAMILY_ENCOUNTER_TYPE_VALUE_MAPPING['family_nutrition_encounter'];
+
+  $count_measurements = count($measurements);
+  $return['messages'][] = "Duplicate got $count_measurements family_nutrition_encounter measurements.";
+
+  $participants_original = hedley_person_family_participants_for_person($original, [$type_value], 'DESC');
+  $count_original = count($participants_original);
+  if ($count_original > 1) {
+    $return['messages'][] = 'Error: Original is the adult of multiple family_participants of this type. Manual fix required.';
+    return $return;
+  }
+
+  $return['messages'][] = "Original got $count_original family_nutrition_encounter participants (as the adult).";
+
+  $participants_duplicate = hedley_person_family_participants_for_person($duplicate, [$type_value], 'DESC');
+  $count_duplicate = count($participants_duplicate);
+  $return['messages'][] = "Duplicate got $count_duplicate family_nutrition_encounter participants (as the adult).";
+
+  $return['success'] = TRUE;
+  return $return;
+}
+
+/**
+ * Performs consolidation of Family Nutrition encounters content.
+ *
+ * Algorithm:
+ * 1. If original has a matching family_participant, use it as the target.
+ *    Otherwise, take the latest of duplicate's matching participants and
+ *    repoint its field_person to original (it becomes the target).
+ * 2. For any remaining duplicate participants, repoint their encounters to
+ *    the target participant and mark the duplicate participant as deleted.
+ * 3. Repoint all measurements where field_person = duplicate to original.
+ *    These cover both adult-targeted measurements (when duplicate is the
+ *    adult) and child-targeted measurements (when duplicate is the child
+ *    in someone else's family encounter).
+ *
+ * @param array $measurements
+ *   Family Nutrition measurements belonging to the 'duplicate' patient.
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_family_nutrition_encounter_content_execute(array $measurements, $original, $duplicate) {
+  $type_value = HEDLEY_PATIENT_FAMILY_ENCOUNTER_TYPE_VALUE_MAPPING['family_nutrition_encounter'];
+
+  $participants_original = hedley_person_family_participants_for_person($original, [$type_value], 'DESC');
+  $participants_duplicate = hedley_person_family_participants_for_person($duplicate, [$type_value], 'DESC');
+
+  $target_participant = NULL;
+  if (empty($participants_original)) {
+    // Original has no matching family_participant. Take the latest of the
+    // duplicate's participants and repoint it to original.
+    $target_participant = array_pop($participants_duplicate);
+    if (!empty($target_participant)) {
+      _associate_content_by_field([$target_participant], 'field_person', $original);
+    }
+  }
+  else {
+    $target_participant = $participants_original[0];
+  }
+
+  // Repoint encounters of remaining duplicate participants to the target;
+  // mark those participants as deleted.
+  if (!empty($target_participant)) {
+    foreach ($participants_duplicate as $participant) {
+      $encounters = hedley_person_load_family_participant_encounters_ids($participant);
+      _associate_content_by_field($encounters, 'field_family_participant', $target_participant);
+
+      $wrapper_participant = entity_metadata_wrapper('node', $participant);
+      $wrapper_participant->field_deleted->set(TRUE);
+      $wrapper_participant->save();
+    }
+  }
+
+  // Move measurements where field_person = duplicate to original. These
+  // cover both adult-targeted measurements (when duplicate is the adult)
+  // and child-targeted measurements (when duplicate is the child in
+  // someone else's family encounter).
+  _associate_content_by_field($measurements, 'field_person', $original);
+
+  return 'Consolidation of Family Nutrition encounters content is completed.';
+}
+
+/**
  * Groups inputs measurements by the type of encounter to which they belong.
  *
- * Encounter types:
- *   - Group.
- *   - Prenatal.
- *   - Nutrition.
- *   - Acute Illness.
- *   - Home visit.
- *   - Well child.
- *   - NCD.
- *   - Child Scorecard.
+ * Buckets are created for every type returned by
+ * hedley_general_get_encounter_types().
  *
  * @param array $measurements
  *   A list of measurements IDs.

--- a/server/hedley/modules/custom/hedley_person/hedley_person.module
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.module
@@ -1414,6 +1414,51 @@ function hedley_person_load_individual_participant_encounters_ids($nid) {
 }
 
 /**
+ * Resolves family_participant nodes IDs where person is the adult.
+ *
+ * @param int $nid
+ *   Person node ID (the adult on field_person of the family_participant).
+ * @param array $types
+ *   Family encounter types (values of field_family_encounter_type).
+ * @param string $order
+ *   Sorting order.
+ *
+ * @return array
+ *   List of family_participant nodes IDs.
+ */
+function hedley_person_family_participants_for_person($nid, array $types, $order = 'ASC') {
+  $query = hedley_general_create_db_select_query_excluding_deleted();
+  $query->join('field_data_field_person', 'p', 'p.entity_id = n.nid');
+  $query->leftJoin('field_data_field_family_encounter_type', 'et', 'et.entity_id = p.entity_id');
+
+  $query->condition('n.type', 'family_participant');
+  $query->condition('et.field_family_encounter_type_value', $types, 'IN');
+  $query->condition('p.field_person_target_id', $nid);
+  $query->addField('n', 'nid');
+  $query->orderBy('n.nid', $order);
+
+  return $query->execute()->fetchCol();
+}
+
+/**
+ * Resolves the encounters IDs associated with a family participant.
+ *
+ * @param int $nid
+ *   Family participant node ID.
+ *
+ * @return array
+ *   An array of encounters nodes IDs associated with the participant.
+ */
+function hedley_person_load_family_participant_encounters_ids($nid) {
+  $query = hedley_general_create_db_select_query_excluding_deleted();
+  $query->join('field_data_field_family_participant', 'p', 'p.entity_id = n.nid');
+  $query->condition('p.field_family_participant_target_id', $nid);
+  $query->addField('n', 'nid');
+
+  return $query->execute()->fetchCol();
+}
+
+/**
  * Resolves measurements IDs associated with an individual encounter / session.
  *
  * @param int $nid


### PR DESCRIPTION
## Summary
Issue #1729.

- Adds `_consolidate_<type>_content_validate/_execute` for `hiv_encounter`, `tuberculosis_encounter`, and `family_nutrition_encounter`, fixing the `consolidate-patients` drush command which currently errors on any duplicate patient with measurements in those programs.
- HIV and Tuberculosis delegate to the existing single-participant helpers (verified the single-ongoing-participant lifecycle on the Elm side: `Pages/HIV/Participant/View.elm` and `Pages/Tuberculosis/Participant/View.elm` filter on `isNothing endDate` and only allow one ongoing program at a time).
- Family Nutrition has a custom handler that correctly handles a duplicate playing adult-only, child-only, or mixed roles across family encounters.
- Two new query helpers in `hedley_person.module` (`hedley_person_family_participants_for_person`, `hedley_person_load_family_participant_encounters_ids`) mirror the existing pmtct/individual helpers, scoped to `family_participant`.

Note: `family_nutrition_encounter` only enters the consolidation iteration once #1593 lands (which folds family encounters into `hedley_general_get_encounter_types()`), so the family handler is dormant until then. The HIV and Tuberculosis handlers fix pre-existing brokenness on develop immediately.

## Test plan
- [x] CircleCI: lint_phpcs, lint_elm, lint_shellcheck, test_simpletest_linux all green
- [ ] Manual: `drush consolidate-patients --original=X --duplicate=Y` on a duplicate with HIV measurements completes without "_consolidate_hiv_encounter_content_execute does not exist" error
- [ ] Manual: same with Tuberculosis measurements
- [ ] Manual (after #1593 merges): same with Family Nutrition measurements where duplicate is (a) the adult, (b) only a child, (c) both

🤖 Generated with [Claude Code](https://claude.com/claude-code)