### PR TITLE
FBF Distribution report

### DIFF
--- a/client/e2e/helpers/reports.ts
+++ b/client/e2e/helpers/reports.ts
@@ -440,6 +440,20 @@ export async function navigateToReportsMenu(page: Page) {
   await page.locator('.page-content.reports-menu').waitFor({ timeout: 30000 });
 }
 
+/**
+ * Navigate to the Statistical Queries results page for the Global scope (all
+ * patients across all health centers). The Drupal route is registered at
+ * `admin/reports/statistical-queries/all` (see hedley_reports.module).
+ */
+export async function navigateToGlobalReportsPage(page: Page) {
+  const baseUrl = getDdevUrl();
+  // Cache-busting parameter to prevent browser from serving stale page.
+  await page.goto(
+    `${baseUrl}/admin/reports/statistical-queries/all?t=${Date.now()}`,
+  );
+  await page.locator('.page-content.reports').waitFor({ timeout: 30000 });
+}
+
 // ---------------------------------------------------------------------------
 // Report type & date selection
 // ---------------------------------------------------------------------------
@@ -728,6 +742,21 @@ export async function readPostnatalCareTable(
   page: Page,
 ): Promise<SimpleTableData> {
   return readSimpleTable(page, 'div.report.postnatal-care div.table');
+}
+
+/**
+ * Read the FBF Distribution report table.
+ * Container: div.report.fbf-distribution div.table
+ * Each row has 2 cells: [category label, total amount].
+ * Categories: "FBF Child", "FBF Mother", "Aheza Child", "Aheza Mother".
+ * Totals are numeric (whole numbers print without decimals; fractional with up
+ * to 2dp). readSimpleTable parses cells via parseInt — sufficient for the
+ * whole-number test fixtures.
+ */
+export async function readFBFDistributionTable(
+  page: Page,
+): Promise<SimpleTableData> {
+  return readSimpleTable(page, 'div.report.fbf-distribution div.table');
 }
 
 /**

--- a/client/e2e/helpers/reports.ts
+++ b/client/e2e/helpers/reports.ts
@@ -750,8 +750,7 @@ export async function readPostnatalCareTable(
  * Each row has 2 cells: [category label, total amount].
  * Categories: "FBF Child", "FBF Mother", "Aheza Child", "Aheza Mother".
  * Totals are numeric (whole numbers print without decimals; fractional with up
- * to 2dp). readSimpleTable parses cells via parseInt — sufficient for the
- * whole-number test fixtures.
+ * to 2dp). readSimpleTable uses parseFloat, so fractional totals round-trip.
  */
 export async function readFBFDistributionTable(
   page: Page,
@@ -802,7 +801,7 @@ async function readSimpleTable(
     if (cellTexts.length >= 2) {
       rows.push({
         label: cellTexts[0].trim(),
-        total: parseInt(cellTexts[1].trim(), 10) || 0,
+        total: parseFloat(cellTexts[1].trim()) || 0,
       });
     }
   }

--- a/client/e2e/helpers/reports.ts
+++ b/client/e2e/helpers/reports.ts
@@ -702,6 +702,12 @@ export function findEncounterRow(
 export interface SimpleTableRow {
   label: string;
   total: number;
+  /**
+   * Third-column count, when the table renders one. Currently only the
+   * FBF Distribution report has a third column ("Occurrences"). Other
+   * simple-table consumers leave this undefined.
+   */
+  occurrences?: number;
 }
 
 export interface SimpleTableData {
@@ -747,10 +753,11 @@ export async function readPostnatalCareTable(
 /**
  * Read the FBF Distribution report table.
  * Container: div.report.fbf-distribution div.table
- * Each row has 2 cells: [category label, total amount].
+ * Each row has 3 cells: [category label, total amount, occurrences].
  * Categories: "FBF Child", "FBF Mother", "Aheza Child", "Aheza Mother".
  * Totals are numeric (whole numbers print without decimals; fractional with up
- * to 2dp). readSimpleTable uses parseFloat, so fractional totals round-trip.
+ * to 2dp). Occurrences is the count of distribution events contributing to
+ * that total (one event per measurement record).
  */
 export async function readFBFDistributionTable(
   page: Page,
@@ -799,10 +806,14 @@ async function readSimpleTable(
       cellTexts.push((await cells.nth(j).textContent()) ?? '');
     }
     if (cellTexts.length >= 2) {
-      rows.push({
+      const row: SimpleTableRow = {
         label: cellTexts[0].trim(),
         total: parseFloat(cellTexts[1].trim()) || 0,
-      });
+      };
+      if (cellTexts.length >= 3) {
+        row.occurrences = parseFloat(cellTexts[2].trim()) || 0;
+      }
+      rows.push(row);
     }
   }
 

--- a/client/e2e/helpers/reports.ts
+++ b/client/e2e/helpers/reports.ts
@@ -703,9 +703,13 @@ export interface SimpleTableRow {
   label: string;
   total: number;
   /**
-   * Third-column count, when the table renders one. Currently only the
-   * FBF Distribution report has a third column ("Occurrences"). Other
-   * simple-table consumers leave this undefined.
+   * Per-row unit string (e.g., "package", "kg") when the table renders a
+   * Unit column. Currently only the FBF Distribution report uses this.
+   */
+  unit?: string;
+  /**
+   * Count of distribution events when the table renders an Occurrences
+   * column. Currently only the FBF Distribution report uses this.
    */
   occurrences?: number;
 }
@@ -753,11 +757,12 @@ export async function readPostnatalCareTable(
 /**
  * Read the FBF Distribution report table.
  * Container: div.report.fbf-distribution div.table
- * Each row has 3 cells: [category label, total amount, occurrences].
+ * Each row has 4 cells: [category label, total amount, unit, occurrences].
  * Categories: "FBF Child", "FBF Mother", "Aheza Child", "Aheza Mother".
- * Totals are numeric (whole numbers print without decimals; fractional with up
- * to 2dp). Occurrences is the count of distribution events contributing to
- * that total (one event per measurement record).
+ * Totals are numeric (whole numbers print without decimals; fractional with
+ * up to 2dp). Unit is "package" for FBF rows and "kg" for Aheza rows.
+ * Occurrences is the count of distribution events contributing to that
+ * total (one event per measurement record).
  */
 export async function readFBFDistributionTable(
   page: Page,
@@ -810,8 +815,10 @@ async function readSimpleTable(
         label: cellTexts[0].trim(),
         total: parseFloat(cellTexts[1].trim()) || 0,
       };
-      if (cellTexts.length >= 3) {
-        row.occurrences = parseFloat(cellTexts[2].trim()) || 0;
+      // 4-cell layout: [label, total, unit, occurrences] (FBF Distribution).
+      if (cellTexts.length >= 4) {
+        row.unit = cellTexts[2].trim();
+        row.occurrences = parseFloat(cellTexts[3].trim()) || 0;
       }
       rows.push(row);
     }

--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -24,6 +24,7 @@ import {
   readAIDiagnosisRow,
   readPrenatalDiagnosisRow,
   readPrenatalVisitsTable,
+  readFBFDistributionTable,
   readPeripartumTable,
   readPostnatalCareTable,
   findPrenatalRow,
@@ -321,6 +322,10 @@ test.describe('Admin Reports', () => {
     let baselinePNC15WeeksTo10Months: number;
     let baselinePNC10To19Months: number;
     let baselinePNC19To24Months: number;
+    let baselineFBFDistChild: number;
+    let baselineFBFDistMother: number;
+    let baselineAhezaDistChild: number;
+    let baselineAhezaDistMother: number;
     let baselineNutrition: Map<number, NutritionMetricRow[]>;
     let baselineCompletion: CompletionTableData;
     let baselinePrenatalCompletion: CompletionTableData;
@@ -429,6 +434,30 @@ test.describe('Admin Reports', () => {
         `7-11w=${baselinePNC7To11Weeks}, 11-15w=${baselinePNC11To15Weeks}, ` +
         `15w-10mo=${baselinePNC15WeeksTo10Months}, ` +
         `10-19mo=${baselinePNC10To19Months}, 19-24mo=${baselinePNC19To24Months}`,
+      );
+
+      // Record FBF Distribution report baselines. The migration / demo
+      // population can already include FBF and AHEZA records, so the test
+      // encounters are verified by delta against this baseline rather than
+      // absolute totals. The reader uses parseInt on the cells; integer
+      // deltas are preserved correctly even when the underlying floats
+      // truncate, since the test's added amounts are whole numbers.
+      await selectReportType(page, 'fbf-distribution');
+      await setDateRange(page, REPORT_START_DATE, reportLimitDate);
+      const baselineFBFDistTable = await readFBFDistributionTable(page);
+      baselineFBFDistChild =
+        findSimpleRow(baselineFBFDistTable, 'FBF Child')?.total ?? 0;
+      baselineFBFDistMother =
+        findSimpleRow(baselineFBFDistTable, 'FBF Mother')?.total ?? 0;
+      baselineAhezaDistChild =
+        findSimpleRow(baselineFBFDistTable, 'Aheza Child')?.total ?? 0;
+      baselineAhezaDistMother =
+        findSimpleRow(baselineFBFDistTable, 'Aheza Mother')?.total ?? 0;
+      console.log(
+        `Baseline FBF Distribution: fbfChild=${baselineFBFDistChild}, ` +
+        `fbfMother=${baselineFBFDistMother}, ` +
+        `ahezaChild=${baselineAhezaDistChild}, ` +
+        `ahezaMother=${baselineAhezaDistMother}`,
       );
 
       // Record Nutrition report baseline (first column = newest completed month).
@@ -1703,6 +1732,51 @@ test.describe('Admin Reports', () => {
 
       // CSV download button.
       await expect(page.locator('button.download-csv'), 'Nutrition CSV download button should be visible').toBeVisible();
+    });
+
+    // ── Phase 3b: FBF Distribution report ──
+    //
+    // Phase 1a created an FBF nurse group session at Nyange I (FBF clinic,
+    // group_type='fbf') with completeChildFbf (amount '1') and
+    // completeMotherFbf (amount '1'). Phase 1b created a CHW Family
+    // Nutrition encounter with completeAhezaMother (amount '3') and
+    // completeAhezaChild (amount '2'). All test-created persons land at
+    // Nyange HC, so the same HC scope used by the other Phase 3 reports
+    // captures the new distribution rows. Pre-existing migration data may
+    // already contribute non-zero baseline totals, so we assert deltas
+    // against the baseline captured in Phase 0.
+
+    await step('Verify FBF Distribution report deltas', async () => {
+      await selectReportType(page, 'fbf-distribution');
+      await setDateRange(page, REPORT_START_DATE, reportLimitDate);
+
+      const fbfDistribution = await readFBFDistributionTable(page);
+
+      const fbfChild = findSimpleRow(fbfDistribution, 'FBF Child')?.total ?? 0;
+      const fbfMother = findSimpleRow(fbfDistribution, 'FBF Mother')?.total ?? 0;
+      const ahezaChild = findSimpleRow(fbfDistribution, 'Aheza Child')?.total ?? 0;
+      const ahezaMother = findSimpleRow(fbfDistribution, 'Aheza Mother')?.total ?? 0;
+
+      console.log('\n=== FBF DISTRIBUTION ===');
+      console.log(`FBF Child:    ${baselineFBFDistChild} → ${fbfChild} (Δ ${fbfChild - baselineFBFDistChild})`);
+      console.log(`FBF Mother:   ${baselineFBFDistMother} → ${fbfMother} (Δ ${fbfMother - baselineFBFDistMother})`);
+      console.log(`Aheza Child:  ${baselineAhezaDistChild} → ${ahezaChild} (Δ ${ahezaChild - baselineAhezaDistChild})`);
+      console.log(`Aheza Mother: ${baselineAhezaDistMother} → ${ahezaMother} (Δ ${ahezaMother - baselineAhezaDistMother})`);
+
+      // completeChildFbf (amount '1') -> FBF Child +1
+      expect(fbfChild - baselineFBFDistChild, 'FBF Child delta should be +1').toBe(1);
+      // completeMotherFbf (amount '1') -> FBF Mother +1
+      expect(fbfMother - baselineFBFDistMother, 'FBF Mother delta should be +1').toBe(1);
+      // completeAhezaChild (amount '2') -> Aheza Child +2
+      expect(ahezaChild - baselineAhezaDistChild, 'Aheza Child delta should be +2').toBe(2);
+      // completeAhezaMother (amount '3') -> Aheza Mother +3
+      expect(ahezaMother - baselineAhezaDistMother, 'Aheza Mother delta should be +3').toBe(3);
+
+      // CSV download button.
+      await expect(
+        page.locator('button.download-csv'),
+        'FBF Distribution CSV download button should be visible',
+      ).toBeVisible();
     });
 
     // ── Phase 4: Demographics scope (Province) ──

--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -1815,10 +1815,10 @@ test.describe('Admin Reports', () => {
       expect(fbfChildAchi - baselineFBFDistChildAchi, 'FBF Child (ACHI) total delta should be 0').toBe(0);
       expect(fbfChildAchiOccurrences - baselineFBFDistChildAchiOccurrences, 'FBF Child (ACHI) occurrences delta should be 0').toBe(0);
 
-      // Unit column: FBF clinic distributions are in packages; ACHI and
-      // CHW family-nutrition (Aheza) distributions are in kg.
-      expect(fbfChildRow?.unit, 'FBF Child unit should be "package"').toBe('package');
-      expect(fbfMotherRow?.unit, 'FBF Mother unit should be "package"').toBe('package');
+      // Unit column: FBF clinic distributions are in packages (pkg);
+      // ACHI and CHW family-nutrition (Aheza) distributions are in kg.
+      expect(fbfChildRow?.unit, 'FBF Child unit should be "pkg"').toBe('pkg');
+      expect(fbfMotherRow?.unit, 'FBF Mother unit should be "pkg"').toBe('pkg');
       expect(fbfChildAchiRow?.unit, 'FBF Child (ACHI) unit should be "kg"').toBe('kg');
       expect(ahezaChildRow?.unit, 'Aheza Child unit should be "kg"').toBe('kg');
       expect(ahezaMotherRow?.unit, 'Aheza Mother unit should be "kg"').toBe('kg');

--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -324,10 +324,12 @@ test.describe('Admin Reports', () => {
     let baselinePNC19To24Months: number;
     let baselineFBFDistChild: number;
     let baselineFBFDistMother: number;
+    let baselineFBFDistChildAchi: number;
     let baselineAhezaDistChild: number;
     let baselineAhezaDistMother: number;
     let baselineFBFDistChildOccurrences: number;
     let baselineFBFDistMotherOccurrences: number;
+    let baselineFBFDistChildAchiOccurrences: number;
     let baselineAhezaDistChildOccurrences: number;
     let baselineAhezaDistMotherOccurrences: number;
     let baselineNutrition: Map<number, NutritionMetricRow[]>;
@@ -448,22 +450,26 @@ test.describe('Admin Reports', () => {
       await selectReportType(page, 'fbf-distribution');
       await setDateRange(page, REPORT_START_DATE, reportLimitDate);
       const baselineFBFDistTable = await readFBFDistributionTable(page);
+      const baselineFBFDistChildAchiRow = findSimpleRow(baselineFBFDistTable, 'FBF Child (ACHI)');
       const baselineFBFDistChildRow = findSimpleRow(baselineFBFDistTable, 'FBF Child');
       const baselineFBFDistMotherRow = findSimpleRow(baselineFBFDistTable, 'FBF Mother');
       const baselineAhezaDistChildRow = findSimpleRow(baselineFBFDistTable, 'Aheza Child');
       const baselineAhezaDistMotherRow = findSimpleRow(baselineFBFDistTable, 'Aheza Mother');
       baselineFBFDistChild = baselineFBFDistChildRow?.total ?? 0;
       baselineFBFDistMother = baselineFBFDistMotherRow?.total ?? 0;
+      baselineFBFDistChildAchi = baselineFBFDistChildAchiRow?.total ?? 0;
       baselineAhezaDistChild = baselineAhezaDistChildRow?.total ?? 0;
       baselineAhezaDistMother = baselineAhezaDistMotherRow?.total ?? 0;
       baselineFBFDistChildOccurrences = baselineFBFDistChildRow?.occurrences ?? 0;
       baselineFBFDistMotherOccurrences = baselineFBFDistMotherRow?.occurrences ?? 0;
+      baselineFBFDistChildAchiOccurrences = baselineFBFDistChildAchiRow?.occurrences ?? 0;
       baselineAhezaDistChildOccurrences = baselineAhezaDistChildRow?.occurrences ?? 0;
       baselineAhezaDistMotherOccurrences = baselineAhezaDistMotherRow?.occurrences ?? 0;
       console.log(
         `Baseline FBF Distribution: ` +
         `fbfChild=${baselineFBFDistChild}/${baselineFBFDistChildOccurrences}occ, ` +
         `fbfMother=${baselineFBFDistMother}/${baselineFBFDistMotherOccurrences}occ, ` +
+        `fbfChildAchi=${baselineFBFDistChildAchi}/${baselineFBFDistChildAchiOccurrences}occ, ` +
         `ahezaChild=${baselineAhezaDistChild}/${baselineAhezaDistChildOccurrences}occ, ` +
         `ahezaMother=${baselineAhezaDistMother}/${baselineAhezaDistMotherOccurrences}occ`,
       );
@@ -1765,6 +1771,7 @@ test.describe('Admin Reports', () => {
 
       const fbfDistribution = await readFBFDistributionTable(page);
 
+      const fbfChildAchiRow = findSimpleRow(fbfDistribution, 'FBF Child (ACHI)');
       const fbfChildRow = findSimpleRow(fbfDistribution, 'FBF Child');
       const fbfMotherRow = findSimpleRow(fbfDistribution, 'FBF Mother');
       const ahezaChildRow = findSimpleRow(fbfDistribution, 'Aheza Child');
@@ -1772,18 +1779,21 @@ test.describe('Admin Reports', () => {
 
       const fbfChild = fbfChildRow?.total ?? 0;
       const fbfMother = fbfMotherRow?.total ?? 0;
+      const fbfChildAchi = fbfChildAchiRow?.total ?? 0;
       const ahezaChild = ahezaChildRow?.total ?? 0;
       const ahezaMother = ahezaMotherRow?.total ?? 0;
       const fbfChildOccurrences = fbfChildRow?.occurrences ?? 0;
       const fbfMotherOccurrences = fbfMotherRow?.occurrences ?? 0;
+      const fbfChildAchiOccurrences = fbfChildAchiRow?.occurrences ?? 0;
       const ahezaChildOccurrences = ahezaChildRow?.occurrences ?? 0;
       const ahezaMotherOccurrences = ahezaMotherRow?.occurrences ?? 0;
 
       console.log('\n=== FBF DISTRIBUTION ===');
-      console.log(`FBF Child:    total ${baselineFBFDistChild} → ${fbfChild} (Δ ${fbfChild - baselineFBFDistChild}); occ ${baselineFBFDistChildOccurrences} → ${fbfChildOccurrences} (Δ ${fbfChildOccurrences - baselineFBFDistChildOccurrences})`);
-      console.log(`FBF Mother:   total ${baselineFBFDistMother} → ${fbfMother} (Δ ${fbfMother - baselineFBFDistMother}); occ ${baselineFBFDistMotherOccurrences} → ${fbfMotherOccurrences} (Δ ${fbfMotherOccurrences - baselineFBFDistMotherOccurrences})`);
-      console.log(`Aheza Child:  total ${baselineAhezaDistChild} → ${ahezaChild} (Δ ${ahezaChild - baselineAhezaDistChild}); occ ${baselineAhezaDistChildOccurrences} → ${ahezaChildOccurrences} (Δ ${ahezaChildOccurrences - baselineAhezaDistChildOccurrences})`);
-      console.log(`Aheza Mother: total ${baselineAhezaDistMother} → ${ahezaMother} (Δ ${ahezaMother - baselineAhezaDistMother}); occ ${baselineAhezaDistMotherOccurrences} → ${ahezaMotherOccurrences} (Δ ${ahezaMotherOccurrences - baselineAhezaDistMotherOccurrences})`);
+      console.log(`FBF Child:        total ${baselineFBFDistChild} → ${fbfChild} (Δ ${fbfChild - baselineFBFDistChild}); occ ${baselineFBFDistChildOccurrences} → ${fbfChildOccurrences} (Δ ${fbfChildOccurrences - baselineFBFDistChildOccurrences})`);
+      console.log(`FBF Mother:       total ${baselineFBFDistMother} → ${fbfMother} (Δ ${fbfMother - baselineFBFDistMother}); occ ${baselineFBFDistMotherOccurrences} → ${fbfMotherOccurrences} (Δ ${fbfMotherOccurrences - baselineFBFDistMotherOccurrences})`);
+      console.log(`FBF Child (ACHI): total ${baselineFBFDistChildAchi} → ${fbfChildAchi} (Δ ${fbfChildAchi - baselineFBFDistChildAchi}); occ ${baselineFBFDistChildAchiOccurrences} → ${fbfChildAchiOccurrences} (Δ ${fbfChildAchiOccurrences - baselineFBFDistChildAchiOccurrences})`);
+      console.log(`Aheza Child:      total ${baselineAhezaDistChild} → ${ahezaChild} (Δ ${ahezaChild - baselineAhezaDistChild}); occ ${baselineAhezaDistChildOccurrences} → ${ahezaChildOccurrences} (Δ ${ahezaChildOccurrences - baselineAhezaDistChildOccurrences})`);
+      console.log(`Aheza Mother:     total ${baselineAhezaDistMother} → ${ahezaMother} (Δ ${ahezaMother - baselineAhezaDistMother}); occ ${baselineAhezaDistMotherOccurrences} → ${ahezaMotherOccurrences} (Δ ${ahezaMotherOccurrences - baselineAhezaDistMotherOccurrences})`);
 
       // Each complete*Fbf / complete*Aheza helper creates exactly one
       // distribution measurement record, so every row's Occurrences
@@ -1800,6 +1810,18 @@ test.describe('Admin Reports', () => {
       // completeAhezaMother (amount '3') -> Aheza Mother total +3, occurrences +1
       expect(ahezaMother - baselineAhezaDistMother, 'Aheza Mother total delta should be +3').toBe(3);
       expect(ahezaMotherOccurrences - baselineAhezaDistMotherOccurrences, 'Aheza Mother occurrences delta should be +1').toBe(1);
+      // The test does not create an ACHI clinic session, so the FBF
+      // Child (ACHI) row's totals should not move from baseline.
+      expect(fbfChildAchi - baselineFBFDistChildAchi, 'FBF Child (ACHI) total delta should be 0').toBe(0);
+      expect(fbfChildAchiOccurrences - baselineFBFDistChildAchiOccurrences, 'FBF Child (ACHI) occurrences delta should be 0').toBe(0);
+
+      // Unit column: FBF clinic distributions are in packages; ACHI and
+      // CHW family-nutrition (Aheza) distributions are in kg.
+      expect(fbfChildRow?.unit, 'FBF Child unit should be "package"').toBe('package');
+      expect(fbfMotherRow?.unit, 'FBF Mother unit should be "package"').toBe('package');
+      expect(fbfChildAchiRow?.unit, 'FBF Child (ACHI) unit should be "kg"').toBe('kg');
+      expect(ahezaChildRow?.unit, 'Aheza Child unit should be "kg"').toBe('kg');
+      expect(ahezaMotherRow?.unit, 'Aheza Mother unit should be "kg"').toBe('kg');
 
       // CSV download button.
       await expect(

--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -326,6 +326,10 @@ test.describe('Admin Reports', () => {
     let baselineFBFDistMother: number;
     let baselineAhezaDistChild: number;
     let baselineAhezaDistMother: number;
+    let baselineFBFDistChildOccurrences: number;
+    let baselineFBFDistMotherOccurrences: number;
+    let baselineAhezaDistChildOccurrences: number;
+    let baselineAhezaDistMotherOccurrences: number;
     let baselineNutrition: Map<number, NutritionMetricRow[]>;
     let baselineCompletion: CompletionTableData;
     let baselinePrenatalCompletion: CompletionTableData;
@@ -439,25 +443,29 @@ test.describe('Admin Reports', () => {
       // Record FBF Distribution report baselines. The migration / demo
       // population can already include FBF and AHEZA records, so the test
       // encounters are verified by delta against this baseline rather than
-      // absolute totals. The reader uses parseInt on the cells; integer
-      // deltas are preserved correctly even when the underlying floats
-      // truncate, since the test's added amounts are whole numbers.
+      // absolute totals. Both the summed amount (Total column) and the
+      // event count (Occurrences column) are baselined.
       await selectReportType(page, 'fbf-distribution');
       await setDateRange(page, REPORT_START_DATE, reportLimitDate);
       const baselineFBFDistTable = await readFBFDistributionTable(page);
-      baselineFBFDistChild =
-        findSimpleRow(baselineFBFDistTable, 'FBF Child')?.total ?? 0;
-      baselineFBFDistMother =
-        findSimpleRow(baselineFBFDistTable, 'FBF Mother')?.total ?? 0;
-      baselineAhezaDistChild =
-        findSimpleRow(baselineFBFDistTable, 'Aheza Child')?.total ?? 0;
-      baselineAhezaDistMother =
-        findSimpleRow(baselineFBFDistTable, 'Aheza Mother')?.total ?? 0;
+      const baselineFBFDistChildRow = findSimpleRow(baselineFBFDistTable, 'FBF Child');
+      const baselineFBFDistMotherRow = findSimpleRow(baselineFBFDistTable, 'FBF Mother');
+      const baselineAhezaDistChildRow = findSimpleRow(baselineFBFDistTable, 'Aheza Child');
+      const baselineAhezaDistMotherRow = findSimpleRow(baselineFBFDistTable, 'Aheza Mother');
+      baselineFBFDistChild = baselineFBFDistChildRow?.total ?? 0;
+      baselineFBFDistMother = baselineFBFDistMotherRow?.total ?? 0;
+      baselineAhezaDistChild = baselineAhezaDistChildRow?.total ?? 0;
+      baselineAhezaDistMother = baselineAhezaDistMotherRow?.total ?? 0;
+      baselineFBFDistChildOccurrences = baselineFBFDistChildRow?.occurrences ?? 0;
+      baselineFBFDistMotherOccurrences = baselineFBFDistMotherRow?.occurrences ?? 0;
+      baselineAhezaDistChildOccurrences = baselineAhezaDistChildRow?.occurrences ?? 0;
+      baselineAhezaDistMotherOccurrences = baselineAhezaDistMotherRow?.occurrences ?? 0;
       console.log(
-        `Baseline FBF Distribution: fbfChild=${baselineFBFDistChild}, ` +
-        `fbfMother=${baselineFBFDistMother}, ` +
-        `ahezaChild=${baselineAhezaDistChild}, ` +
-        `ahezaMother=${baselineAhezaDistMother}`,
+        `Baseline FBF Distribution: ` +
+        `fbfChild=${baselineFBFDistChild}/${baselineFBFDistChildOccurrences}occ, ` +
+        `fbfMother=${baselineFBFDistMother}/${baselineFBFDistMotherOccurrences}occ, ` +
+        `ahezaChild=${baselineAhezaDistChild}/${baselineAhezaDistChildOccurrences}occ, ` +
+        `ahezaMother=${baselineAhezaDistMother}/${baselineAhezaDistMotherOccurrences}occ`,
       );
 
       // Record Nutrition report baseline (first column = newest completed month).
@@ -1752,25 +1760,41 @@ test.describe('Admin Reports', () => {
 
       const fbfDistribution = await readFBFDistributionTable(page);
 
-      const fbfChild = findSimpleRow(fbfDistribution, 'FBF Child')?.total ?? 0;
-      const fbfMother = findSimpleRow(fbfDistribution, 'FBF Mother')?.total ?? 0;
-      const ahezaChild = findSimpleRow(fbfDistribution, 'Aheza Child')?.total ?? 0;
-      const ahezaMother = findSimpleRow(fbfDistribution, 'Aheza Mother')?.total ?? 0;
+      const fbfChildRow = findSimpleRow(fbfDistribution, 'FBF Child');
+      const fbfMotherRow = findSimpleRow(fbfDistribution, 'FBF Mother');
+      const ahezaChildRow = findSimpleRow(fbfDistribution, 'Aheza Child');
+      const ahezaMotherRow = findSimpleRow(fbfDistribution, 'Aheza Mother');
+
+      const fbfChild = fbfChildRow?.total ?? 0;
+      const fbfMother = fbfMotherRow?.total ?? 0;
+      const ahezaChild = ahezaChildRow?.total ?? 0;
+      const ahezaMother = ahezaMotherRow?.total ?? 0;
+      const fbfChildOccurrences = fbfChildRow?.occurrences ?? 0;
+      const fbfMotherOccurrences = fbfMotherRow?.occurrences ?? 0;
+      const ahezaChildOccurrences = ahezaChildRow?.occurrences ?? 0;
+      const ahezaMotherOccurrences = ahezaMotherRow?.occurrences ?? 0;
 
       console.log('\n=== FBF DISTRIBUTION ===');
-      console.log(`FBF Child:    ${baselineFBFDistChild} → ${fbfChild} (Δ ${fbfChild - baselineFBFDistChild})`);
-      console.log(`FBF Mother:   ${baselineFBFDistMother} → ${fbfMother} (Δ ${fbfMother - baselineFBFDistMother})`);
-      console.log(`Aheza Child:  ${baselineAhezaDistChild} → ${ahezaChild} (Δ ${ahezaChild - baselineAhezaDistChild})`);
-      console.log(`Aheza Mother: ${baselineAhezaDistMother} → ${ahezaMother} (Δ ${ahezaMother - baselineAhezaDistMother})`);
+      console.log(`FBF Child:    total ${baselineFBFDistChild} → ${fbfChild} (Δ ${fbfChild - baselineFBFDistChild}); occ ${baselineFBFDistChildOccurrences} → ${fbfChildOccurrences} (Δ ${fbfChildOccurrences - baselineFBFDistChildOccurrences})`);
+      console.log(`FBF Mother:   total ${baselineFBFDistMother} → ${fbfMother} (Δ ${fbfMother - baselineFBFDistMother}); occ ${baselineFBFDistMotherOccurrences} → ${fbfMotherOccurrences} (Δ ${fbfMotherOccurrences - baselineFBFDistMotherOccurrences})`);
+      console.log(`Aheza Child:  total ${baselineAhezaDistChild} → ${ahezaChild} (Δ ${ahezaChild - baselineAhezaDistChild}); occ ${baselineAhezaDistChildOccurrences} → ${ahezaChildOccurrences} (Δ ${ahezaChildOccurrences - baselineAhezaDistChildOccurrences})`);
+      console.log(`Aheza Mother: total ${baselineAhezaDistMother} → ${ahezaMother} (Δ ${ahezaMother - baselineAhezaDistMother}); occ ${baselineAhezaDistMotherOccurrences} → ${ahezaMotherOccurrences} (Δ ${ahezaMotherOccurrences - baselineAhezaDistMotherOccurrences})`);
 
-      // completeChildFbf (amount '1') -> FBF Child +1
-      expect(fbfChild - baselineFBFDistChild, 'FBF Child delta should be +1').toBe(1);
-      // completeMotherFbf (amount '1') -> FBF Mother +1
-      expect(fbfMother - baselineFBFDistMother, 'FBF Mother delta should be +1').toBe(1);
-      // completeAhezaChild (amount '2') -> Aheza Child +2
-      expect(ahezaChild - baselineAhezaDistChild, 'Aheza Child delta should be +2').toBe(2);
-      // completeAhezaMother (amount '3') -> Aheza Mother +3
-      expect(ahezaMother - baselineAhezaDistMother, 'Aheza Mother delta should be +3').toBe(3);
+      // Each complete*Fbf / complete*Aheza helper creates exactly one
+      // distribution measurement record, so every row's Occurrences
+      // delta is +1 regardless of the amount entered.
+      // completeChildFbf (amount '1') -> FBF Child total +1, occurrences +1
+      expect(fbfChild - baselineFBFDistChild, 'FBF Child total delta should be +1').toBe(1);
+      expect(fbfChildOccurrences - baselineFBFDistChildOccurrences, 'FBF Child occurrences delta should be +1').toBe(1);
+      // completeMotherFbf (amount '1') -> FBF Mother total +1, occurrences +1
+      expect(fbfMother - baselineFBFDistMother, 'FBF Mother total delta should be +1').toBe(1);
+      expect(fbfMotherOccurrences - baselineFBFDistMotherOccurrences, 'FBF Mother occurrences delta should be +1').toBe(1);
+      // completeAhezaChild (amount '2') -> Aheza Child total +2, occurrences +1
+      expect(ahezaChild - baselineAhezaDistChild, 'Aheza Child total delta should be +2').toBe(2);
+      expect(ahezaChildOccurrences - baselineAhezaDistChildOccurrences, 'Aheza Child occurrences delta should be +1').toBe(1);
+      // completeAhezaMother (amount '3') -> Aheza Mother total +3, occurrences +1
+      expect(ahezaMother - baselineAhezaDistMother, 'Aheza Mother total delta should be +3').toBe(3);
+      expect(ahezaMotherOccurrences - baselineAhezaDistMotherOccurrences, 'Aheza Mother occurrences delta should be +1').toBe(1);
 
       // CSV download button.
       await expect(

--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -234,7 +234,7 @@ test.describe('Admin Reports', () => {
   // Statistical Queries and Completion reports show the correct deltas.
   //
   // Patients created:
-  //   Nurse: NutrChild (M 10mo) — Nutrition (with measurements) + SPV (2 encounters, impacted)
+  //   Nurse: NutrChild (M 11mo) — Nutrition (with measurements) + SPV (2 encounters, impacted)
   //          PrenatalMom (F 25y) — Prenatal initial + postpartum (2 encounters, impacted)
   //          AINurse (F 30y) — AI initial + subsequent (2 encounters, impacted)
   //          AIChild (M 30mo) — AI initial (with MUAC + Nutrition)
@@ -309,7 +309,7 @@ test.describe('Admin Reports', () => {
     let baselinePeripartumPrematureLabour: number;
     let baselinePeripartumBreastfedFirstHour: number;
     // Postnatal Care report baselines (PR #1556). Among the existing test
-    // patients, only NutrChild (M, 10mo, full nurse SPV with
+    // patients, only NutrChild (M, 11mo, full nurse SPV with
     // completeWCImmunisation) contributes — they fall in the "10-19 months
     // UpToDate" bucket. Other test children either lack a well-child
     // encounter (AIChild, CSChild, HVChild) or are below the lowest age
@@ -635,10 +635,15 @@ test.describe('Admin Reports', () => {
       await page.goto(pwaBaseUrl);
       await setupDevice(page, '1234', 'Nyange Health Center');
 
-      // --- NutrChild (male, 10 months): Nutrition encounter ---
+      // --- NutrChild (male, 11 months): Nutrition encounter ---
       // Complete mandatory activities with abnormal measurements to trigger
-      // stunting severe (height 60cm at 10mo) + underweight severe (6.0kg at 10mo).
-      const nutrChild = await createNutritionChild(page, { ageMonths: 10 });
+      // stunting severe (height 60cm at 11mo) + underweight severe (6.0kg
+      // at 11mo). Age 11mo intentionally clears both the 10-month bucket
+      // boundary in the Postnatal Care report (Date.diff Months on a
+      // 10-month-old DOB occasionally rounds to 9 due to UTC/local-day
+      // shift in setDate, flipping the child between buckets) and stays
+      // inside the Demographics "1M - 2Y" bucket.
+      const nutrChild = await createNutritionChild(page, { ageMonths: 11 });
       nutrChildName = nutrChild.fullName;
       await enterHeight(page, '60');
       await saveActivity(page);
@@ -1623,7 +1628,7 @@ test.describe('Admin Reports', () => {
     //
     // The report has 6 rows: SPV/Newborn-Exam-within-24h-of-birth + 5
     // age-bucket "UpToDate with immunization" rows (7-11w, 11-15w,
-    // 15w-10mo, 10-19mo, 19-24mo). NutrChild (M, 10mo) gets a full nurse
+    // 15w-10mo, 10-19mo, 19-24mo). NutrChild (M, 11mo) gets a full nurse
     // SPV here with completeWCImmunisation, which administers every
     // age-eligible vaccine today. After sync, NutrChild's wellChildData
     // carries the full immunisation dict; the report's
@@ -1661,7 +1666,7 @@ test.describe('Admin Reports', () => {
       // Within-24h row should not move (no test patient has a same-day SPV).
       expect(newWithin24h - baselinePNCWithin24h,
         '"within 24 hours of birth" row should be unchanged').toBe(0);
-      // NutrChild (10mo, full SPV with all eligible vaccines administered
+      // NutrChild (11mo, full SPV with all eligible vaccines administered
       // today) should land in the 10-19 months bucket as UpToDate.
       expect(new10To19Months - baselinePNC10To19Months,
         '"Children aged 10-19 mos UpToDate" row should grow by +1').toBe(1);
@@ -2446,7 +2451,7 @@ test.describe('Admin Reports', () => {
 
     // ── Phase 12: Completion Report — Well Child (SPV) ──
     //
-    // NutrChild (10mo male, Nurse) completed SPV encounter:
+    // NutrChild (11mo male, Nurse) completed SPV encounter:
     // DangerSigns, NutritionAssessment, ECD, Medication, Immunisation, NCDA, NextSteps.
     // Supports Taken By filter (Nurse + CHW).
 

--- a/server/elm/src/App/Types.elm
+++ b/server/elm/src/App/Types.elm
@@ -2,6 +2,7 @@ module App.Types exposing
     ( Language(..)
     , Page(..)
     , Site(..)
+    , SiteFeature(..)
     )
 
 
@@ -27,3 +28,20 @@ type Site
     | SiteBurundi
     | SiteSomalia
     | SiteUnknown
+
+
+{-| Toggleable site features. Mirrors `SiteFeature` in
+client/src/elm/SyncManager/Model.elm and the canonical list in
+hedley\_admin\_get\_available\_features (PHP). Update all together.
+-}
+type SiteFeature
+    = FeatureFamilyNutrition
+    | FeatureGPSCoordinates
+    | FeatureGroupEducation
+    | FeatureHealthyStart
+    | FeatureHIVManagement
+    | FeatureNCDA
+    | FeatureReportToWhatsApp
+    | FeatureStockManagementHC
+    | FeatureStockManagementVillage
+    | FeatureTuberculosisManagement

--- a/server/elm/src/Backend/Decoder.elm
+++ b/server/elm/src/Backend/Decoder.elm
@@ -1,7 +1,9 @@
-module Backend.Decoder exposing (decodeSite, decodeWithFallback)
+module Backend.Decoder exposing (decodeSite, decodeSiteFeatures, decodeWithFallback)
 
-import App.Types exposing (Site(..))
+import App.Types exposing (Site(..), SiteFeature(..))
+import EverySet exposing (EverySet)
 import Json.Decode exposing (Decoder, oneOf, string, succeed)
+import Maybe.Extra
 
 
 decodeSite : Decoder Site
@@ -24,6 +26,62 @@ siteFromString str =
 
         _ ->
             SiteUnknown
+
+
+{-| Decodes the space-delimited `features` string emitted by
+hedley\_admin\_get\_enabled\_features\_string into the set of currently
+enabled features. Unknown identifiers are silently dropped so adding a new
+flag on the server never breaks an older admin app build.
+-}
+decodeSiteFeatures : Decoder (EverySet SiteFeature)
+decodeSiteFeatures =
+    string
+        |> Json.Decode.map siteFeaturesFromString
+
+
+siteFeaturesFromString : String -> EverySet SiteFeature
+siteFeaturesFromString str =
+    String.words str
+        |> List.map siteFeatureFromString
+        |> Maybe.Extra.values
+        |> EverySet.fromList
+
+
+siteFeatureFromString : String -> Maybe SiteFeature
+siteFeatureFromString str =
+    case String.toLower str of
+        "family_nutrition" ->
+            Just FeatureFamilyNutrition
+
+        "gps_coordinates" ->
+            Just FeatureGPSCoordinates
+
+        "group_education" ->
+            Just FeatureGroupEducation
+
+        "healthy_start" ->
+            Just FeatureHealthyStart
+
+        "hiv_management" ->
+            Just FeatureHIVManagement
+
+        "ncda" ->
+            Just FeatureNCDA
+
+        "report_to_whatsapp" ->
+            Just FeatureReportToWhatsApp
+
+        "stock_management_hc" ->
+            Just FeatureStockManagementHC
+
+        "stock_management_village" ->
+            Just FeatureStockManagementVillage
+
+        "tuberculosis_management" ->
+            Just FeatureTuberculosisManagement
+
+        _ ->
+            Nothing
 
 
 decodeWithFallback : a -> Decoder a -> Decoder a

--- a/server/elm/src/Backend/Reports/Decoder.elm
+++ b/server/elm/src/Backend/Reports/Decoder.elm
@@ -1,7 +1,7 @@
 module Backend.Reports.Decoder exposing (decodeReportsData)
 
 import AssocList as Dict exposing (Dict)
-import Backend.Decoder exposing (decodeSite, decodeWithFallback)
+import Backend.Decoder exposing (decodeSite, decodeSiteFeatures, decodeWithFallback)
 import Backend.Reports.Model exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterData, AcuteIllnessEncounterType(..), BackendGeneratedNutritionReportTableDate, DeliveryLocation(..), FamilyNutritionEncounterData, FamilyNutritionMotherEncounterData, Gender(..), MotherFbfEncounterData, NutritionData, NutritionEncounterData, NutritionReportTableType(..), PatientData, PregnancyOutcome(..), PrenatalDiagnosis(..), PrenatalEncounterData, PrenatalEncounterType(..), PrenatalIndicator(..), PrenatalParticipantData, ReportsData, SelectedEntity(..), WellChildEncounterData)
 import Backend.Reports.Utils exposing (genderFromString)
 import Backend.Scoreboard.Model exposing (VaccineType(..))
@@ -18,6 +18,7 @@ decodeReportsData : Decoder ReportsData
 decodeReportsData =
     succeed ReportsData
         |> required "site" decodeSite
+        |> required "features" decodeSiteFeatures
         |> required "entity_name" string
         |> required "entity_type" decodeSelectedEntity
         |> required "results" (list decodePatientData)

--- a/server/elm/src/Backend/Reports/Decoder.elm
+++ b/server/elm/src/Backend/Reports/Decoder.elm
@@ -2,7 +2,7 @@ module Backend.Reports.Decoder exposing (decodeReportsData)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Decoder exposing (decodeSite, decodeWithFallback)
-import Backend.Reports.Model exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterData, AcuteIllnessEncounterType(..), BackendGeneratedNutritionReportTableDate, DeliveryLocation(..), FamilyNutritionEncounterData, Gender(..), NutritionData, NutritionEncounterData, NutritionReportTableType(..), PatientData, PregnancyOutcome(..), PrenatalDiagnosis(..), PrenatalEncounterData, PrenatalEncounterType(..), PrenatalIndicator(..), PrenatalParticipantData, ReportsData, SelectedEntity(..), WellChildEncounterData)
+import Backend.Reports.Model exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterData, AcuteIllnessEncounterType(..), BackendGeneratedNutritionReportTableDate, DeliveryLocation(..), FamilyNutritionEncounterData, FamilyNutritionMotherEncounterData, Gender(..), MotherFbfEncounterData, NutritionData, NutritionEncounterData, NutritionReportTableType(..), PatientData, PregnancyOutcome(..), PrenatalDiagnosis(..), PrenatalEncounterData, PrenatalEncounterType(..), PrenatalIndicator(..), PrenatalParticipantData, ReportsData, SelectedEntity(..), WellChildEncounterData)
 import Backend.Reports.Utils exposing (genderFromString)
 import Backend.Scoreboard.Model exposing (VaccineType(..))
 import Date
@@ -65,7 +65,7 @@ decodePatientData =
         |> required "gender" (decodeWithFallback Female decodeGender)
         |> optionalAt [ "individual", "acute-illness" ] (nullable (list (list decodeAcuteIllnessEncounterData))) Nothing
         |> optionalAt [ "individual", "antenatal" ] (nullable (list decodePrenatalParticipantData)) Nothing
-        |> optionalAt [ "individual", "family-nutrition" ] (nullable (list (list decodeFamilyNutritionEncounterData))) Nothing
+        |> optionalAt [ "individual", "family-nutrition" ] (nullable (list (list decodeFamilyNutritionMotherEncounterData))) Nothing
         |> optionalAt [ "individual", "family-nutrition-muac" ] (nullable (list (list decodeFamilyNutritionEncounterData))) Nothing
         |> optionalAt [ "individual", "home-visit" ] (nullable (list (list decodeYYYYMMDD))) Nothing
         |> optionalAt [ "individual", "well-child" ] (nullable (list (list decodeWellChildEncounterData))) Nothing
@@ -79,6 +79,7 @@ decodePatientData =
         |> optionalAt [ "group_nutrition", "sorwathe" ] (nullable (list decodeNutritionEncounterData)) Nothing
         |> optionalAt [ "group_nutrition", "chw" ] (nullable (list decodeNutritionEncounterData)) Nothing
         |> optionalAt [ "group_nutrition", "achi" ] (nullable (list decodeNutritionEncounterData)) Nothing
+        |> optionalAt [ "group_nutrition_mother", "fbf" ] (nullable (list decodeMotherFbfEncounterData)) Nothing
 
 
 decodeGender : Decoder Gender
@@ -563,6 +564,22 @@ prenatalIndicatorFromMapping s =
             Nothing
 
 
+{-| Decoder for child entries on `individual.family-nutrition-muac`.
+
+Wire shapes emitted by hedley\_reports\_calculate\_aggregated\_data\_for\_person:
+
+  - "YYYY-MM-DD" (legacy date-only, kept for backward compatibility)
+  - "YYYY-MM-DD <muac>" (legacy MUAC-only, kept for backward compatibility)
+  - "YYYY-MM-DD <muac>|<aheza\_amount>" (MUAC + AHEZA recorded together)
+  - "YYYY-MM-DD |<aheza\_amount>" (AHEZA only -- empty MUAC chunk)
+
+The optional "|<amount>" tail chunk inside the second space-segment is the
+same convention used by decodeNutritionEncounterData below for FBF amounts.
+Stays in sync with the family-nutrition-muac emission in
+server/hedley/modules/custom/hedley\_reports/hedley\_reports.module; update
+both together.
+
+-}
 decodeFamilyNutritionEncounterData : Decoder FamilyNutritionEncounterData
 decodeFamilyNutritionEncounterData =
     string
@@ -574,7 +591,7 @@ decodeFamilyNutritionEncounterData =
                             |> Result.toMaybe
                             |> Maybe.map
                                 (\startDate ->
-                                    succeed { startDate = startDate, muacCm = Nothing }
+                                    succeed { startDate = startDate, muacCm = Nothing, ahezaAmount = Nothing }
                                 )
                             |> Maybe.withDefault (fail "Failed to decode FamilyNutritionEncounterData")
 
@@ -583,7 +600,11 @@ decodeFamilyNutritionEncounterData =
                             |> Result.toMaybe
                             |> Maybe.map
                                 (\startDate ->
-                                    succeed { startDate = startDate, muacCm = String.toFloat second }
+                                    let
+                                        ( muacCm, ahezaAmount ) =
+                                            parseFamilyNutritionPayload second
+                                    in
+                                    succeed { startDate = startDate, muacCm = muacCm, ahezaAmount = ahezaAmount }
                                 )
                             |> Maybe.withDefault (fail "Failed to decode FamilyNutritionEncounterData")
 
@@ -592,6 +613,107 @@ decodeFamilyNutritionEncounterData =
             )
 
 
+parseFamilyNutritionPayload : String -> ( Maybe Float, Maybe Float )
+parseFamilyNutritionPayload s =
+    case String.split "|" s of
+        [ muacPart ] ->
+            ( String.toFloat muacPart, Nothing )
+
+        [ muacPart, ahezaPart ] ->
+            ( String.toFloat muacPart, String.toFloat ahezaPart )
+
+        _ ->
+            ( Nothing, Nothing )
+
+
+{-| Decoder for mother entries on `individual.family-nutrition`.
+
+Wire shapes:
+
+  - "YYYY-MM-DD" (legacy date-only entry, kept for backward compatibility)
+  - "YYYY-MM-DD <aheza\_amount>" (AHEZA mother distribution recorded)
+
+Stays in sync with the family-nutrition mother emission in
+server/hedley/modules/custom/hedley\_reports/hedley\_reports.module; update
+both together.
+
+-}
+decodeFamilyNutritionMotherEncounterData : Decoder FamilyNutritionMotherEncounterData
+decodeFamilyNutritionMotherEncounterData =
+    string
+        |> andThen
+            (\s ->
+                case String.split " " (String.trim s) of
+                    [ first ] ->
+                        Date.fromIsoString first
+                            |> Result.toMaybe
+                            |> Maybe.map
+                                (\startDate ->
+                                    succeed { startDate = startDate, ahezaAmount = Nothing }
+                                )
+                            |> Maybe.withDefault (fail "Failed to decode FamilyNutritionMotherEncounterData")
+
+                    [ first, second ] ->
+                        Date.fromIsoString first
+                            |> Result.toMaybe
+                            |> Maybe.map
+                                (\startDate ->
+                                    succeed { startDate = startDate, ahezaAmount = String.toFloat second }
+                                )
+                            |> Maybe.withDefault (fail "Failed to decode FamilyNutritionMotherEncounterData")
+
+                    _ ->
+                        fail "Failed to decode FamilyNutritionMotherEncounterData"
+            )
+
+
+{-| Decoder for `group_nutrition_mother.fbf`.
+
+Wire shape: "YYYY-MM-DD <amount>". Mother FBF distribution records have no
+anthropometry to embed alongside, so the wire is always exactly two
+space-separated segments. Stays in sync with the mother FBF emission in
+server/hedley/modules/custom/hedley\_reports/hedley\_reports.module.
+
+-}
+decodeMotherFbfEncounterData : Decoder MotherFbfEncounterData
+decodeMotherFbfEncounterData =
+    string
+        |> andThen
+            (\s ->
+                case String.split " " (String.trim s) of
+                    [ first, second ] ->
+                        case ( Date.fromIsoString first |> Result.toMaybe, String.toFloat second ) of
+                            ( Just startDate, Just fbfAmount ) ->
+                                succeed { startDate = startDate, fbfAmount = fbfAmount }
+
+                            _ ->
+                                fail "Failed to decode MotherFbfEncounterData"
+
+                    _ ->
+                        fail "Failed to decode MotherFbfEncounterData"
+            )
+
+
+{-| Decoder for child entries on `individual.nutrition` and on
+`group_nutrition.{pmtct,fbf,sorwathe,chw,achi}`.
+
+Wire shapes emitted by hedley\_reports\_calculate\_aggregated\_data\_for\_person:
+
+  - "YYYY-MM-DD" (legacy date-only)
+  - "YYYY-MM-DD <anth>" (anthropometry, where <anth> is the comma-separated
+    payload from hedley\_reports\_nutrition\_metrics\_to\_string)
+  - "YYYY-MM-DD <anth>|<fbf\_amount>" (anthropometry + FBF distribution)
+  - "YYYY-MM-DD ,,,,|<fbf\_amount>" (FBF only -- empty anthropometry chunk;
+    the PHP emitter always produces ",,,," for empty anthropometry, never
+    an empty string)
+
+The optional "|<amount>" tail chunk is appended to the existing
+space-delimited second segment. Stays in sync with the group\_nutrition
+emission in
+server/hedley/modules/custom/hedley\_reports/hedley\_reports.module; update
+both together.
+
+-}
 decodeNutritionEncounterData : Decoder NutritionEncounterData
 decodeNutritionEncounterData =
     string
@@ -608,6 +730,7 @@ decodeNutritionEncounterData =
                                         , nutritionData = Nothing
                                         , muacCm = Nothing
                                         , hasEdema = False
+                                        , fbfAmount = Nothing
                                         }
                                 )
                             |> Maybe.withDefault (fail "Failed to decode NutritionEncounterData")
@@ -618,14 +741,23 @@ decodeNutritionEncounterData =
                             |> Maybe.map
                                 (\startDate ->
                                     let
+                                        ( anthropometryPart, fbfAmount ) =
+                                            case String.split "|" second of
+                                                [ anth, fbf ] ->
+                                                    ( anth, String.toFloat fbf )
+
+                                                _ ->
+                                                    ( second, Nothing )
+
                                         ( nutritionData, muacCm, hasEdema ) =
-                                            parseNutritionEncounterPayload second
+                                            parseAnthropometryPayload anthropometryPart
                                     in
                                     succeed
                                         { startDate = startDate
                                         , nutritionData = nutritionData
                                         , muacCm = muacCm
                                         , hasEdema = hasEdema
+                                        , fbfAmount = fbfAmount
                                         }
                                 )
                             |> Maybe.withDefault (fail "Failed to decode NutritionEncounterData")
@@ -766,8 +898,8 @@ vaccineTypeFromMapping s =
 -- fields without duplicating data inside the nested NutritionData.
 
 
-parseNutritionEncounterPayload : String -> ( Maybe NutritionData, Maybe Float, Bool )
-parseNutritionEncounterPayload payload =
+parseAnthropometryPayload : String -> ( Maybe NutritionData, Maybe Float, Bool )
+parseAnthropometryPayload payload =
     case String.split "," payload of
         [ stunting, underweight, wasting ] ->
             ( Just (NutritionData (String.toFloat stunting) (String.toFloat underweight) (String.toFloat wasting))

--- a/server/elm/src/Backend/Reports/Model.elm
+++ b/server/elm/src/Backend/Reports/Model.elm
@@ -1,4 +1,4 @@
-module Backend.Reports.Model exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterData, AcuteIllnessEncounterType(..), BackendGeneratedNutritionReportTableDate, ChildScorecardEncounterData, DeliveryLocation(..), FamilyNutritionEncounterData, Gender(..), HIVEncounterData, HomeVisitEncounterData, Msg(..), NCDEncounterData, NutritionData, NutritionEncounterData, NutritionReportTableType(..), PatientData, PersonId, PregnancyOutcome(..), PrenatalDiagnosis(..), PrenatalEncounterData, PrenatalEncounterType(..), PrenatalIndicator(..), PrenatalParticipantData, ReportsData, SelectedEntity(..), TuberculosisEncounterData, WellChildEncounterData)
+module Backend.Reports.Model exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterData, AcuteIllnessEncounterType(..), BackendGeneratedNutritionReportTableDate, ChildScorecardEncounterData, DeliveryLocation(..), FamilyNutritionEncounterData, FamilyNutritionMotherEncounterData, Gender(..), HIVEncounterData, HomeVisitEncounterData, MotherFbfEncounterData, Msg(..), NCDEncounterData, NutritionData, NutritionEncounterData, NutritionReportTableType(..), PatientData, PersonId, PregnancyOutcome(..), PrenatalDiagnosis(..), PrenatalEncounterData, PrenatalEncounterType(..), PrenatalIndicator(..), PrenatalParticipantData, ReportsData, SelectedEntity(..), TuberculosisEncounterData, WellChildEncounterData)
 
 import App.Types exposing (Site)
 import AssocList exposing (Dict)
@@ -34,7 +34,7 @@ type alias PatientData =
     , gender : Gender
     , acuteIllnessData : Maybe (List (List AcuteIllnessEncounterData))
     , prenatalData : Maybe (List PrenatalParticipantData)
-    , familyNutritionData : Maybe (List (List FamilyNutritionEncounterData))
+    , familyNutritionData : Maybe (List (List FamilyNutritionMotherEncounterData))
     , familyNutritionMuacData : Maybe (List (List FamilyNutritionEncounterData))
     , homeVisitData : Maybe (List (List HomeVisitEncounterData))
     , wellChildData : Maybe (List (List WellChildEncounterData))
@@ -48,6 +48,7 @@ type alias PatientData =
     , groupNutritionSorwatheData : Maybe (List NutritionEncounterData)
     , groupNutritionChwData : Maybe (List NutritionEncounterData)
     , groupNutritionAchiData : Maybe (List NutritionEncounterData)
+    , groupNutritionFbfMotherData : Maybe (List MotherFbfEncounterData)
     }
 
 
@@ -224,6 +225,7 @@ type alias NutritionEncounterData =
     , nutritionData : Maybe NutritionData
     , muacCm : Maybe Float
     , hasEdema : Bool
+    , fbfAmount : Maybe Float
     }
 
 
@@ -245,6 +247,19 @@ type alias WellChildEncounterData =
 type alias FamilyNutritionEncounterData =
     { startDate : NominalDate
     , muacCm : Maybe Float
+    , ahezaAmount : Maybe Float
+    }
+
+
+type alias FamilyNutritionMotherEncounterData =
+    { startDate : NominalDate
+    , ahezaAmount : Maybe Float
+    }
+
+
+type alias MotherFbfEncounterData =
+    { startDate : NominalDate
+    , fbfAmount : Float
     }
 
 

--- a/server/elm/src/Backend/Reports/Model.elm
+++ b/server/elm/src/Backend/Reports/Model.elm
@@ -1,6 +1,6 @@
 module Backend.Reports.Model exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterData, AcuteIllnessEncounterType(..), BackendGeneratedNutritionReportTableDate, ChildScorecardEncounterData, DeliveryLocation(..), FamilyNutritionEncounterData, FamilyNutritionMotherEncounterData, Gender(..), HIVEncounterData, HomeVisitEncounterData, MotherFbfEncounterData, Msg(..), NCDEncounterData, NutritionData, NutritionEncounterData, NutritionReportTableType(..), PatientData, PersonId, PregnancyOutcome(..), PrenatalDiagnosis(..), PrenatalEncounterData, PrenatalEncounterType(..), PrenatalIndicator(..), PrenatalParticipantData, ReportsData, SelectedEntity(..), TuberculosisEncounterData, WellChildEncounterData)
 
-import App.Types exposing (Site)
+import App.Types exposing (Site, SiteFeature)
 import AssocList exposing (Dict)
 import Backend.Scoreboard.Model exposing (VaccineType)
 import EverySet exposing (EverySet)
@@ -10,6 +10,7 @@ import Json.Encode exposing (Value)
 
 type alias ReportsData =
     { site : Site
+    , features : EverySet SiteFeature
     , entityName : String
     , entityType : SelectedEntity
     , records : List PatientData

--- a/server/elm/src/Pages/Reports/Model.elm
+++ b/server/elm/src/Pages/Reports/Model.elm
@@ -1,4 +1,4 @@
-module Pages.Reports.Model exposing (Model, Msg(..), NutritionMetrics, NutritionMetricsResults, NutritionReportData, PregnancyTrimester(..), PrenatalContactType(..), ReportType(..), emptyModel, emptyNutritionMetrics)
+module Pages.Reports.Model exposing (FbfDistributionCategory(..), Model, Msg(..), NutritionMetrics, NutritionMetricsResults, NutritionReportData, PregnancyTrimester(..), PrenatalContactType(..), ReportType(..), allFbfDistributionCategories, emptyModel, emptyNutritionMetrics)
 
 import AssocList exposing (Dict)
 import Backend.Reports.Model exposing (PersonId)
@@ -31,12 +31,33 @@ emptyModel =
 type ReportType
     = ReportAcuteIllness
     | ReportDemographics
+    | ReportFBFDistribution
     | ReportNutrition
     | ReportPeripartum
     | ReportPostnatalCare
     | ReportPrenatal
     | ReportPrenatalContacts
     | ReportPrenatalDiagnoses
+
+
+{-| Categories shown as rows in the FBF Distribution report. Only the FBF
+group with `field_group_type = 'fbf'` contributes child distributions
+(Achi-clinic child\_fbf is intentionally out of scope).
+-}
+type FbfDistributionCategory
+    = FbfDistributionAhezaChild
+    | FbfDistributionAhezaMother
+    | FbfDistributionFbfChild
+    | FbfDistributionFbfMother
+
+
+allFbfDistributionCategories : List FbfDistributionCategory
+allFbfDistributionCategories =
+    [ FbfDistributionFbfChild
+    , FbfDistributionFbfMother
+    , FbfDistributionAhezaChild
+    , FbfDistributionAhezaMother
+    ]
 
 
 type alias NutritionReportData =

--- a/server/elm/src/Pages/Reports/Model.elm
+++ b/server/elm/src/Pages/Reports/Model.elm
@@ -48,6 +48,7 @@ type FbfDistributionCategory
     = FbfDistributionAhezaChild
     | FbfDistributionAhezaMother
     | FbfDistributionFbfChild
+    | FbfDistributionFbfChildAchi
     | FbfDistributionFbfMother
 
 
@@ -55,6 +56,7 @@ allFbfDistributionCategories : List FbfDistributionCategory
 allFbfDistributionCategories =
     [ FbfDistributionFbfChild
     , FbfDistributionFbfMother
+    , FbfDistributionFbfChildAchi
     , FbfDistributionAhezaChild
     , FbfDistributionAhezaMother
     ]

--- a/server/elm/src/Pages/Reports/Update.elm
+++ b/server/elm/src/Pages/Reports/Update.elm
@@ -153,12 +153,14 @@ calculateNutritionReportDataTask currentDate data =
                                     (\item ->
                                         -- WellChildEncounterData mirrors NutritionEncounterData's
                                         -- shape (date, nutritionData, muacCm) plus immunisationData;
-                                        -- well-child wire doesn't carry edema today, so default to False.
+                                        -- well-child wire doesn't carry edema or FBF distribution
+                                        -- today, so default both to absent.
                                         ( record.id
                                         , { startDate = item.startDate
                                           , nutritionData = item.nutritionData
                                           , muacCm = item.muacCm
                                           , hasEdema = False
+                                          , fbfAmount = Nothing
                                           }
                                         )
                                     )

--- a/server/elm/src/Pages/Reports/Utils.elm
+++ b/server/elm/src/Pages/Reports/Utils.elm
@@ -69,6 +69,9 @@ reportTypeToString reportType =
         ReportDemographics ->
             "demographics"
 
+        ReportFBFDistribution ->
+            "fbf-distribution"
+
         ReportNutrition ->
             "nutrition"
 
@@ -96,6 +99,9 @@ reportTypeFromString reportType =
 
         "demographics" ->
             Just ReportDemographics
+
+        "fbf-distribution" ->
+            Just ReportFBFDistribution
 
         "nutrition" ->
             Just ReportNutrition

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -1,6 +1,6 @@
 module Pages.Reports.View exposing (view)
 
-import App.Types exposing (Language, Site)
+import App.Types exposing (Language, Site, SiteFeature(..))
 import AssocList as Dict exposing (Dict)
 import Backend.Model exposing (ModelBackend)
 import Backend.Reports.Model
@@ -23,7 +23,7 @@ import Backend.Reports.Utils exposing (allAcuteIllnessDiagnoses, allPrenatalDiag
 import Backend.Scoreboard.Utils exposing (generateVaccinationProgressForVaccine)
 import Date exposing (Unit(..))
 import DateSelector.SelectorPopup exposing (viewCalendarPopup)
-import EverySet
+import EverySet exposing (EverySet)
 import Gizra.Html exposing (emptyNode)
 import Gizra.NominalDate
     exposing
@@ -307,7 +307,7 @@ viewReportsData language currentDate themePath data model =
                                 viewDemographicsReport language startDate limitDate scopeLabel recordsTillLimitDate
 
                             ReportFBFDistribution ->
-                                viewFBFDistributionReport language limitDate scopeLabel recordsTillLimitDate
+                                viewFBFDistributionReport language data.features limitDate scopeLabel recordsTillLimitDate
 
                             ReportNutrition ->
                                 viewNutritionReport language limitDate scopeLabel data.nutritionReportData model.nutritionReportData
@@ -345,14 +345,14 @@ viewReportsData language currentDate themePath data model =
             (viewSelectListInput language
                 model.reportType
                 [ ReportAcuteIllness
-                , ReportPrenatal
-                , ReportPrenatalContacts
-                , ReportPrenatalDiagnoses
                 , ReportDemographics
+                , ReportFBFDistribution
                 , ReportNutrition
                 , ReportPeripartum
                 , ReportPostnatalCare
-                , ReportFBFDistribution
+                , ReportPrenatal
+                , ReportPrenatalContacts
+                , ReportPrenatalDiagnoses
                 ]
                 reportTypeToString
                 SetReportType
@@ -2796,11 +2796,14 @@ generatePeripartumReportData language records =
     }
 
 
-viewFBFDistributionReport : Language -> NominalDate -> String -> List PatientData -> Html Msg
-viewFBFDistributionReport language limitDate scopeLabel records =
+viewFBFDistributionReport : Language -> EverySet SiteFeature -> NominalDate -> String -> List PatientData -> Html Msg
+viewFBFDistributionReport language features limitDate scopeLabel records =
     let
+        categories =
+            visibleFbfDistributionCategories features
+
         data =
-            generateFBFDistributionReportData language records
+            generateFBFDistributionReportData language categories records
 
         captionsRow =
             viewStandardCells data.captions
@@ -2822,7 +2825,7 @@ viewFBFDistributionReport language limitDate scopeLabel records =
                     viewStandardCells row
                         |> div [ class <| "row " ++ fbfDistributionCategoryCssClass category ]
                 )
-                allFbfDistributionCategories
+                categories
                 data.rows
     in
     div [ class "report fbf-distribution" ]
@@ -2833,11 +2836,39 @@ viewFBFDistributionReport language limitDate scopeLabel records =
         ]
 
 
+{-| Aheza categories are family-nutrition-only, so they are dropped when the
+feature is disabled. FBF categories always show.
+-}
+visibleFbfDistributionCategories : EverySet SiteFeature -> List FbfDistributionCategory
+visibleFbfDistributionCategories features =
+    let
+        familyNutritionEnabled =
+            EverySet.member FeatureFamilyNutrition features
+    in
+    List.filter
+        (\category ->
+            case category of
+                FbfDistributionAhezaChild ->
+                    familyNutritionEnabled
+
+                FbfDistributionAhezaMother ->
+                    familyNutritionEnabled
+
+                FbfDistributionFbfChild ->
+                    True
+
+                FbfDistributionFbfMother ->
+                    True
+        )
+        allFbfDistributionCategories
+
+
 generateFBFDistributionReportData :
     Language
+    -> List FbfDistributionCategory
     -> List PatientData
     -> MetricsResultsTableData
-generateFBFDistributionReportData language records =
+generateFBFDistributionReportData language categories records =
     let
         -- FBF child totals come exclusively from groupNutritionFbfData
         -- (clinic group_type = 'fbf'); Achi child_fbf rows live under
@@ -2893,7 +2924,7 @@ generateFBFDistributionReportData language records =
                     , formatDistributionTotal (totalFor category)
                     ]
                 )
-                allFbfDistributionCategories
+                categories
     in
     { heading = ""
     , captions =

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -2885,58 +2885,61 @@ generateFBFDistributionReportData :
     -> MetricsResultsTableData
 generateFBFDistributionReportData language categories records =
     let
-        -- FBF child totals come exclusively from groupNutritionFbfData
+        -- FBF child amounts come exclusively from groupNutritionFbfData
         -- (clinic group_type = 'fbf'); Achi child_fbf rows live under
-        -- groupNutritionAchiData and are intentionally out of scope.
-        fbfChildTotal =
+        -- groupNutritionAchiData and are intentionally out of scope. Each
+        -- entry with a Just fbfAmount is one distribution event, so the
+        -- occurrence count is just the length of the filtered list.
+        fbfChildAmounts =
             records
                 |> List.filterMap .groupNutritionFbfData
                 |> List.concat
                 |> List.filterMap .fbfAmount
-                |> List.sum
 
-        fbfMotherTotal =
+        fbfMotherAmounts =
             records
                 |> List.filterMap .groupNutritionFbfMotherData
                 |> List.concat
                 |> List.map .fbfAmount
-                |> List.sum
 
-        ahezaChildTotal =
+        ahezaChildAmounts =
             records
                 |> List.filterMap .familyNutritionMuacData
                 |> List.concat
                 |> List.concat
                 |> List.filterMap .ahezaAmount
-                |> List.sum
 
-        ahezaMotherTotal =
+        ahezaMotherAmounts =
             records
                 |> List.filterMap .familyNutritionData
                 |> List.concat
                 |> List.concat
                 |> List.filterMap .ahezaAmount
-                |> List.sum
 
-        totalFor category =
+        amountsFor category =
             case category of
                 FbfDistributionAhezaChild ->
-                    ahezaChildTotal
+                    ahezaChildAmounts
 
                 FbfDistributionAhezaMother ->
-                    ahezaMotherTotal
+                    ahezaMotherAmounts
 
                 FbfDistributionFbfChild ->
-                    fbfChildTotal
+                    fbfChildAmounts
 
                 FbfDistributionFbfMother ->
-                    fbfMotherTotal
+                    fbfMotherAmounts
 
         rows =
             List.map
                 (\category ->
+                    let
+                        amounts =
+                            amountsFor category
+                    in
                     [ translate language (Translate.FbfDistributionCategory category)
-                    , formatDistributionTotal (totalFor category)
+                    , formatDistributionTotal (List.sum amounts)
+                    , String.fromInt (List.length amounts)
                     ]
                 )
                 categories
@@ -2945,6 +2948,7 @@ generateFBFDistributionReportData language categories records =
     , captions =
         [ translate language Translate.FbfDistributionType
         , translate language Translate.Total
+        , translate language Translate.FbfDistributionOccurrences
         ]
     , rows = rows
     }

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -42,7 +42,7 @@ import List.Extra
 import Maybe.Extra exposing (isJust, isNothing)
 import Pages.Components.View exposing (viewMetricsResultsTable, viewStandardCells, viewStandardRow)
 import Pages.Model exposing (MetricsResultsTableData)
-import Pages.Reports.Model exposing (Model, Msg(..), NutritionMetrics, NutritionMetricsResults, NutritionReportData, PregnancyTrimester(..), PrenatalContactType(..), ReportType(..), emptyNutritionMetrics)
+import Pages.Reports.Model exposing (FbfDistributionCategory(..), Model, Msg(..), NutritionMetrics, NutritionMetricsResults, NutritionReportData, PregnancyTrimester(..), PrenatalContactType(..), ReportType(..), allFbfDistributionCategories, emptyNutritionMetrics)
 import Pages.Reports.Utils exposing (allVaccineTypes, countTotalEncounters, eddToLmpDate, generateIncidenceNutritionMetricsResults, generatePrevalenceNutritionMetricsResults, isWideScope, prenatalContactTypeToEncountersAtWeek, reportTypeToString, resolveDataSetForMonth, resolveDataSetForQuarter, resolveDataSetForYear, resolvePregnancyTrimester, resolvePreviousDataSetForMonth)
 import Pages.Scoreboard.Utils exposing (generateFutureVaccinationsData)
 import Pages.Utils
@@ -289,6 +289,9 @@ viewReportsData language currentDate themePath data model =
                                                         , groupNutritionSorwatheData = filterGroupBy .startDate record.groupNutritionSorwatheData
                                                         , groupNutritionChwData = filterGroupBy .startDate record.groupNutritionChwData
                                                         , groupNutritionAchiData = filterGroupBy .startDate record.groupNutritionAchiData
+                                                        , groupNutritionFbfMotherData = filterGroupBy .startDate record.groupNutritionFbfMotherData
+                                                        , familyNutritionData = filterIndividualBy .startDate record.familyNutritionData
+                                                        , familyNutritionMuacData = filterIndividualBy .startDate record.familyNutritionMuacData
                                                     }
 
                                             else
@@ -302,6 +305,9 @@ viewReportsData language currentDate themePath data model =
 
                             ReportDemographics ->
                                 viewDemographicsReport language startDate limitDate scopeLabel recordsTillLimitDate
+
+                            ReportFBFDistribution ->
+                                viewFBFDistributionReport language limitDate scopeLabel recordsTillLimitDate
 
                             ReportNutrition ->
                                 viewNutritionReport language limitDate scopeLabel data.nutritionReportData model.nutritionReportData
@@ -346,6 +352,7 @@ viewReportsData language currentDate themePath data model =
                 , ReportNutrition
                 , ReportPeripartum
                 , ReportPostnatalCare
+                , ReportFBFDistribution
                 ]
                 reportTypeToString
                 SetReportType
@@ -2787,6 +2794,144 @@ generatePeripartumReportData language records =
             (List.length <| pregnanciesWithIndicator IndicatorBreastfedFirstHour pregnancies)
         ]
     }
+
+
+viewFBFDistributionReport : Language -> NominalDate -> String -> List PatientData -> Html Msg
+viewFBFDistributionReport language limitDate scopeLabel records =
+    let
+        data =
+            generateFBFDistributionReportData language records
+
+        captionsRow =
+            viewStandardCells data.captions
+                |> div [ class "row captions" ]
+
+        csvFileName =
+            "fbf-distribution-report-"
+                ++ (String.toLower <| String.replace " " "-" scopeLabel)
+                ++ "-"
+                ++ customFormatDDMMYYYY "-" limitDate
+                ++ ".csv"
+
+        csvContent =
+            reportTableDataToCSV data
+
+        dataRows =
+            List.map2
+                (\category row ->
+                    viewStandardCells row
+                        |> div [ class <| "row " ++ fbfDistributionCategoryCssClass category ]
+                )
+                allFbfDistributionCategories
+                data.rows
+    in
+    div [ class "report fbf-distribution" ]
+        [ div [ class "table" ] <|
+            captionsRow
+                :: dataRows
+        , viewDownloadCSVButton language csvFileName csvContent
+        ]
+
+
+generateFBFDistributionReportData :
+    Language
+    -> List PatientData
+    -> MetricsResultsTableData
+generateFBFDistributionReportData language records =
+    let
+        -- FBF child totals come exclusively from groupNutritionFbfData
+        -- (clinic group_type = 'fbf'); Achi child_fbf rows live under
+        -- groupNutritionAchiData and are intentionally out of scope.
+        fbfChildTotal =
+            records
+                |> List.filterMap .groupNutritionFbfData
+                |> List.concat
+                |> List.filterMap .fbfAmount
+                |> List.sum
+
+        fbfMotherTotal =
+            records
+                |> List.filterMap .groupNutritionFbfMotherData
+                |> List.concat
+                |> List.map .fbfAmount
+                |> List.sum
+
+        ahezaChildTotal =
+            records
+                |> List.filterMap .familyNutritionMuacData
+                |> List.concat
+                |> List.concat
+                |> List.filterMap .ahezaAmount
+                |> List.sum
+
+        ahezaMotherTotal =
+            records
+                |> List.filterMap .familyNutritionData
+                |> List.concat
+                |> List.concat
+                |> List.filterMap .ahezaAmount
+                |> List.sum
+
+        totalFor category =
+            case category of
+                FbfDistributionAhezaChild ->
+                    ahezaChildTotal
+
+                FbfDistributionAhezaMother ->
+                    ahezaMotherTotal
+
+                FbfDistributionFbfChild ->
+                    fbfChildTotal
+
+                FbfDistributionFbfMother ->
+                    fbfMotherTotal
+
+        rows =
+            List.map
+                (\category ->
+                    [ translate language (Translate.FbfDistributionCategory category)
+                    , formatDistributionTotal (totalFor category)
+                    ]
+                )
+                allFbfDistributionCategories
+    in
+    { heading = ""
+    , captions =
+        [ translate language Translate.FbfDistributionType
+        , translate language Translate.Total
+        ]
+    , rows = rows
+    }
+
+
+{-| Show whole-number totals as integers (e.g. "5") and fractional totals
+with up to two decimal places (e.g. "5.25"). Distribution amounts can be
+integers (AHEZA, FBF packages) or decimals (FBF kg from legacy Achi data,
+out of scope here).
+-}
+formatDistributionTotal : Float -> String
+formatDistributionTotal value =
+    if value == toFloat (round value) then
+        String.fromInt (round value)
+
+    else
+        Round.round 2 value
+
+
+fbfDistributionCategoryCssClass : FbfDistributionCategory -> String
+fbfDistributionCategoryCssClass category =
+    case category of
+        FbfDistributionAhezaChild ->
+            "aheza-child"
+
+        FbfDistributionAhezaMother ->
+            "aheza-mother"
+
+        FbfDistributionFbfChild ->
+            "fbf-child"
+
+        FbfDistributionFbfMother ->
+            "fbf-mother"
 
 
 viewPostnatalCareReport : Language -> Site -> NominalDate -> String -> List PatientData -> Html Msg

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -2872,6 +2872,9 @@ visibleFbfDistributionCategories features =
                 FbfDistributionFbfChild ->
                     True
 
+                FbfDistributionFbfChildAchi ->
+                    True
+
                 FbfDistributionFbfMother ->
                     True
         )
@@ -2885,14 +2888,23 @@ generateFBFDistributionReportData :
     -> MetricsResultsTableData
 generateFBFDistributionReportData language categories records =
     let
-        -- FBF child amounts come exclusively from groupNutritionFbfData
-        -- (clinic group_type = 'fbf'); Achi child_fbf rows live under
-        -- groupNutritionAchiData and are intentionally out of scope. Each
-        -- entry with a Just fbfAmount is one distribution event, so the
-        -- occurrence count is just the length of the filtered list.
+        -- FBF child amounts come from groupNutritionFbfData (clinic
+        -- group_type = 'fbf'). The same child_fbf measurement type is
+        -- also used at Achi clinics, where it represents Aheza in kg
+        -- rather than FBF packages; those records live under
+        -- groupNutritionAchiData and are surfaced as a separate row.
+        -- Each entry with a Just fbfAmount is one distribution event,
+        -- so the occurrence count is just the length of the filtered
+        -- list.
         fbfChildAmounts =
             records
                 |> List.filterMap .groupNutritionFbfData
+                |> List.concat
+                |> List.filterMap .fbfAmount
+
+        fbfChildAchiAmounts =
+            records
+                |> List.filterMap .groupNutritionAchiData
                 |> List.concat
                 |> List.filterMap .fbfAmount
 
@@ -2927,6 +2939,9 @@ generateFBFDistributionReportData language categories records =
                 FbfDistributionFbfChild ->
                     fbfChildAmounts
 
+                FbfDistributionFbfChildAchi ->
+                    fbfChildAchiAmounts
+
                 FbfDistributionFbfMother ->
                     fbfMotherAmounts
 
@@ -2939,6 +2954,7 @@ generateFBFDistributionReportData language categories records =
                     in
                     [ translate language (Translate.FbfDistributionCategory category)
                     , formatDistributionTotal (List.sum amounts)
+                    , translate language (fbfDistributionCategoryUnit category)
                     , String.fromInt (List.length amounts)
                     ]
                 )
@@ -2948,10 +2964,33 @@ generateFBFDistributionReportData language categories records =
     , captions =
         [ translate language Translate.FbfDistributionType
         , translate language Translate.FbfDistributionTotalAmount
+        , translate language Translate.FbfDistributionUnit
         , translate language Translate.FbfDistributionOccurrences
         ]
     , rows = rows
     }
+
+
+{-| FBF clinic distributions are reported in packages; AHEZA (CHW family
+nutrition) and ACHI clinic distributions are reported in kg.
+-}
+fbfDistributionCategoryUnit : FbfDistributionCategory -> TranslationId
+fbfDistributionCategoryUnit category =
+    case category of
+        FbfDistributionAhezaChild ->
+            Translate.FbfDistributionUnitKg
+
+        FbfDistributionAhezaMother ->
+            Translate.FbfDistributionUnitKg
+
+        FbfDistributionFbfChild ->
+            Translate.FbfDistributionUnitPackage
+
+        FbfDistributionFbfChildAchi ->
+            Translate.FbfDistributionUnitKg
+
+        FbfDistributionFbfMother ->
+            Translate.FbfDistributionUnitPackage
 
 
 {-| Show whole-number totals as integers (e.g. "5") and fractional totals
@@ -2979,6 +3018,9 @@ fbfDistributionCategoryCssClass category =
 
         FbfDistributionFbfChild ->
             "fbf-child"
+
+        FbfDistributionFbfChildAchi ->
+            "fbf-child-achi"
 
         FbfDistributionFbfMother ->
             "fbf-mother"

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -2947,7 +2947,7 @@ generateFBFDistributionReportData language categories records =
     { heading = ""
     , captions =
         [ translate language Translate.FbfDistributionType
-        , translate language Translate.Total
+        , translate language Translate.FbfDistributionTotalAmount
         , translate language Translate.FbfDistributionOccurrences
         ]
     , rows = rows

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -304,7 +304,7 @@ viewReportsData language currentDate themePath data model =
                                 viewAcuteIllnessReport language limitDate startDate scopeLabel recordsTillLimitDate
 
                             ReportDemographics ->
-                                viewDemographicsReport language startDate limitDate scopeLabel recordsTillLimitDate
+                                viewDemographicsReport language data.features startDate limitDate scopeLabel recordsTillLimitDate
 
                             ReportFBFDistribution ->
                                 viewFBFDistributionReport language data.features limitDate scopeLabel recordsTillLimitDate
@@ -369,8 +369,8 @@ viewReportsData language currentDate themePath data model =
         ]
 
 
-viewDemographicsReport : Language -> NominalDate -> NominalDate -> String -> List PatientData -> Html Msg
-viewDemographicsReport language startDate limitDate scopeLabel records =
+viewDemographicsReport : Language -> EverySet SiteFeature -> NominalDate -> NominalDate -> String -> List PatientData -> Html Msg
+viewDemographicsReport language features startDate limitDate scopeLabel records =
     let
         demographicsReportPatientsData =
             -- We get recoderds for all patients that were created not before
@@ -386,7 +386,7 @@ viewDemographicsReport language startDate limitDate scopeLabel records =
                 |> generateDemographicsReportPatientsData language limitDate
 
         demographicsReportEncountersData =
-            generateDemographicsReportEncountersData language records
+            generateDemographicsReportEncountersData language features records
 
         csvFileName =
             "demographics-report-"
@@ -688,6 +688,7 @@ demographicsReportPatientsDataToCSV data =
 
 generateDemographicsReportEncountersData :
     Language
+    -> EverySet SiteFeature
     -> List PatientData
     ->
         { heading : String
@@ -695,7 +696,7 @@ generateDemographicsReportEncountersData :
         , rows : List ( List String, Bool )
         , totals : { label : String, total : String, unique : String }
         }
-generateDemographicsReportEncountersData language records =
+generateDemographicsReportEncountersData language features records =
     let
         prenatalDataNurseEncounters =
             List.filterMap
@@ -905,10 +906,17 @@ generateDemographicsReportEncountersData language records =
         nutritionGroupAchiEncountersUnique =
             countUnique nutritionGroupAchiEncountersData
 
+        familyNutritionEnabled =
+            EverySet.member FeatureFamilyNutrition features
+
         familyNutritionEncountersData =
-            List.filterMap
-                (.familyNutritionData >> Maybe.map List.concat)
-                records
+            if familyNutritionEnabled then
+                List.filterMap
+                    (.familyNutritionData >> Maybe.map List.concat)
+                    records
+
+            else
+                []
 
         familyNutritionEncountersTotal =
             countTotal familyNutritionEncountersData
@@ -997,8 +1005,13 @@ generateDemographicsReportEncountersData language records =
         , generateRow Translate.CBNP nutritionGroupChwEncountersTotal nutritionGroupChwEncountersUnique True
         , generateRow Translate.ACHI nutritionGroupAchiEncountersTotal nutritionGroupAchiEncountersUnique True
         , generateRow Translate.Individual nutritionIndividualEncountersTotal nutritionIndividualEncountersUnique True
-        , generateRow Translate.FamilyNutrition familyNutritionEncountersTotal familyNutritionEncountersUnique False
         ]
+            ++ (if familyNutritionEnabled then
+                    [ generateRow Translate.FamilyNutrition familyNutritionEncountersTotal familyNutritionEncountersUnique False ]
+
+                else
+                    []
+               )
     , totals =
         { label = translate language Translate.Total
         , total = String.fromInt overallTotal

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -344,16 +344,18 @@ viewReportsData language currentDate themePath data model =
         , div [ class "inputs" ] <|
             (viewSelectListInput language
                 model.reportType
-                [ ReportAcuteIllness
-                , ReportDemographics
-                , ReportFBFDistribution
-                , ReportNutrition
-                , ReportPeripartum
-                , ReportPostnatalCare
-                , ReportPrenatal
-                , ReportPrenatalContacts
-                , ReportPrenatalDiagnoses
-                ]
+                ([ ReportAcuteIllness
+                 , ReportDemographics
+                 , ReportFBFDistribution
+                 , ReportNutrition
+                 , ReportPeripartum
+                 , ReportPostnatalCare
+                 , ReportPrenatal
+                 , ReportPrenatalContacts
+                 , ReportPrenatalDiagnoses
+                 ]
+                    |> List.sortBy (\rt -> String.toLower (translate language (Translate.ReportType rt)))
+                )
                 reportTypeToString
                 SetReportType
                 Translate.ReportType

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -125,6 +125,7 @@ type TranslationId
     | FamilyPlanning
     | FBF
     | FbfDistributionCategory FbfDistributionCategory
+    | FbfDistributionOccurrences
     | FbfDistributionType
     | Feeding
     | Female
@@ -915,6 +916,13 @@ translationSet transId =
                     , kirundi = Nothing
                     , somali = Nothing
                     }
+
+        FbfDistributionOccurrences ->
+            { english = "Occurrences"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
 
         FbfDistributionType ->
             { english = "Type"

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -126,6 +126,7 @@ type TranslationId
     | FBF
     | FbfDistributionCategory FbfDistributionCategory
     | FbfDistributionOccurrences
+    | FbfDistributionTotalAmount
     | FbfDistributionType
     | Feeding
     | Female
@@ -918,7 +919,14 @@ translationSet transId =
                     }
 
         FbfDistributionOccurrences ->
-            { english = "Occurrences"
+            { english = "# of Encounters"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        FbfDistributionTotalAmount ->
+            { english = "Total amount"
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing
@@ -3053,7 +3061,7 @@ translationSet transId =
                     }
 
                 ReportFBFDistribution ->
-                    { english = "FBF Distribution"
+                    { english = "Stock Management"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -889,28 +889,28 @@ translationSet transId =
         FbfDistributionCategory category ->
             case category of
                 FbfDistributionFbfChild ->
-                    { english = "FBF Child"
+                    { english = "FBF Child (packages)"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
 
                 FbfDistributionFbfMother ->
-                    { english = "FBF Mother"
+                    { english = "FBF Mother (packages)"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
 
                 FbfDistributionAhezaChild ->
-                    { english = "Aheza Child"
+                    { english = "Aheza Child (kg)"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
 
                 FbfDistributionAhezaMother ->
-                    { english = "Aheza Mother"
+                    { english = "Aheza Mother (kg)"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -964,7 +964,7 @@ translationSet transId =
             }
 
         FbfDistributionUnitPackage ->
-            { english = "package"
+            { english = "pkg"
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -128,6 +128,9 @@ type TranslationId
     | FbfDistributionOccurrences
     | FbfDistributionTotalAmount
     | FbfDistributionType
+    | FbfDistributionUnit
+    | FbfDistributionUnitKg
+    | FbfDistributionUnitPackage
     | Feeding
     | Female
     | FirstVisit
@@ -891,28 +894,35 @@ translationSet transId =
         FbfDistributionCategory category ->
             case category of
                 FbfDistributionFbfChild ->
-                    { english = "FBF Child (packages)"
+                    { english = "FBF Child"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                FbfDistributionFbfChildAchi ->
+                    { english = "FBF Child (ACHI)"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
 
                 FbfDistributionFbfMother ->
-                    { english = "FBF Mother (packages)"
+                    { english = "FBF Mother"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
 
                 FbfDistributionAhezaChild ->
-                    { english = "Aheza Child (kg)"
+                    { english = "Aheza Child"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
                     }
 
                 FbfDistributionAhezaMother ->
-                    { english = "Aheza Mother (kg)"
+                    { english = "Aheza Mother"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing
@@ -934,6 +944,27 @@ translationSet transId =
 
         FbfDistributionType ->
             { english = "Type"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        FbfDistributionUnit ->
+            { english = "Unit"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        FbfDistributionUnitKg ->
+            { english = "kg"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        FbfDistributionUnitPackage ->
+            { english = "package"
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -32,7 +32,7 @@ import Backend.Scoreboard.Model
 import Date
 import Pages.Completion.Model
 import Pages.Components.Types exposing (PopulationSelectionOption(..))
-import Pages.Reports.Model exposing (PregnancyTrimester(..), PrenatalContactType(..), ReportType(..))
+import Pages.Reports.Model exposing (FbfDistributionCategory(..), PregnancyTrimester(..), PrenatalContactType(..), ReportType(..))
 import Pages.Scoreboard.Model exposing (NCDAANCNewbornItem(..), NCDAAcuteMalnutritionItem(..), NCDADemographicsItem(..), NCDAInfrastructureEnvironmentWashItem(..), NCDANutritionBehaviorItem(..), NCDAStuntingItem(..), NCDATargetedInterventionsItem(..), NCDAUniversalInterventionItem(..))
 import Time exposing (Month(..))
 
@@ -124,6 +124,8 @@ type TranslationId
     | FamilyNutrition
     | FamilyPlanning
     | FBF
+    | FbfDistributionCategory FbfDistributionCategory
+    | FbfDistributionType
     | Feeding
     | Female
     | FirstVisit
@@ -879,6 +881,43 @@ translationSet transId =
 
         FBF ->
             { english = "FBF"
+            , kinyarwanda = Nothing
+            , kirundi = Nothing
+            , somali = Nothing
+            }
+
+        FbfDistributionCategory category ->
+            case category of
+                FbfDistributionFbfChild ->
+                    { english = "FBF Child"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                FbfDistributionFbfMother ->
+                    { english = "FBF Mother"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                FbfDistributionAhezaChild ->
+                    { english = "Aheza Child"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                FbfDistributionAhezaMother ->
+                    { english = "Aheza Mother"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+        FbfDistributionType ->
+            { english = "Type"
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing
@@ -3000,6 +3039,13 @@ translationSet transId =
 
                 ReportDemographics ->
                     { english = "Demographics"
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                ReportFBFDistribution ->
+                    { english = "FBF Distribution"
                     , kinyarwanda = Nothing
                     , kirundi = Nothing
                     , somali = Nothing

--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -53,6 +53,7 @@ define('HEDLEY_ACTIVITY_WELL_CHILD_NCDA_CONTENT_TYPE', 'well_child_ncda');
 define('HEDLEY_ACTIVITY_CHILD_SCOREBOARD_NCDA_CONTENT_TYPE', 'child_scoreboard_ncda');
 define('HEDLEY_ACTIVITY_WELL_CHILD_PREGNANCY_SUMMARY_CONTENT_TYPE', 'well_child_pregnancy_summary');
 define('HEDLEY_ACTIVITY_CHILD_FBF_CONTENT_TYPE', 'child_fbf');
+define('HEDLEY_ACTIVITY_MOTHER_FBF_CONTENT_TYPE', 'mother_fbf');
 define('HEDLEY_ACTIVITY_GROUP_SEND_TO_HC_CONTENT_TYPE', 'group_send_to_hc');
 define('HEDLEY_ACTIVITY_NUTRITION_SEND_TO_HC_CONTENT_TYPE', 'nutrition_send_to_hc');
 define('HEDLEY_ACTIVITY_WELL_CHILD_SEND_TO_HC_CONTENT_TYPE', 'well_child_send_to_hc');

--- a/server/hedley/modules/custom/hedley_admin/hedley_admin.module
+++ b/server/hedley/modules/custom/hedley_admin/hedley_admin.module
@@ -622,3 +622,48 @@ function hedley_admin_resilience_survey_export_csv($form, &$form_state) {
   echo $csv_output;
   exit;
 }
+
+/**
+ * Returns the canonical list of toggleable site features.
+ *
+ * Each entry corresponds to a `hedley_admin_feature_<name>_enabled` variable.
+ * Stays in sync with the SiteFeature union in
+ * client/src/elm/SyncManager/Model.elm and
+ * server/elm/src/App/Types.elm; update all together.
+ *
+ * @return array
+ *   List of feature identifiers in alphabetical order.
+ */
+function hedley_admin_get_available_features() {
+  return [
+    'family_nutrition',
+    'gps_coordinates',
+    'group_education',
+    'healthy_start',
+    'hiv_management',
+    'ncda',
+    'report_to_whatsapp',
+    'stock_management_hc',
+    'stock_management_village',
+    'tuberculosis_management',
+  ];
+}
+
+/**
+ * Returns the space-delimited list of currently enabled site features.
+ *
+ * Suitable for emission as the `features` field consumed by both the client
+ * sync API and the admin Reports Elm app (decoded by decodeSiteFeatures).
+ *
+ * @return string
+ *   Space-delimited identifiers; empty string when no feature is enabled.
+ */
+function hedley_admin_get_enabled_features_string() {
+  $enabled = array_filter(
+    hedley_admin_get_available_features(),
+    function ($feature) {
+      return variable_get("hedley_admin_feature_{$feature}_enabled", FALSE);
+    }
+  );
+  return implode(' ', $enabled);
+}

--- a/server/hedley/modules/custom/hedley_family_nutrition/hedley_family_nutrition.module
+++ b/server/hedley/modules/custom/hedley_family_nutrition/hedley_family_nutrition.module
@@ -6,3 +6,6 @@
  */
 
 include_once 'hedley_family_nutrition.features.inc';
+
+define('HEDLEY_FAMILY_NUTRITION_AHEZA_CHILD_CONTENT_TYPE', 'aheza_child');
+define('HEDLEY_FAMILY_NUTRITION_AHEZA_MOTHER_CONTENT_TYPE', 'aheza_mother');

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -22008,8 +22008,17 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 								$author$project$Pages$Utils$viewSelectListInput,
 								language,
 								model.reportType,
-								_List_fromArray(
-									[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportFBFDistribution, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses]),
+								A2(
+									$elm$core$List$sortBy,
+									function (rt) {
+										return $elm$core$String$toLower(
+											A2(
+												$author$project$Translate$translate,
+												language,
+												$author$project$Translate$ReportType(rt)));
+									},
+									_List_fromArray(
+										[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportFBFDistribution, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses])),
 								$author$project$Pages$Reports$Utils$reportTypeToString,
 								$author$project$Pages$Reports$Model$SetReportType,
 								$author$project$Translate$ReportType,

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -6735,6 +6735,7 @@ var $author$project$Pages$Reports$Update$performNutritionReportDataCalculation =
 	});
 var $author$project$Pages$Reports$Model$ReportAcuteIllness = {$: 'ReportAcuteIllness'};
 var $author$project$Pages$Reports$Model$ReportDemographics = {$: 'ReportDemographics'};
+var $author$project$Pages$Reports$Model$ReportFBFDistribution = {$: 'ReportFBFDistribution'};
 var $author$project$Pages$Reports$Model$ReportNutrition = {$: 'ReportNutrition'};
 var $author$project$Pages$Reports$Model$ReportPeripartum = {$: 'ReportPeripartum'};
 var $author$project$Pages$Reports$Model$ReportPostnatalCare = {$: 'ReportPostnatalCare'};
@@ -6747,6 +6748,8 @@ var $author$project$Pages$Reports$Utils$reportTypeFromString = function (reportT
 			return $elm$core$Maybe$Just($author$project$Pages$Reports$Model$ReportAcuteIllness);
 		case 'demographics':
 			return $elm$core$Maybe$Just($author$project$Pages$Reports$Model$ReportDemographics);
+		case 'fbf-distribution':
+			return $elm$core$Maybe$Just($author$project$Pages$Reports$Model$ReportFBFDistribution);
 		case 'nutrition':
 			return $elm$core$Maybe$Just($author$project$Pages$Reports$Model$ReportNutrition);
 		case 'peripartum':
@@ -11805,6 +11808,20 @@ var $author$project$Translate$translationSet = function (transId) {
 				return {english: 'Family Planning', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'FBF':
 				return {english: 'FBF', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+			case 'FbfDistributionCategory':
+				var category = transId.a;
+				switch (category.$) {
+					case 'FbfDistributionFbfChild':
+						return {english: 'FBF Child', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+					case 'FbfDistributionFbfMother':
+						return {english: 'FBF Mother', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+					case 'FbfDistributionAhezaChild':
+						return {english: 'Aheza Child', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+					default:
+						return {english: 'Aheza Mother', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+				}
+			case 'FbfDistributionType':
+				return {english: 'Type', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Feeding':
 				return {english: 'Feeding', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Female':
@@ -13145,6 +13162,8 @@ var $author$project$Translate$translationSet = function (transId) {
 						continue translationSet;
 					case 'ReportDemographics':
 						return {english: 'Demographics', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+					case 'ReportFBFDistribution':
+						return {english: 'FBF Distribution', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'ReportNutrition':
 						var $temp$transId = $author$project$Translate$Nutrition;
 						transId = $temp$transId;
@@ -17156,6 +17175,8 @@ var $author$project$Pages$Reports$Utils$reportTypeToString = function (reportTyp
 			return 'acute-illness';
 		case 'ReportDemographics':
 			return 'demographics';
+		case 'ReportFBFDistribution':
+			return 'fbf-distribution';
 		case 'ReportNutrition':
 			return 'nutrition';
 		case 'ReportPeripartum':
@@ -18153,6 +18174,173 @@ var $author$project$Pages$Reports$View$viewDemographicsReport = F5(
 						[
 							A3($author$project$Pages$Reports$View$viewDownloadCSVButton, language, csvFileName, csvContent)
 						]))));
+	});
+var $author$project$Pages$Reports$Model$FbfDistributionAhezaChild = {$: 'FbfDistributionAhezaChild'};
+var $author$project$Pages$Reports$Model$FbfDistributionAhezaMother = {$: 'FbfDistributionAhezaMother'};
+var $author$project$Pages$Reports$Model$FbfDistributionFbfChild = {$: 'FbfDistributionFbfChild'};
+var $author$project$Pages$Reports$Model$FbfDistributionFbfMother = {$: 'FbfDistributionFbfMother'};
+var $author$project$Pages$Reports$Model$allFbfDistributionCategories = _List_fromArray(
+	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
+var $author$project$Pages$Reports$View$fbfDistributionCategoryCssClass = function (category) {
+	switch (category.$) {
+		case 'FbfDistributionAhezaChild':
+			return 'aheza-child';
+		case 'FbfDistributionAhezaMother':
+			return 'aheza-mother';
+		case 'FbfDistributionFbfChild':
+			return 'fbf-child';
+		default:
+			return 'fbf-mother';
+	}
+};
+var $author$project$Translate$FbfDistributionCategory = function (a) {
+	return {$: 'FbfDistributionCategory', a: a};
+};
+var $author$project$Translate$FbfDistributionType = {$: 'FbfDistributionType'};
+var $elm$core$Basics$round = _Basics_round;
+var $author$project$Pages$Reports$View$formatDistributionTotal = function (value) {
+	return _Utils_eq(
+		value,
+		$elm$core$Basics$round(value)) ? $elm$core$String$fromInt(
+		$elm$core$Basics$round(value)) : A2($myrho$elm_round$Round$round, 2, value);
+};
+var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F2(
+	function (language, records) {
+		var fbfMotherTotal = $elm$core$List$sum(
+			A2(
+				$elm$core$List$map,
+				function ($) {
+					return $.fbfAmount;
+				},
+				$elm$core$List$concat(
+					A2(
+						$elm$core$List$filterMap,
+						function ($) {
+							return $.groupNutritionFbfMotherData;
+						},
+						records))));
+		var fbfChildTotal = $elm$core$List$sum(
+			A2(
+				$elm$core$List$filterMap,
+				function ($) {
+					return $.fbfAmount;
+				},
+				$elm$core$List$concat(
+					A2(
+						$elm$core$List$filterMap,
+						function ($) {
+							return $.groupNutritionFbfData;
+						},
+						records))));
+		var ahezaMotherTotal = $elm$core$List$sum(
+			A2(
+				$elm$core$List$filterMap,
+				function ($) {
+					return $.ahezaAmount;
+				},
+				$elm$core$List$concat(
+					$elm$core$List$concat(
+						A2(
+							$elm$core$List$filterMap,
+							function ($) {
+								return $.familyNutritionData;
+							},
+							records)))));
+		var ahezaChildTotal = $elm$core$List$sum(
+			A2(
+				$elm$core$List$filterMap,
+				function ($) {
+					return $.ahezaAmount;
+				},
+				$elm$core$List$concat(
+					$elm$core$List$concat(
+						A2(
+							$elm$core$List$filterMap,
+							function ($) {
+								return $.familyNutritionMuacData;
+							},
+							records)))));
+		var totalFor = function (category) {
+			switch (category.$) {
+				case 'FbfDistributionAhezaChild':
+					return ahezaChildTotal;
+				case 'FbfDistributionAhezaMother':
+					return ahezaMotherTotal;
+				case 'FbfDistributionFbfChild':
+					return fbfChildTotal;
+				default:
+					return fbfMotherTotal;
+			}
+		};
+		var rows = A2(
+			$elm$core$List$map,
+			function (category) {
+				return _List_fromArray(
+					[
+						A2(
+						$author$project$Translate$translate,
+						language,
+						$author$project$Translate$FbfDistributionCategory(category)),
+						$author$project$Pages$Reports$View$formatDistributionTotal(
+						totalFor(category))
+					]);
+			},
+			$author$project$Pages$Reports$Model$allFbfDistributionCategories);
+		return {
+			captions: _List_fromArray(
+				[
+					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionType),
+					A2($author$project$Translate$translate, language, $author$project$Translate$Total)
+				]),
+			heading: '',
+			rows: rows
+		};
+	});
+var $author$project$Pages$Reports$View$viewFBFDistributionReport = F4(
+	function (language, limitDate, scopeLabel, records) {
+		var data = A2($author$project$Pages$Reports$View$generateFBFDistributionReportData, language, records);
+		var dataRows = A3(
+			$elm$core$List$map2,
+			F2(
+				function (category, row) {
+					return A2(
+						$elm$html$Html$div,
+						_List_fromArray(
+							[
+								$elm$html$Html$Attributes$class(
+								'row ' + $author$project$Pages$Reports$View$fbfDistributionCategoryCssClass(category))
+							]),
+						$author$project$Pages$Components$View$viewStandardCells(row));
+				}),
+			$author$project$Pages$Reports$Model$allFbfDistributionCategories,
+			data.rows);
+		var csvFileName = 'fbf-distribution-report-' + ($elm$core$String$toLower(
+			A3($elm$core$String$replace, ' ', '-', scopeLabel)) + ('-' + (A2($author$project$Gizra$NominalDate$customFormatDDMMYYYY, '-', limitDate) + '.csv')));
+		var csvContent = $author$project$Pages$Reports$View$reportTableDataToCSV(data);
+		var captionsRow = A2(
+			$elm$html$Html$div,
+			_List_fromArray(
+				[
+					$elm$html$Html$Attributes$class('row captions')
+				]),
+			$author$project$Pages$Components$View$viewStandardCells(data.captions));
+		return A2(
+			$elm$html$Html$div,
+			_List_fromArray(
+				[
+					$elm$html$Html$Attributes$class('report fbf-distribution')
+				]),
+			_List_fromArray(
+				[
+					A2(
+					$elm$html$Html$div,
+					_List_fromArray(
+						[
+							$elm$html$Html$Attributes$class('table')
+						]),
+					A2($elm$core$List$cons, captionsRow, dataRows)),
+					A3($author$project$Pages$Reports$View$viewDownloadCSVButton, language, csvFileName, csvContent)
+				]));
 	});
 var $author$project$Translate$AcuteMalnutritionMam = {$: 'AcuteMalnutritionMam'};
 var $author$project$Translate$AcuteMalnutritionSam = {$: 'AcuteMalnutritionSam'};
@@ -21621,6 +21809,18 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 															},
 															record.acuteIllnessData),
 														childScorecardData: A2(filterIndividualBy, $elm$core$Basics$identity, record.childScorecardData),
+														familyNutritionData: A2(
+															filterIndividualBy,
+															function ($) {
+																return $.startDate;
+															},
+															record.familyNutritionData),
+														familyNutritionMuacData: A2(
+															filterIndividualBy,
+															function ($) {
+																return $.startDate;
+															},
+															record.familyNutritionMuacData),
 														groupNutritionAchiData: A2(
 															filterGroupBy,
 															function ($) {
@@ -21639,6 +21839,12 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 																return $.startDate;
 															},
 															record.groupNutritionFbfData),
+														groupNutritionFbfMotherData: A2(
+															filterGroupBy,
+															function ($) {
+																return $.startDate;
+															},
+															record.groupNutritionFbfMotherData),
 														groupNutritionPmtctData: A2(
 															filterGroupBy,
 															function ($) {
@@ -21679,6 +21885,8 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 										return A5($author$project$Pages$Reports$View$viewAcuteIllnessReport, language, limitDate, startDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportDemographics':
 										return A5($author$project$Pages$Reports$View$viewDemographicsReport, language, startDate, limitDate, scopeLabel, recordsTillLimitDate);
+									case 'ReportFBFDistribution':
+										return A4($author$project$Pages$Reports$View$viewFBFDistributionReport, language, limitDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportNutrition':
 										return A5($author$project$Pages$Reports$View$viewNutritionReport, language, limitDate, scopeLabel, data.nutritionReportData, model.nutritionReportData);
 									case 'ReportPeripartum':
@@ -21726,7 +21934,7 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 								language,
 								model.reportType,
 								_List_fromArray(
-									[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare]),
+									[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportFBFDistribution]),
 								$author$project$Pages$Reports$Utils$reportTypeToString,
 								$author$project$Pages$Reports$Model$SetReportType,
 								$author$project$Translate$ReportType,

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -6609,7 +6609,7 @@ var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F2(
 													function (item) {
 														return _Utils_Tuple2(
 															record.id,
-															{hasEdema: false, muacCm: item.muacCm, nutritionData: item.nutritionData, startDate: item.startDate});
+															{fbfAmount: $elm$core$Maybe$Nothing, hasEdema: false, muacCm: item.muacCm, nutritionData: item.nutritionData, startDate: item.startDate});
 													}))),
 										record.wellChildData),
 										A2(
@@ -8950,7 +8950,9 @@ var $author$project$Backend$Reports$Model$PatientData = function (id) {
 																	return function (groupNutritionSorwatheData) {
 																		return function (groupNutritionChwData) {
 																			return function (groupNutritionAchiData) {
-																				return {acuteIllnessData: acuteIllnessData, birthDate: birthDate, childScorecardData: childScorecardData, created: created, familyNutritionData: familyNutritionData, familyNutritionMuacData: familyNutritionMuacData, gender: gender, groupNutritionAchiData: groupNutritionAchiData, groupNutritionChwData: groupNutritionChwData, groupNutritionFbfData: groupNutritionFbfData, groupNutritionPmtctData: groupNutritionPmtctData, groupNutritionSorwatheData: groupNutritionSorwatheData, hivData: hivData, homeVisitData: homeVisitData, id: id, individualNutritionData: individualNutritionData, ncdData: ncdData, prenatalData: prenatalData, tuberculosisData: tuberculosisData, wellChildData: wellChildData};
+																				return function (groupNutritionFbfMotherData) {
+																					return {acuteIllnessData: acuteIllnessData, birthDate: birthDate, childScorecardData: childScorecardData, created: created, familyNutritionData: familyNutritionData, familyNutritionMuacData: familyNutritionMuacData, gender: gender, groupNutritionAchiData: groupNutritionAchiData, groupNutritionChwData: groupNutritionChwData, groupNutritionFbfData: groupNutritionFbfData, groupNutritionFbfMotherData: groupNutritionFbfMotherData, groupNutritionPmtctData: groupNutritionPmtctData, groupNutritionSorwatheData: groupNutritionSorwatheData, hivData: hivData, homeVisitData: homeVisitData, id: id, individualNutritionData: individualNutritionData, ncdData: ncdData, prenatalData: prenatalData, tuberculosisData: tuberculosisData, wellChildData: wellChildData};
+																				};
 																			};
 																		};
 																	};
@@ -9084,6 +9086,34 @@ var $author$project$Backend$Reports$Decoder$decodeAcuteIllnessEncounterData = A2
 	},
 	$elm$json$Json$Decode$string);
 var $elm$core$String$toFloat = _String_toFloat;
+var $author$project$Backend$Reports$Decoder$parseFamilyNutritionPayload = function (s) {
+	var _v0 = A2($elm$core$String$split, '|', s);
+	_v0$2:
+	while (true) {
+		if (_v0.b) {
+			if (!_v0.b.b) {
+				var muacPart = _v0.a;
+				return _Utils_Tuple2(
+					$elm$core$String$toFloat(muacPart),
+					$elm$core$Maybe$Nothing);
+			} else {
+				if (!_v0.b.b.b) {
+					var muacPart = _v0.a;
+					var _v1 = _v0.b;
+					var ahezaPart = _v1.a;
+					return _Utils_Tuple2(
+						$elm$core$String$toFloat(muacPart),
+						$elm$core$String$toFloat(ahezaPart));
+				} else {
+					break _v0$2;
+				}
+			}
+		} else {
+			break _v0$2;
+		}
+	}
+	return _Utils_Tuple2($elm$core$Maybe$Nothing, $elm$core$Maybe$Nothing);
+};
 var $author$project$Backend$Reports$Decoder$decodeFamilyNutritionEncounterData = A2(
 	$elm$json$Json$Decode$andThen,
 	function (s) {
@@ -9103,7 +9133,7 @@ var $author$project$Backend$Reports$Decoder$decodeFamilyNutritionEncounterData =
 							$elm$core$Maybe$map,
 							function (startDate) {
 								return $elm$json$Json$Decode$succeed(
-									{muacCm: $elm$core$Maybe$Nothing, startDate: startDate});
+									{ahezaAmount: $elm$core$Maybe$Nothing, muacCm: $elm$core$Maybe$Nothing, startDate: startDate});
 							},
 							$elm$core$Result$toMaybe(
 								$justinmimbs$date$Date$fromIsoString(first))));
@@ -9118,9 +9148,62 @@ var $author$project$Backend$Reports$Decoder$decodeFamilyNutritionEncounterData =
 							A2(
 								$elm$core$Maybe$map,
 								function (startDate) {
+									var _v2 = $author$project$Backend$Reports$Decoder$parseFamilyNutritionPayload(second);
+									var muacCm = _v2.a;
+									var ahezaAmount = _v2.b;
+									return $elm$json$Json$Decode$succeed(
+										{ahezaAmount: ahezaAmount, muacCm: muacCm, startDate: startDate});
+								},
+								$elm$core$Result$toMaybe(
+									$justinmimbs$date$Date$fromIsoString(first))));
+					} else {
+						break _v0$2;
+					}
+				}
+			} else {
+				break _v0$2;
+			}
+		}
+		return $elm$json$Json$Decode$fail('Failed to decode FamilyNutritionEncounterData');
+	},
+	$elm$json$Json$Decode$string);
+var $author$project$Backend$Reports$Decoder$decodeFamilyNutritionMotherEncounterData = A2(
+	$elm$json$Json$Decode$andThen,
+	function (s) {
+		var _v0 = A2(
+			$elm$core$String$split,
+			' ',
+			$elm$core$String$trim(s));
+		_v0$2:
+		while (true) {
+			if (_v0.b) {
+				if (!_v0.b.b) {
+					var first = _v0.a;
+					return A2(
+						$elm$core$Maybe$withDefault,
+						$elm$json$Json$Decode$fail('Failed to decode FamilyNutritionMotherEncounterData'),
+						A2(
+							$elm$core$Maybe$map,
+							function (startDate) {
+								return $elm$json$Json$Decode$succeed(
+									{ahezaAmount: $elm$core$Maybe$Nothing, startDate: startDate});
+							},
+							$elm$core$Result$toMaybe(
+								$justinmimbs$date$Date$fromIsoString(first))));
+				} else {
+					if (!_v0.b.b.b) {
+						var first = _v0.a;
+						var _v1 = _v0.b;
+						var second = _v1.a;
+						return A2(
+							$elm$core$Maybe$withDefault,
+							$elm$json$Json$Decode$fail('Failed to decode FamilyNutritionMotherEncounterData'),
+							A2(
+								$elm$core$Maybe$map,
+								function (startDate) {
 									return $elm$json$Json$Decode$succeed(
 										{
-											muacCm: $elm$core$String$toFloat(second),
+											ahezaAmount: $elm$core$String$toFloat(second),
 											startDate: startDate
 										});
 								},
@@ -9134,7 +9217,7 @@ var $author$project$Backend$Reports$Decoder$decodeFamilyNutritionEncounterData =
 				break _v0$2;
 			}
 		}
-		return $elm$json$Json$Decode$fail('Failed to decode FamilyNutritionEncounterData');
+		return $elm$json$Json$Decode$fail('Failed to decode FamilyNutritionMotherEncounterData');
 	},
 	$elm$json$Json$Decode$string);
 var $author$project$Backend$Reports$Model$Male = {$: 'Male'};
@@ -9160,11 +9243,39 @@ var $author$project$Backend$Reports$Decoder$decodeGender = A2(
 				$author$project$Backend$Reports$Utils$genderFromString(gender)));
 	},
 	$elm$json$Json$Decode$string);
+var $author$project$Backend$Reports$Decoder$decodeMotherFbfEncounterData = A2(
+	$elm$json$Json$Decode$andThen,
+	function (s) {
+		var _v0 = A2(
+			$elm$core$String$split,
+			' ',
+			$elm$core$String$trim(s));
+		if ((_v0.b && _v0.b.b) && (!_v0.b.b.b)) {
+			var first = _v0.a;
+			var _v1 = _v0.b;
+			var second = _v1.a;
+			var _v2 = _Utils_Tuple2(
+				$elm$core$Result$toMaybe(
+					$justinmimbs$date$Date$fromIsoString(first)),
+				$elm$core$String$toFloat(second));
+			if ((_v2.a.$ === 'Just') && (_v2.b.$ === 'Just')) {
+				var startDate = _v2.a.a;
+				var fbfAmount = _v2.b.a;
+				return $elm$json$Json$Decode$succeed(
+					{fbfAmount: fbfAmount, startDate: startDate});
+			} else {
+				return $elm$json$Json$Decode$fail('Failed to decode MotherFbfEncounterData');
+			}
+		} else {
+			return $elm$json$Json$Decode$fail('Failed to decode MotherFbfEncounterData');
+		}
+	},
+	$elm$json$Json$Decode$string);
 var $author$project$Backend$Reports$Model$NutritionData = F3(
 	function (stunting, underweight, wasting) {
 		return {stunting: stunting, underweight: underweight, wasting: wasting};
 	});
-var $author$project$Backend$Reports$Decoder$parseNutritionEncounterPayload = function (payload) {
+var $author$project$Backend$Reports$Decoder$parseAnthropometryPayload = function (payload) {
 	var _v0 = A2($elm$core$String$split, ',', payload);
 	_v0$2:
 	while (true) {
@@ -9233,7 +9344,7 @@ var $author$project$Backend$Reports$Decoder$decodeNutritionEncounterData = A2(
 							$elm$core$Maybe$map,
 							function (startDate) {
 								return $elm$json$Json$Decode$succeed(
-									{hasEdema: false, muacCm: $elm$core$Maybe$Nothing, nutritionData: $elm$core$Maybe$Nothing, startDate: startDate});
+									{fbfAmount: $elm$core$Maybe$Nothing, hasEdema: false, muacCm: $elm$core$Maybe$Nothing, nutritionData: $elm$core$Maybe$Nothing, startDate: startDate});
 							},
 							$elm$core$Result$toMaybe(
 								$justinmimbs$date$Date$fromIsoString(first))));
@@ -9248,12 +9359,27 @@ var $author$project$Backend$Reports$Decoder$decodeNutritionEncounterData = A2(
 							A2(
 								$elm$core$Maybe$map,
 								function (startDate) {
-									var _v2 = $author$project$Backend$Reports$Decoder$parseNutritionEncounterPayload(second);
-									var nutritionData = _v2.a;
-									var muacCm = _v2.b;
-									var hasEdema = _v2.c;
+									var _v2 = function () {
+										var _v3 = A2($elm$core$String$split, '|', second);
+										if ((_v3.b && _v3.b.b) && (!_v3.b.b.b)) {
+											var anth = _v3.a;
+											var _v4 = _v3.b;
+											var fbf = _v4.a;
+											return _Utils_Tuple2(
+												anth,
+												$elm$core$String$toFloat(fbf));
+										} else {
+											return _Utils_Tuple2(second, $elm$core$Maybe$Nothing);
+										}
+									}();
+									var anthropometryPart = _v2.a;
+									var fbfAmount = _v2.b;
+									var _v5 = $author$project$Backend$Reports$Decoder$parseAnthropometryPayload(anthropometryPart);
+									var nutritionData = _v5.a;
+									var muacCm = _v5.b;
+									var hasEdema = _v5.c;
 									return $elm$json$Json$Decode$succeed(
-										{hasEdema: hasEdema, muacCm: muacCm, nutritionData: nutritionData, startDate: startDate});
+										{fbfAmount: fbfAmount, hasEdema: hasEdema, muacCm: muacCm, nutritionData: nutritionData, startDate: startDate});
 								},
 								$elm$core$Result$toMaybe(
 									$justinmimbs$date$Date$fromIsoString(first))));
@@ -9840,58 +9966,57 @@ var $NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt = F4(
 var $author$project$Backend$Reports$Decoder$decodePatientData = A4(
 	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 	_List_fromArray(
-		['group_nutrition', 'achi']),
+		['group_nutrition_mother', 'fbf']),
 	$elm$json$Json$Decode$nullable(
-		$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData)),
+		$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeMotherFbfEncounterData)),
 	$elm$core$Maybe$Nothing,
 	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 		_List_fromArray(
-			['group_nutrition', 'chw']),
+			['group_nutrition', 'achi']),
 		$elm$json$Json$Decode$nullable(
 			$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData)),
 		$elm$core$Maybe$Nothing,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 			_List_fromArray(
-				['group_nutrition', 'sorwathe']),
+				['group_nutrition', 'chw']),
 			$elm$json$Json$Decode$nullable(
 				$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData)),
 			$elm$core$Maybe$Nothing,
 			A4(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 				_List_fromArray(
-					['group_nutrition', 'fbf']),
+					['group_nutrition', 'sorwathe']),
 				$elm$json$Json$Decode$nullable(
 					$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData)),
 				$elm$core$Maybe$Nothing,
 				A4(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 					_List_fromArray(
-						['group_nutrition', 'pmtct']),
+						['group_nutrition', 'fbf']),
 					$elm$json$Json$Decode$nullable(
 						$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData)),
 					$elm$core$Maybe$Nothing,
 					A4(
 						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 						_List_fromArray(
-							['individual', 'nutrition']),
+							['group_nutrition', 'pmtct']),
 						$elm$json$Json$Decode$nullable(
-							$elm$json$Json$Decode$list(
-								$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData))),
+							$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData)),
 						$elm$core$Maybe$Nothing,
 						A4(
 							$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 							_List_fromArray(
-								['individual', 'tuberculosis']),
+								['individual', 'nutrition']),
 							$elm$json$Json$Decode$nullable(
 								$elm$json$Json$Decode$list(
-									$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
+									$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeNutritionEncounterData))),
 							$elm$core$Maybe$Nothing,
 							A4(
 								$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 								_List_fromArray(
-									['individual', 'hiv']),
+									['individual', 'tuberculosis']),
 								$elm$json$Json$Decode$nullable(
 									$elm$json$Json$Decode$list(
 										$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
@@ -9899,7 +10024,7 @@ var $author$project$Backend$Reports$Decoder$decodePatientData = A4(
 								A4(
 									$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 									_List_fromArray(
-										['individual', 'ncd']),
+										['individual', 'hiv']),
 									$elm$json$Json$Decode$nullable(
 										$elm$json$Json$Decode$list(
 											$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
@@ -9907,7 +10032,7 @@ var $author$project$Backend$Reports$Decoder$decodePatientData = A4(
 									A4(
 										$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 										_List_fromArray(
-											['individual', 'child-scoreboard']),
+											['individual', 'ncd']),
 										$elm$json$Json$Decode$nullable(
 											$elm$json$Json$Decode$list(
 												$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
@@ -9915,31 +10040,31 @@ var $author$project$Backend$Reports$Decoder$decodePatientData = A4(
 										A4(
 											$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 											_List_fromArray(
-												['individual', 'well-child']),
+												['individual', 'child-scoreboard']),
 											$elm$json$Json$Decode$nullable(
 												$elm$json$Json$Decode$list(
-													$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeWellChildEncounterData))),
+													$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
 											$elm$core$Maybe$Nothing,
 											A4(
 												$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 												_List_fromArray(
-													['individual', 'home-visit']),
+													['individual', 'well-child']),
 												$elm$json$Json$Decode$nullable(
 													$elm$json$Json$Decode$list(
-														$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
+														$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeWellChildEncounterData))),
 												$elm$core$Maybe$Nothing,
 												A4(
 													$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 													_List_fromArray(
-														['individual', 'family-nutrition-muac']),
+														['individual', 'home-visit']),
 													$elm$json$Json$Decode$nullable(
 														$elm$json$Json$Decode$list(
-															$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeFamilyNutritionEncounterData))),
+															$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD))),
 													$elm$core$Maybe$Nothing,
 													A4(
 														$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 														_List_fromArray(
-															['individual', 'family-nutrition']),
+															['individual', 'family-nutrition-muac']),
 														$elm$json$Json$Decode$nullable(
 															$elm$json$Json$Decode$list(
 																$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeFamilyNutritionEncounterData))),
@@ -9947,35 +10072,43 @@ var $author$project$Backend$Reports$Decoder$decodePatientData = A4(
 														A4(
 															$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 															_List_fromArray(
-																['individual', 'antenatal']),
+																['individual', 'family-nutrition']),
 															$elm$json$Json$Decode$nullable(
-																$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodePrenatalParticipantData)),
+																$elm$json$Json$Decode$list(
+																	$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeFamilyNutritionMotherEncounterData))),
 															$elm$core$Maybe$Nothing,
 															A4(
 																$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 																_List_fromArray(
-																	['individual', 'acute-illness']),
+																	['individual', 'antenatal']),
 																$elm$json$Json$Decode$nullable(
-																	$elm$json$Json$Decode$list(
-																		$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeAcuteIllnessEncounterData))),
+																	$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodePrenatalParticipantData)),
 																$elm$core$Maybe$Nothing,
-																A3(
-																	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-																	'gender',
-																	A2($author$project$Backend$Decoder$decodeWithFallback, $author$project$Backend$Reports$Model$Female, $author$project$Backend$Reports$Decoder$decodeGender),
+																A4(
+																	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
+																	_List_fromArray(
+																		['individual', 'acute-illness']),
+																	$elm$json$Json$Decode$nullable(
+																		$elm$json$Json$Decode$list(
+																			$elm$json$Json$Decode$list($author$project$Backend$Reports$Decoder$decodeAcuteIllnessEncounterData))),
+																	$elm$core$Maybe$Nothing,
 																	A3(
 																		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-																		'birth_date',
-																		$author$project$Gizra$NominalDate$decodeYYYYMMDD,
+																		'gender',
+																		A2($author$project$Backend$Decoder$decodeWithFallback, $author$project$Backend$Reports$Model$Female, $author$project$Backend$Reports$Decoder$decodeGender),
 																		A3(
 																			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-																			'created',
+																			'birth_date',
 																			$author$project$Gizra$NominalDate$decodeYYYYMMDD,
 																			A3(
 																				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-																				'id',
-																				$author$project$Gizra$Json$decodeInt,
-																				$elm$json$Json$Decode$succeed($author$project$Backend$Reports$Model$PatientData)))))))))))))))))))));
+																				'created',
+																				$author$project$Gizra$NominalDate$decodeYYYYMMDD,
+																				A3(
+																					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
+																					'id',
+																					$author$project$Gizra$Json$decodeInt,
+																					$elm$json$Json$Decode$succeed($author$project$Backend$Reports$Model$PatientData))))))))))))))))))))));
 var $author$project$Backend$Reports$Model$EntityCell = {$: 'EntityCell'};
 var $author$project$Backend$Reports$Model$EntitySector = {$: 'EntitySector'};
 var $author$project$Backend$Reports$Model$EntityVillage = {$: 'EntityVillage'};

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -11884,7 +11884,7 @@ var $author$project$Translate$translationSet = function (transId) {
 			case 'FbfDistributionUnitKg':
 				return {english: 'kg', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'FbfDistributionUnitPackage':
-				return {english: 'package', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+				return {english: 'pkg', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Feeding':
 				return {english: 'Feeding', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Female':

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -17560,8 +17560,22 @@ var $author$project$Translate$NutritionTotal = {$: 'NutritionTotal'};
 var $author$project$Translate$PMTCT = {$: 'PMTCT'};
 var $author$project$Translate$Sorwathe = {$: 'Sorwathe'};
 var $author$project$Translate$Unique = {$: 'Unique'};
-var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData = F2(
-	function (language, records) {
+var $pzp1997$assoc_list$AssocList$member = F2(
+	function (targetKey, dict) {
+		var _v0 = A2($pzp1997$assoc_list$AssocList$get, targetKey, dict);
+		if (_v0.$ === 'Just') {
+			return true;
+		} else {
+			return false;
+		}
+	});
+var $Gizra$elm_all_set$EverySet$member = F2(
+	function (k, _v0) {
+		var d = _v0.a;
+		return A2($pzp1997$assoc_list$AssocList$member, k, d);
+	});
+var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData = F3(
+	function (language, features, records) {
 		var wellChildEncountersData = A2(
 			$elm$core$List$filterMap,
 			A2(
@@ -17703,7 +17717,8 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 						]),
 					shiftLeft);
 			});
-		var familyNutritionEncountersData = A2(
+		var familyNutritionEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureFamilyNutrition, features);
+		var familyNutritionEncountersData = familyNutritionEnabled ? A2(
 			$elm$core$List$filterMap,
 			A2(
 				$elm$core$Basics$composeR,
@@ -17711,7 +17726,7 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 					return $.familyNutritionData;
 				},
 				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
+			records) : _List_Nil;
 		var countUnique = A2(
 			$elm$core$Basics$composeR,
 			$elm$core$List$filter(
@@ -17815,29 +17830,33 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 				_List_fromArray(
 					[$author$project$Translate$EncounterType, $author$project$Translate$All, $author$project$Translate$Unique])),
 			heading: A2($author$project$Translate$translate, language, $author$project$Translate$Encounters) + ':',
-			rows: _List_fromArray(
-				[
-					A4(generateRow, $author$project$Translate$ANCTotal, prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal, prenatalDataNurseEncountersUnique + prenatalDataChwEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$HealthCenter, prenatalDataNurseEncountersTotal, prenatalDataNurseEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$CHW, prenatalDataChwEncountersTotal, prenatalDataChwEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$AcuteIllnessTotal, acuteIllnessDataNurseEncountersTotal + acuteIllnessDataChwEncountersTotal, acuteIllnessDataNurseEncountersUnique + acuteIllnessDataChwEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$HealthCenter, acuteIllnessDataNurseEncountersTotal, acuteIllnessDataNurseEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$CHW, acuteIllnessDataChwEncountersTotal, acuteIllnessDataChwEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$StandardPediatricVisit, wellChildDataEncountersTotal, wellChildDataEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$HomeVisit, homeVisitDataEncountersTotal, homeVisitDataEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$ChildScorecard, childScorecardDataEncountersTotal, childScorecardDataEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$NCD, ncdDataEncountersTotal, ncdDataEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$HIV, hivDataEncountersTotal, hivDataEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$Tuberculosis, tuberculosisDataEncountersTotal, tuberculosisDataEncountersUnique, false),
-					A4(generateRow, $author$project$Translate$NutritionTotal, overallNutritionTotal, overallNutritionUnique, false),
-					A4(generateRow, $author$project$Translate$PMTCT, nutritionGroupPmtctEncountersTotal, nutritionGroupPmtctEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$FBF, nutritionGroupFbfEncountersTotal, nutritionGroupFbfEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$Sorwathe, nutritionGroupSorwatheEncountersTotal, nutritionGroupSorwatheEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$CBNP, nutritionGroupChwEncountersTotal, nutritionGroupChwEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$ACHI, nutritionGroupAchiEncountersTotal, nutritionGroupAchiEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$Individual, nutritionIndividualEncountersTotal, nutritionIndividualEncountersUnique, true),
-					A4(generateRow, $author$project$Translate$FamilyNutrition, familyNutritionEncountersTotal, familyNutritionEncountersUnique, false)
-				]),
+			rows: _Utils_ap(
+				_List_fromArray(
+					[
+						A4(generateRow, $author$project$Translate$ANCTotal, prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal, prenatalDataNurseEncountersUnique + prenatalDataChwEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$HealthCenter, prenatalDataNurseEncountersTotal, prenatalDataNurseEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$CHW, prenatalDataChwEncountersTotal, prenatalDataChwEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$AcuteIllnessTotal, acuteIllnessDataNurseEncountersTotal + acuteIllnessDataChwEncountersTotal, acuteIllnessDataNurseEncountersUnique + acuteIllnessDataChwEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$HealthCenter, acuteIllnessDataNurseEncountersTotal, acuteIllnessDataNurseEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$CHW, acuteIllnessDataChwEncountersTotal, acuteIllnessDataChwEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$StandardPediatricVisit, wellChildDataEncountersTotal, wellChildDataEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$HomeVisit, homeVisitDataEncountersTotal, homeVisitDataEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$ChildScorecard, childScorecardDataEncountersTotal, childScorecardDataEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$NCD, ncdDataEncountersTotal, ncdDataEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$HIV, hivDataEncountersTotal, hivDataEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$Tuberculosis, tuberculosisDataEncountersTotal, tuberculosisDataEncountersUnique, false),
+						A4(generateRow, $author$project$Translate$NutritionTotal, overallNutritionTotal, overallNutritionUnique, false),
+						A4(generateRow, $author$project$Translate$PMTCT, nutritionGroupPmtctEncountersTotal, nutritionGroupPmtctEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$FBF, nutritionGroupFbfEncountersTotal, nutritionGroupFbfEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$Sorwathe, nutritionGroupSorwatheEncountersTotal, nutritionGroupSorwatheEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$CBNP, nutritionGroupChwEncountersTotal, nutritionGroupChwEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$ACHI, nutritionGroupAchiEncountersTotal, nutritionGroupAchiEncountersUnique, true),
+						A4(generateRow, $author$project$Translate$Individual, nutritionIndividualEncountersTotal, nutritionIndividualEncountersUnique, true)
+					]),
+				familyNutritionEnabled ? _List_fromArray(
+					[
+						A4(generateRow, $author$project$Translate$FamilyNutrition, familyNutritionEncountersTotal, familyNutritionEncountersUnique, false)
+					]) : _List_Nil),
 			totals: {
 				label: A2($author$project$Translate$translate, language, $author$project$Translate$Total),
 				total: $elm$core$String$fromInt(overallTotal),
@@ -18193,8 +18212,8 @@ var $author$project$Pages$Reports$View$viewDemographicsReportPatients = function
 				])),
 		A2($elm$core$List$map, viewTable, data.tables));
 };
-var $author$project$Pages$Reports$View$viewDemographicsReport = F5(
-	function (language, startDate, limitDate, scopeLabel, records) {
+var $author$project$Pages$Reports$View$viewDemographicsReport = F6(
+	function (language, features, startDate, limitDate, scopeLabel, records) {
 		var demographicsReportPatientsData = A3(
 			$author$project$Pages$Reports$View$generateDemographicsReportPatientsData,
 			language,
@@ -18207,7 +18226,7 @@ var $author$project$Pages$Reports$View$viewDemographicsReport = F5(
 						$elm$core$Basics$LT);
 				},
 				records));
-		var demographicsReportEncountersData = A2($author$project$Pages$Reports$View$generateDemographicsReportEncountersData, language, records);
+		var demographicsReportEncountersData = A3($author$project$Pages$Reports$View$generateDemographicsReportEncountersData, language, features, records);
 		var csvFileName = 'demographics-report-' + ($elm$core$String$toLower(
 			A3($elm$core$String$replace, ' ', '-', scopeLabel)) + ('-' + (A2($author$project$Gizra$NominalDate$customFormatDDMMYYYY, '-', limitDate) + '.csv')));
 		var csvContent = $author$project$Pages$Reports$View$demographicsReportPatientsDataToCSV(demographicsReportPatientsData) + ('\n\n\n' + $author$project$Pages$Reports$View$demographicsReportEncountersDataToCSV(demographicsReportEncountersData));
@@ -18347,20 +18366,6 @@ var $author$project$Pages$Reports$Model$FbfDistributionFbfChild = {$: 'FbfDistri
 var $author$project$Pages$Reports$Model$FbfDistributionFbfMother = {$: 'FbfDistributionFbfMother'};
 var $author$project$Pages$Reports$Model$allFbfDistributionCategories = _List_fromArray(
 	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
-var $pzp1997$assoc_list$AssocList$member = F2(
-	function (targetKey, dict) {
-		var _v0 = A2($pzp1997$assoc_list$AssocList$get, targetKey, dict);
-		if (_v0.$ === 'Just') {
-			return true;
-		} else {
-			return false;
-		}
-	});
-var $Gizra$elm_all_set$EverySet$member = F2(
-	function (k, _v0) {
-		var d = _v0.a;
-		return A2($pzp1997$assoc_list$AssocList$member, k, d);
-	});
 var $author$project$Pages$Reports$View$visibleFbfDistributionCategories = function (features) {
 	var familyNutritionEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureFamilyNutrition, features);
 	return A2(
@@ -21959,7 +21964,7 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 									case 'ReportAcuteIllness':
 										return A5($author$project$Pages$Reports$View$viewAcuteIllnessReport, language, limitDate, startDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportDemographics':
-										return A5($author$project$Pages$Reports$View$viewDemographicsReport, language, startDate, limitDate, scopeLabel, recordsTillLimitDate);
+										return A6($author$project$Pages$Reports$View$viewDemographicsReport, language, data.features, startDate, limitDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportFBFDistribution':
 										return A5($author$project$Pages$Reports$View$viewFBFDistributionReport, language, data.features, limitDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportNutrition':

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -8833,9 +8833,9 @@ var $author$project$Backend$CompletionMenu$Update$update = F2(
 			});
 		return A4($author$project$Backend$Types$BackendReturn, modelUpdated, $elm$core$Platform$Cmd$none, $author$project$Error$Utils$noError, _List_Nil);
 	});
-var $author$project$Backend$Reports$Model$ReportsData = F5(
-	function (site, entityName, entityType, records, nutritionReportData) {
-		return {entityName: entityName, entityType: entityType, nutritionReportData: nutritionReportData, records: records, site: site};
+var $author$project$Backend$Reports$Model$ReportsData = F6(
+	function (site, features, entityName, entityType, records, nutritionReportData) {
+		return {entityName: entityName, entityType: entityType, features: features, nutritionReportData: nutritionReportData, records: records, site: site};
 	});
 var $author$project$Backend$Reports$Model$BackendGeneratedNutritionReportTableDate = function (tableType) {
 	return function (captions) {
@@ -10138,6 +10138,53 @@ var $author$project$Backend$Reports$Decoder$decodeSelectedEntity = A2(
 		}
 	},
 	$elm$json$Json$Decode$string);
+var $author$project$App$Types$FeatureFamilyNutrition = {$: 'FeatureFamilyNutrition'};
+var $author$project$App$Types$FeatureGPSCoordinates = {$: 'FeatureGPSCoordinates'};
+var $author$project$App$Types$FeatureGroupEducation = {$: 'FeatureGroupEducation'};
+var $author$project$App$Types$FeatureHIVManagement = {$: 'FeatureHIVManagement'};
+var $author$project$App$Types$FeatureHealthyStart = {$: 'FeatureHealthyStart'};
+var $author$project$App$Types$FeatureNCDA = {$: 'FeatureNCDA'};
+var $author$project$App$Types$FeatureReportToWhatsApp = {$: 'FeatureReportToWhatsApp'};
+var $author$project$App$Types$FeatureStockManagementHC = {$: 'FeatureStockManagementHC'};
+var $author$project$App$Types$FeatureStockManagementVillage = {$: 'FeatureStockManagementVillage'};
+var $author$project$App$Types$FeatureTuberculosisManagement = {$: 'FeatureTuberculosisManagement'};
+var $author$project$Backend$Decoder$siteFeatureFromString = function (str) {
+	var _v0 = $elm$core$String$toLower(str);
+	switch (_v0) {
+		case 'family_nutrition':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureFamilyNutrition);
+		case 'gps_coordinates':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureGPSCoordinates);
+		case 'group_education':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureGroupEducation);
+		case 'healthy_start':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureHealthyStart);
+		case 'hiv_management':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureHIVManagement);
+		case 'ncda':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureNCDA);
+		case 'report_to_whatsapp':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureReportToWhatsApp);
+		case 'stock_management_hc':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureStockManagementHC);
+		case 'stock_management_village':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureStockManagementVillage);
+		case 'tuberculosis_management':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureTuberculosisManagement);
+		default:
+			return $elm$core$Maybe$Nothing;
+	}
+};
+var $elm$core$String$words = _String_words;
+var $author$project$Backend$Decoder$siteFeaturesFromString = function (str) {
+	return $Gizra$elm_all_set$EverySet$fromList(
+		$elm_community$maybe_extra$Maybe$Extra$values(
+			A2(
+				$elm$core$List$map,
+				$author$project$Backend$Decoder$siteFeatureFromString,
+				$elm$core$String$words(str))));
+};
+var $author$project$Backend$Decoder$decodeSiteFeatures = A2($elm$json$Json$Decode$map, $author$project$Backend$Decoder$siteFeaturesFromString, $elm$json$Json$Decode$string);
 var $author$project$Backend$Reports$Decoder$decodeReportsData = A4(
 	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt,
 	_List_fromArray(
@@ -10159,9 +10206,13 @@ var $author$project$Backend$Reports$Decoder$decodeReportsData = A4(
 				$elm$json$Json$Decode$string,
 				A3(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-					'site',
-					$author$project$Backend$Decoder$decodeSite,
-					$elm$json$Json$Decode$succeed($author$project$Backend$Reports$Model$ReportsData))))));
+					'features',
+					$author$project$Backend$Decoder$decodeSiteFeatures,
+					A3(
+						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
+						'site',
+						$author$project$Backend$Decoder$decodeSite,
+						$elm$json$Json$Decode$succeed($author$project$Backend$Reports$Model$ReportsData)))))));
 var $author$project$Backend$Reports$Update$update = F2(
 	function (msg, model) {
 		var value = msg.a;
@@ -11812,13 +11863,13 @@ var $author$project$Translate$translationSet = function (transId) {
 				var category = transId.a;
 				switch (category.$) {
 					case 'FbfDistributionFbfChild':
-						return {english: 'FBF Child', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'FBF Child (packages)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'FbfDistributionFbfMother':
-						return {english: 'FBF Mother', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'FBF Mother (packages)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'FbfDistributionAhezaChild':
-						return {english: 'Aheza Child', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'Aheza Child (kg)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					default:
-						return {english: 'Aheza Mother', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'Aheza Mother (kg)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 				}
 			case 'FbfDistributionType':
 				return {english: 'Type', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
@@ -18175,12 +18226,6 @@ var $author$project$Pages$Reports$View$viewDemographicsReport = F5(
 							A3($author$project$Pages$Reports$View$viewDownloadCSVButton, language, csvFileName, csvContent)
 						]))));
 	});
-var $author$project$Pages$Reports$Model$FbfDistributionAhezaChild = {$: 'FbfDistributionAhezaChild'};
-var $author$project$Pages$Reports$Model$FbfDistributionAhezaMother = {$: 'FbfDistributionAhezaMother'};
-var $author$project$Pages$Reports$Model$FbfDistributionFbfChild = {$: 'FbfDistributionFbfChild'};
-var $author$project$Pages$Reports$Model$FbfDistributionFbfMother = {$: 'FbfDistributionFbfMother'};
-var $author$project$Pages$Reports$Model$allFbfDistributionCategories = _List_fromArray(
-	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
 var $author$project$Pages$Reports$View$fbfDistributionCategoryCssClass = function (category) {
 	switch (category.$) {
 		case 'FbfDistributionAhezaChild':
@@ -18204,8 +18249,8 @@ var $author$project$Pages$Reports$View$formatDistributionTotal = function (value
 		$elm$core$Basics$round(value)) ? $elm$core$String$fromInt(
 		$elm$core$Basics$round(value)) : A2($myrho$elm_round$Round$round, 2, value);
 };
-var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F2(
-	function (language, records) {
+var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
+	function (language, categories, records) {
 		var fbfMotherTotal = $elm$core$List$sum(
 			A2(
 				$elm$core$List$map,
@@ -18285,7 +18330,7 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F2(
 						totalFor(category))
 					]);
 			},
-			$author$project$Pages$Reports$Model$allFbfDistributionCategories);
+			categories);
 		return {
 			captions: _List_fromArray(
 				[
@@ -18296,9 +18341,51 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F2(
 			rows: rows
 		};
 	});
-var $author$project$Pages$Reports$View$viewFBFDistributionReport = F4(
-	function (language, limitDate, scopeLabel, records) {
-		var data = A2($author$project$Pages$Reports$View$generateFBFDistributionReportData, language, records);
+var $author$project$Pages$Reports$Model$FbfDistributionAhezaChild = {$: 'FbfDistributionAhezaChild'};
+var $author$project$Pages$Reports$Model$FbfDistributionAhezaMother = {$: 'FbfDistributionAhezaMother'};
+var $author$project$Pages$Reports$Model$FbfDistributionFbfChild = {$: 'FbfDistributionFbfChild'};
+var $author$project$Pages$Reports$Model$FbfDistributionFbfMother = {$: 'FbfDistributionFbfMother'};
+var $author$project$Pages$Reports$Model$allFbfDistributionCategories = _List_fromArray(
+	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
+var $pzp1997$assoc_list$AssocList$member = F2(
+	function (targetKey, dict) {
+		var _v0 = A2($pzp1997$assoc_list$AssocList$get, targetKey, dict);
+		if (_v0.$ === 'Just') {
+			return true;
+		} else {
+			return false;
+		}
+	});
+var $Gizra$elm_all_set$EverySet$member = F2(
+	function (k, _v0) {
+		var d = _v0.a;
+		return A2($pzp1997$assoc_list$AssocList$member, k, d);
+	});
+var $author$project$Pages$Reports$View$visibleFbfDistributionCategories = function (features) {
+	var familyNutritionEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureFamilyNutrition, features);
+	return A2(
+		$elm$core$List$filter,
+		function (category) {
+			switch (category.$) {
+				case 'FbfDistributionAhezaChild':
+					return familyNutritionEnabled;
+				case 'FbfDistributionAhezaMother':
+					return familyNutritionEnabled;
+				case 'FbfDistributionFbfChild':
+					return true;
+				default:
+					return true;
+			}
+		},
+		$author$project$Pages$Reports$Model$allFbfDistributionCategories);
+};
+var $author$project$Pages$Reports$View$viewFBFDistributionReport = F5(
+	function (language, features, limitDate, scopeLabel, records) {
+		var csvFileName = 'fbf-distribution-report-' + ($elm$core$String$toLower(
+			A3($elm$core$String$replace, ' ', '-', scopeLabel)) + ('-' + (A2($author$project$Gizra$NominalDate$customFormatDDMMYYYY, '-', limitDate) + '.csv')));
+		var categories = $author$project$Pages$Reports$View$visibleFbfDistributionCategories(features);
+		var data = A3($author$project$Pages$Reports$View$generateFBFDistributionReportData, language, categories, records);
+		var csvContent = $author$project$Pages$Reports$View$reportTableDataToCSV(data);
 		var dataRows = A3(
 			$elm$core$List$map2,
 			F2(
@@ -18312,11 +18399,8 @@ var $author$project$Pages$Reports$View$viewFBFDistributionReport = F4(
 							]),
 						$author$project$Pages$Components$View$viewStandardCells(row));
 				}),
-			$author$project$Pages$Reports$Model$allFbfDistributionCategories,
+			categories,
 			data.rows);
-		var csvFileName = 'fbf-distribution-report-' + ($elm$core$String$toLower(
-			A3($elm$core$String$replace, ' ', '-', scopeLabel)) + ('-' + (A2($author$project$Gizra$NominalDate$customFormatDDMMYYYY, '-', limitDate) + '.csv')));
-		var csvContent = $author$project$Pages$Reports$View$reportTableDataToCSV(data);
 		var captionsRow = A2(
 			$elm$html$Html$div,
 			_List_fromArray(
@@ -20173,15 +20257,6 @@ var $author$project$Pages$Scoreboard$Utils$generateFutureVaccinationsData = F3(
 				return _Utils_Tuple2(vaccineType, nextVaccinationData);
 			});
 	});
-var $pzp1997$assoc_list$AssocList$member = F2(
-	function (targetKey, dict) {
-		var _v0 = A2($pzp1997$assoc_list$AssocList$get, targetKey, dict);
-		if (_v0.$ === 'Just') {
-			return true;
-		} else {
-			return false;
-		}
-	});
 var $pzp1997$assoc_list$AssocList$merge = F6(
 	function (leftStep, bothStep, rightStep, leftDict, _v0, initialResult) {
 		var leftAlist = leftDict.a;
@@ -21886,7 +21961,7 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 									case 'ReportDemographics':
 										return A5($author$project$Pages$Reports$View$viewDemographicsReport, language, startDate, limitDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportFBFDistribution':
-										return A4($author$project$Pages$Reports$View$viewFBFDistributionReport, language, limitDate, scopeLabel, recordsTillLimitDate);
+										return A5($author$project$Pages$Reports$View$viewFBFDistributionReport, language, data.features, limitDate, scopeLabel, recordsTillLimitDate);
 									case 'ReportNutrition':
 										return A5($author$project$Pages$Reports$View$viewNutritionReport, language, limitDate, scopeLabel, data.nutritionReportData, model.nutritionReportData);
 									case 'ReportPeripartum':
@@ -21934,7 +22009,7 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 								language,
 								model.reportType,
 								_List_fromArray(
-									[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportFBFDistribution]),
+									[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportFBFDistribution, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses]),
 								$author$project$Pages$Reports$Utils$reportTypeToString,
 								$author$project$Pages$Reports$Model$SetReportType,
 								$author$project$Translate$ReportType,

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -11872,7 +11872,9 @@ var $author$project$Translate$translationSet = function (transId) {
 						return {english: 'Aheza Mother (kg)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 				}
 			case 'FbfDistributionOccurrences':
-				return {english: 'Occurrences', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+				return {english: '# of Encounters', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+			case 'FbfDistributionTotalAmount':
+				return {english: 'Total amount', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'FbfDistributionType':
 				return {english: 'Type', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Feeding':
@@ -13216,7 +13218,7 @@ var $author$project$Translate$translationSet = function (transId) {
 					case 'ReportDemographics':
 						return {english: 'Demographics', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'ReportFBFDistribution':
-						return {english: 'FBF Distribution', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'Stock Management', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'ReportNutrition':
 						var $temp$transId = $author$project$Translate$Nutrition;
 						transId = $temp$transId;
@@ -18263,6 +18265,7 @@ var $author$project$Translate$FbfDistributionCategory = function (a) {
 	return {$: 'FbfDistributionCategory', a: a};
 };
 var $author$project$Translate$FbfDistributionOccurrences = {$: 'FbfDistributionOccurrences'};
+var $author$project$Translate$FbfDistributionTotalAmount = {$: 'FbfDistributionTotalAmount'};
 var $author$project$Translate$FbfDistributionType = {$: 'FbfDistributionType'};
 var $elm$core$Basics$round = _Basics_round;
 var $author$project$Pages$Reports$View$formatDistributionTotal = function (value) {
@@ -18356,7 +18359,7 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 			captions: _List_fromArray(
 				[
 					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionType),
-					A2($author$project$Translate$translate, language, $author$project$Translate$Total),
+					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionTotalAmount),
 					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionOccurrences)
 				]),
 			heading: '',

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -11863,13 +11863,15 @@ var $author$project$Translate$translationSet = function (transId) {
 				var category = transId.a;
 				switch (category.$) {
 					case 'FbfDistributionFbfChild':
-						return {english: 'FBF Child (packages)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'FBF Child', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+					case 'FbfDistributionFbfChildAchi':
+						return {english: 'FBF Child (ACHI)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'FbfDistributionFbfMother':
-						return {english: 'FBF Mother (packages)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'FBF Mother', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					case 'FbfDistributionAhezaChild':
-						return {english: 'Aheza Child (kg)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'Aheza Child', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 					default:
-						return {english: 'Aheza Mother (kg)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+						return {english: 'Aheza Mother', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 				}
 			case 'FbfDistributionOccurrences':
 				return {english: '# of Encounters', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
@@ -11877,6 +11879,12 @@ var $author$project$Translate$translationSet = function (transId) {
 				return {english: 'Total amount', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'FbfDistributionType':
 				return {english: 'Type', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+			case 'FbfDistributionUnit':
+				return {english: 'Unit', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+			case 'FbfDistributionUnitKg':
+				return {english: 'kg', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+			case 'FbfDistributionUnitPackage':
+				return {english: 'package', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Feeding':
 				return {english: 'Feeding', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Female':
@@ -18257,6 +18265,8 @@ var $author$project$Pages$Reports$View$fbfDistributionCategoryCssClass = functio
 			return 'aheza-mother';
 		case 'FbfDistributionFbfChild':
 			return 'fbf-child';
+		case 'FbfDistributionFbfChildAchi':
+			return 'fbf-child-achi';
 		default:
 			return 'fbf-mother';
 	}
@@ -18267,6 +18277,23 @@ var $author$project$Translate$FbfDistributionCategory = function (a) {
 var $author$project$Translate$FbfDistributionOccurrences = {$: 'FbfDistributionOccurrences'};
 var $author$project$Translate$FbfDistributionTotalAmount = {$: 'FbfDistributionTotalAmount'};
 var $author$project$Translate$FbfDistributionType = {$: 'FbfDistributionType'};
+var $author$project$Translate$FbfDistributionUnit = {$: 'FbfDistributionUnit'};
+var $author$project$Translate$FbfDistributionUnitKg = {$: 'FbfDistributionUnitKg'};
+var $author$project$Translate$FbfDistributionUnitPackage = {$: 'FbfDistributionUnitPackage'};
+var $author$project$Pages$Reports$View$fbfDistributionCategoryUnit = function (category) {
+	switch (category.$) {
+		case 'FbfDistributionAhezaChild':
+			return $author$project$Translate$FbfDistributionUnitKg;
+		case 'FbfDistributionAhezaMother':
+			return $author$project$Translate$FbfDistributionUnitKg;
+		case 'FbfDistributionFbfChild':
+			return $author$project$Translate$FbfDistributionUnitPackage;
+		case 'FbfDistributionFbfChildAchi':
+			return $author$project$Translate$FbfDistributionUnitKg;
+		default:
+			return $author$project$Translate$FbfDistributionUnitPackage;
+	}
+};
 var $elm$core$Basics$round = _Basics_round;
 var $author$project$Pages$Reports$View$formatDistributionTotal = function (value) {
 	return _Utils_eq(
@@ -18298,6 +18325,18 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 					$elm$core$List$filterMap,
 					function ($) {
 						return $.groupNutritionFbfData;
+					},
+					records)));
+		var fbfChildAchiAmounts = A2(
+			$elm$core$List$filterMap,
+			function ($) {
+				return $.fbfAmount;
+			},
+			$elm$core$List$concat(
+				A2(
+					$elm$core$List$filterMap,
+					function ($) {
+						return $.groupNutritionAchiData;
 					},
 					records)));
 		var ahezaMotherAmounts = A2(
@@ -18334,6 +18373,8 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 					return ahezaMotherAmounts;
 				case 'FbfDistributionFbfChild':
 					return fbfChildAmounts;
+				case 'FbfDistributionFbfChildAchi':
+					return fbfChildAchiAmounts;
 				default:
 					return fbfMotherAmounts;
 			}
@@ -18350,6 +18391,10 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 						$author$project$Translate$FbfDistributionCategory(category)),
 						$author$project$Pages$Reports$View$formatDistributionTotal(
 						$elm$core$List$sum(amounts)),
+						A2(
+						$author$project$Translate$translate,
+						language,
+						$author$project$Pages$Reports$View$fbfDistributionCategoryUnit(category)),
 						$elm$core$String$fromInt(
 						$elm$core$List$length(amounts))
 					]);
@@ -18360,6 +18405,7 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 				[
 					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionType),
 					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionTotalAmount),
+					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionUnit),
 					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionOccurrences)
 				]),
 			heading: '',
@@ -18369,9 +18415,10 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 var $author$project$Pages$Reports$Model$FbfDistributionAhezaChild = {$: 'FbfDistributionAhezaChild'};
 var $author$project$Pages$Reports$Model$FbfDistributionAhezaMother = {$: 'FbfDistributionAhezaMother'};
 var $author$project$Pages$Reports$Model$FbfDistributionFbfChild = {$: 'FbfDistributionFbfChild'};
+var $author$project$Pages$Reports$Model$FbfDistributionFbfChildAchi = {$: 'FbfDistributionFbfChildAchi'};
 var $author$project$Pages$Reports$Model$FbfDistributionFbfMother = {$: 'FbfDistributionFbfMother'};
 var $author$project$Pages$Reports$Model$allFbfDistributionCategories = _List_fromArray(
-	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
+	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionFbfChildAchi, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
 var $author$project$Pages$Reports$View$visibleFbfDistributionCategories = function (features) {
 	var familyNutritionEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureFamilyNutrition, features);
 	return A2(
@@ -18383,6 +18430,8 @@ var $author$project$Pages$Reports$View$visibleFbfDistributionCategories = functi
 				case 'FbfDistributionAhezaMother':
 					return familyNutritionEnabled;
 				case 'FbfDistributionFbfChild':
+					return true;
+				case 'FbfDistributionFbfChildAchi':
 					return true;
 				default:
 					return true;

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -11871,6 +11871,8 @@ var $author$project$Translate$translationSet = function (transId) {
 					default:
 						return {english: 'Aheza Mother (kg)', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 				}
+			case 'FbfDistributionOccurrences':
+				return {english: 'Occurrences', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'FbfDistributionType':
 				return {english: 'Type', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
 			case 'Feeding':
@@ -18260,6 +18262,7 @@ var $author$project$Pages$Reports$View$fbfDistributionCategoryCssClass = functio
 var $author$project$Translate$FbfDistributionCategory = function (a) {
 	return {$: 'FbfDistributionCategory', a: a};
 };
+var $author$project$Translate$FbfDistributionOccurrences = {$: 'FbfDistributionOccurrences'};
 var $author$project$Translate$FbfDistributionType = {$: 'FbfDistributionType'};
 var $elm$core$Basics$round = _Basics_round;
 var $author$project$Pages$Reports$View$formatDistributionTotal = function (value) {
@@ -18270,75 +18273,72 @@ var $author$project$Pages$Reports$View$formatDistributionTotal = function (value
 };
 var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 	function (language, categories, records) {
-		var fbfMotherTotal = $elm$core$List$sum(
-			A2(
-				$elm$core$List$map,
-				function ($) {
-					return $.fbfAmount;
-				},
+		var fbfMotherAmounts = A2(
+			$elm$core$List$map,
+			function ($) {
+				return $.fbfAmount;
+			},
+			$elm$core$List$concat(
+				A2(
+					$elm$core$List$filterMap,
+					function ($) {
+						return $.groupNutritionFbfMotherData;
+					},
+					records)));
+		var fbfChildAmounts = A2(
+			$elm$core$List$filterMap,
+			function ($) {
+				return $.fbfAmount;
+			},
+			$elm$core$List$concat(
+				A2(
+					$elm$core$List$filterMap,
+					function ($) {
+						return $.groupNutritionFbfData;
+					},
+					records)));
+		var ahezaMotherAmounts = A2(
+			$elm$core$List$filterMap,
+			function ($) {
+				return $.ahezaAmount;
+			},
+			$elm$core$List$concat(
 				$elm$core$List$concat(
 					A2(
 						$elm$core$List$filterMap,
 						function ($) {
-							return $.groupNutritionFbfMotherData;
+							return $.familyNutritionData;
 						},
 						records))));
-		var fbfChildTotal = $elm$core$List$sum(
-			A2(
-				$elm$core$List$filterMap,
-				function ($) {
-					return $.fbfAmount;
-				},
+		var ahezaChildAmounts = A2(
+			$elm$core$List$filterMap,
+			function ($) {
+				return $.ahezaAmount;
+			},
+			$elm$core$List$concat(
 				$elm$core$List$concat(
 					A2(
 						$elm$core$List$filterMap,
 						function ($) {
-							return $.groupNutritionFbfData;
+							return $.familyNutritionMuacData;
 						},
 						records))));
-		var ahezaMotherTotal = $elm$core$List$sum(
-			A2(
-				$elm$core$List$filterMap,
-				function ($) {
-					return $.ahezaAmount;
-				},
-				$elm$core$List$concat(
-					$elm$core$List$concat(
-						A2(
-							$elm$core$List$filterMap,
-							function ($) {
-								return $.familyNutritionData;
-							},
-							records)))));
-		var ahezaChildTotal = $elm$core$List$sum(
-			A2(
-				$elm$core$List$filterMap,
-				function ($) {
-					return $.ahezaAmount;
-				},
-				$elm$core$List$concat(
-					$elm$core$List$concat(
-						A2(
-							$elm$core$List$filterMap,
-							function ($) {
-								return $.familyNutritionMuacData;
-							},
-							records)))));
-		var totalFor = function (category) {
+		var amountsFor = function (category) {
 			switch (category.$) {
 				case 'FbfDistributionAhezaChild':
-					return ahezaChildTotal;
+					return ahezaChildAmounts;
 				case 'FbfDistributionAhezaMother':
-					return ahezaMotherTotal;
+					return ahezaMotherAmounts;
 				case 'FbfDistributionFbfChild':
-					return fbfChildTotal;
+					return fbfChildAmounts;
 				default:
-					return fbfMotherTotal;
+					return fbfMotherAmounts;
 			}
 		};
 		var rows = A2(
 			$elm$core$List$map,
 			function (category) {
+				var amounts = amountsFor(category);
 				return _List_fromArray(
 					[
 						A2(
@@ -18346,7 +18346,9 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 						language,
 						$author$project$Translate$FbfDistributionCategory(category)),
 						$author$project$Pages$Reports$View$formatDistributionTotal(
-						totalFor(category))
+						$elm$core$List$sum(amounts)),
+						$elm$core$String$fromInt(
+						$elm$core$List$length(amounts))
 					]);
 			},
 			categories);
@@ -18354,7 +18356,8 @@ var $author$project$Pages$Reports$View$generateFBFDistributionReportData = F3(
 			captions: _List_fromArray(
 				[
 					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionType),
-					A2($author$project$Translate$translate, language, $author$project$Translate$Total)
+					A2($author$project$Translate$translate, language, $author$project$Translate$Total),
+					A2($author$project$Translate$translate, language, $author$project$Translate$FbfDistributionOccurrences)
 				]),
 			heading: '',
 			rows: rows

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1294,17 +1294,18 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
     }
 
     // Mother FBF: per (session, mother) wire "YYYY-MM-DD <amount>" emitted
-    // under group_nutrition_mother.<group>. In practice only Fbf clinics
-    // produce mother distributions, but we key by group_type defensively so
-    // any future clinic type carrying mother distributions surfaces under a
-    // matching key without code changes.
+    // under group_nutrition_mother.fbf. Only Fbf clinics produce mother
+    // distributions, so the group key is hardcoded to match the Elm
+    // decoder which reads exactly this path -- decodeReportsData in
+    // server/elm/src/Backend/Reports/Decoder.elm. If another clinic type
+    // ever needs to carry mother distributions, both sides must change.
     if (isset($mother_fbf_amount_by_session[$session->nid])) {
       $mother_session_data = "$encounter_date " . $mother_fbf_amount_by_session[$session->nid];
-      if (empty($mother_sessions_data[$group_type])) {
-        $mother_sessions_data[$group_type] = [$mother_session_data];
+      if (empty($mother_sessions_data['fbf'])) {
+        $mother_sessions_data['fbf'] = [$mother_session_data];
       }
       else {
-        $mother_sessions_data[$group_type][] = $mother_session_data;
+        $mother_sessions_data['fbf'][] = $mother_session_data;
       }
     }
   }
@@ -1493,7 +1494,8 @@ function hedley_reports_family_nutrition_metrics_to_string($values) {
  *   with no parent reference or no amount are skipped. If multiple records
  *   share the same parent for this person (not expected in practice), the
  *   last one read wins, matching the existing per-encounter "last write
- *   wins" pattern used elsewhere in this function (e.g. MUAC at line 658).
+ *   wins" pattern used by the per-encounter MUAC / Z-score aggregation in
+ *   hedley_reports_calculate_aggregated_data_for_person.
  */
 function hedley_reports_collect_distributed_amounts_by_parent($person_id, $bundle, $parent_field_name) {
   $query = hedley_general_create_entity_field_query_excluding_deleted();

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -986,9 +986,8 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
           // Resolving indicators.
           // 'GWG adequate' indicator is recorded on encounter itself.
           $indicators = [];
-          $prenatal_indicators = $encounter->field_prenatal_indicators[LANGUAGE_NONE];
-          if (!empty($prenatal_indicators)) {
-            foreach ($prenatal_indicators as $item) {
+          if (!empty($encounter->field_prenatal_indicators) && !empty($encounter->field_prenatal_indicators[LANGUAGE_NONE])) {
+            foreach ($encounter->field_prenatal_indicators[LANGUAGE_NONE] as $item) {
               if ($item['value'] == 'adequate-gwg') {
                 $indicators[] = $prenatal_indicator_mapping['gwg'];
                 break;

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1834,7 +1834,17 @@ function hedley_reports_load_results_data($report_variant, $scope, $province = N
   }
 
   $node = node_load($node_id);
-  $file = file_load($node->field_data_file[LANGUAGE_NONE][0]['fid']);
+  // The report_data node may exist as a placeholder with no file yet (e.g.
+  // when the recalculate-large-datasets.php script has not produced the
+  // data file for this scope). Guard the field access so a missing file
+  // doesn't spam notices via $node->field_data_file[LANGUAGE_NONE][0].
+  $file_id = isset($node->field_data_file[LANGUAGE_NONE][0]['fid'])
+    ? $node->field_data_file[LANGUAGE_NONE][0]['fid']
+    : 0;
+  if (empty($file_id)) {
+    return [[], NULL];
+  }
+  $file = file_load($file_id);
   if (!$file) {
     return [[], NULL];
   }
@@ -1911,7 +1921,12 @@ function hedley_reports_create_or_update_results_data_node(array $data, $report_
   else {
     // Update the Report Data node.
     $node = node_load($node_id);
-    $old_file = file_load($node->field_data_file[LANGUAGE_NONE][0]['fid']);
+    // Same guard as in hedley_reports_load_results_data: a stub
+    // report_data node may exist without an attached file.
+    $old_file_id = isset($node->field_data_file[LANGUAGE_NONE][0]['fid'])
+      ? $node->field_data_file[LANGUAGE_NONE][0]['fid']
+      : 0;
+    $old_file = !empty($old_file_id) ? file_load($old_file_id) : FALSE;
     if ($old_file) {
       // Delete the old file.
       file_delete($old_file, TRUE);

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -472,8 +472,10 @@ function hedley_reports_get_triggering_measurement_types() {
     HEDLEY_ACTIVITY_REPORTS_GROUP_MEASUREMENT_BUNDLES,
     HEDLEY_ACTIVITY_WELL_CHILD_IMMUNISATION_BUNDLES,
     [
+      HEDLEY_ACTIVITY_CHILD_FBF_CONTENT_TYPE,
       HEDLEY_ACTIVITY_DANGER_SIGNS_CONTENT_TYPE,
       HEDLEY_ACTIVITY_FAMILY_NUTRITION_MUAC_CHILD_CONTENT_TYPE,
+      HEDLEY_ACTIVITY_MOTHER_FBF_CONTENT_TYPE,
       HEDLEY_ACTIVITY_PRENATAL_ASPIRIN_CONTENT_TYPE,
       HEDLEY_ACTIVITY_PRENATAL_BREASTFEEDING_CONTENT_TYPE,
       HEDLEY_ACTIVITY_PRENATAL_CALCIUM_CONTENT_TYPE,
@@ -486,6 +488,8 @@ function hedley_reports_get_triggering_measurement_types() {
       // Completes the immunisations list (not included
       // at HEDLEY_ACTIVITY_WELL_CHILD_IMMUNISATION_BUNDLES).
       HEDLEY_ACTIVITY_WELL_CHILD_HPV_IMMUNISATION_CONTENT_TYPE,
+      HEDLEY_FAMILY_NUTRITION_AHEZA_CHILD_CONTENT_TYPE,
+      HEDLEY_FAMILY_NUTRITION_AHEZA_MOTHER_CONTENT_TYPE,
     ],
   ));
 }
@@ -533,13 +537,18 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
   ];
   $vaccine_type_mapping = hedley_reports_vaccine_type_mapping();
 
-  // Exclude family_nutrition_muac_child from the query: it is in the
-  // triggering list so that node saves enqueue an AQ recalc, but this
-  // loop has no use for those nodes -- the per-child MUAC data is
-  // collected via a dedicated query further down in this function.
+  // Bundles that participate in the AQ trigger list but have dedicated
+  // queries further down in this function; exclude them from the generic
+  // measurement loop so we don't load them twice.
   $measurements_bundles = array_diff(
     hedley_reports_get_triggering_measurement_types(),
-    [HEDLEY_ACTIVITY_FAMILY_NUTRITION_MUAC_CHILD_CONTENT_TYPE]
+    [
+      HEDLEY_ACTIVITY_CHILD_FBF_CONTENT_TYPE,
+      HEDLEY_ACTIVITY_FAMILY_NUTRITION_MUAC_CHILD_CONTENT_TYPE,
+      HEDLEY_ACTIVITY_MOTHER_FBF_CONTENT_TYPE,
+      HEDLEY_FAMILY_NUTRITION_AHEZA_CHILD_CONTENT_TYPE,
+      HEDLEY_FAMILY_NUTRITION_AHEZA_MOTHER_CONTENT_TYPE,
+    ]
   );
   $measurements_ids = hedley_general_get_person_measurements($person->nid, $measurements_bundles);
   $measurements = node_load_multiple($measurements_ids);
@@ -1062,17 +1071,38 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
     }
   }
 
+  // AHEZA distribution amounts (mother and child) live on family-nutrition
+  // encounter measurements. Collected here so both the mother-side
+  // 'family-nutrition' wire (below) and the child-side 'family-nutrition-muac'
+  // wire (further down) can embed the amount alongside the existing data
+  // they emit per encounter.
+  $aheza_mother_amount_by_encounter = hedley_reports_collect_distributed_amounts_by_parent(
+    $person->nid,
+    HEDLEY_FAMILY_NUTRITION_AHEZA_MOTHER_CONTENT_TYPE,
+    'field_family_nutrition_encounter'
+  );
+  $aheza_child_amount_by_encounter = hedley_reports_collect_distributed_amounts_by_parent(
+    $person->nid,
+    HEDLEY_FAMILY_NUTRITION_AHEZA_CHILD_CONTENT_TYPE,
+    'field_family_nutrition_encounter'
+  );
+
   // Family nutrition encounters: walk family_participant nodes whose
   // field_person points at $person. field_person on family_participant is
   // the mother (the registering adult), so this block only contributes data
-  // when $person is a mother. Each family encounter is recorded as a
-  // date-only wire entry under the 'family-nutrition' key. These entries
-  // drive the Demographics report's "Family Nutrition" encounter row, which
-  // counts mothers and their family encounters across all ages (no child
-  // age filter). Per-child MUAC measurements are emitted separately under
-  // 'family-nutrition-muac' on each child's reports data; that path is
-  // what feeds the MAM/SAM stats and lives where the nutrition stats
-  // pipelines (which filter to children under 6) can actually find it.
+  // when $person is a mother. Each family encounter is recorded under the
+  // 'family-nutrition' key, with the wire shape determined by whether an
+  // aheza_mother distribution exists for the encounter:
+  // - "YYYY-MM-DD" (no AHEZA -- legacy date-only entry).
+  // - "YYYY-MM-DD <amount>" (AHEZA mother distribution recorded).
+  // These entries drive the Demographics report's "Family Nutrition"
+  // encounter row, which counts mothers and their family encounters across
+  // all ages (no child age filter). Per-child MUAC measurements are emitted
+  // separately under 'family-nutrition-muac' on each child's reports data;
+  // that path is what feeds the MAM/SAM stats and lives where the nutrition
+  // stats pipelines (which filter to children under 6) can actually find it.
+  // Stays in sync with decodeFamilyNutritionMotherEncounterData in
+  // server/elm/src/Backend/Reports/Decoder.elm; update both together.
   $family_participants_query = hedley_general_create_entity_field_query_excluding_deleted();
   $family_participants_result = $family_participants_query
     ->entityCondition('entity_type', 'node')
@@ -1096,21 +1126,32 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
       foreach ($family_encounters as $family_encounter) {
         $participant_id = $family_encounter->field_family_participant[LANGUAGE_NONE][0]['target_id'];
         $encounter_date = date("Y-m-d", strtotime($family_encounter->field_scheduled_date[LANGUAGE_NONE][0]['value']));
-        $encounters_data['family-nutrition'][$participant_id][] = $encounter_date;
+        $wire = isset($aheza_mother_amount_by_encounter[$family_encounter->nid])
+          ? "$encounter_date " . $aheza_mother_amount_by_encounter[$family_encounter->nid]
+          : $encounter_date;
+        $encounters_data['family-nutrition'][$participant_id][] = $wire;
       }
     }
   }
 
-  // Per-child family-nutrition MUAC measurements. Walk child MUAC measurement
-  // nodes whose field_person is THIS person; these only match when $person
-  // is a child (the measurement records the child's arm circumference).
-  // Each measurement contributes one wire entry to the child's
-  // 'family-nutrition-muac' data, in the same "YYYY-MM-DD muac" format that
-  // hedley_reports_generate_nutrition_report_data parses for AM stats.
+  // Per-child family-nutrition data: child MUAC and child AHEZA distribution.
+  // Walk child MUAC measurement nodes whose field_person is THIS person, and
+  // pair them up with AHEZA child distribution amounts collected above.
+  // These only match when $person is a child (the measurements record the
+  // child's arm circumference / supplement received).
+  //
+  // Each (encounter, child) pairing contributes one wire entry to the
+  // child's 'family-nutrition-muac' data. Wire shapes:
+  // - "YYYY-MM-DD <muac>" (legacy MUAC-only entry).
+  // - "YYYY-MM-DD <muac>|<amount>" (MUAC and AHEZA recorded together).
+  // - "YYYY-MM-DD |<amount>" (AHEZA only -- empty MUAC chunk).
+  //
   // Storing per-child measurements on the child rather than the mother is
-  // what gives the AM stats correct per-child denominators -- the nutrition
-  // pipelines downstream filter records to children under 6 before the
-  // computation runs, so mother-side data would be invisible to them.
+  // what gives the MAM/SAM stats correct per-child denominators -- the
+  // nutrition pipelines downstream filter records to children under 6
+  // before computation, so mother-side data would be invisible to them.
+  // Stays in sync with decodeFamilyNutritionEncounterData in
+  // server/elm/src/Backend/Reports/Decoder.elm; update both together.
   $family_muac_query = hedley_general_create_entity_field_query_excluding_deleted();
   $family_muac_result = $family_muac_query
     ->entityCondition('entity_type', 'node')
@@ -1119,27 +1160,16 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
     ->propertyCondition('status', NODE_PUBLISHED)
     ->execute();
 
+  // Build a per-encounter map of {MUAC, AHEZA} for this child. Either or
+  // both may be present; encounters with neither yield no entry.
+  $child_data_by_encounter = [];
   if (!empty($family_muac_result['node'])) {
     $family_muac_measurements = node_load_multiple(array_keys($family_muac_result['node']));
-
-    // Batch-load parent encounters to read each measurement's scheduled
-    // date. We need the encounter's date, not the measurement's
-    // field_date_measured, for consistency with the way the rest of this
-    // function dates encounters.
-    $parent_encounter_ids = [];
     foreach ($family_muac_measurements as $family_muac) {
-      $parent_id = $family_muac->field_family_nutrition_encounter[LANGUAGE_NONE][0]['target_id'];
-      if (!empty($parent_id)) {
-        $parent_encounter_ids[] = $parent_id;
-      }
-    }
-    $parent_encounters = !empty($parent_encounter_ids)
-      ? node_load_multiple(array_unique($parent_encounter_ids))
-      : [];
-
-    foreach ($family_muac_measurements as $family_muac) {
-      $parent_id = $family_muac->field_family_nutrition_encounter[LANGUAGE_NONE][0]['target_id'];
-      if (empty($parent_encounters[$parent_id])) {
+      $parent_id = !empty($family_muac->field_family_nutrition_encounter[LANGUAGE_NONE][0]['target_id'])
+        ? $family_muac->field_family_nutrition_encounter[LANGUAGE_NONE][0]['target_id']
+        : NULL;
+      if (empty($parent_id)) {
         continue;
       }
       $muac_value = !empty($family_muac->field_muac[LANGUAGE_NONE][0]['value'])
@@ -1148,9 +1178,34 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
       if (is_null($muac_value) || $muac_value === '') {
         continue;
       }
-      $parent = $parent_encounters[$parent_id];
+      $child_data_by_encounter[$parent_id]['m'] = $muac_value;
+    }
+  }
+  foreach ($aheza_child_amount_by_encounter as $encounter_id => $amount) {
+    $child_data_by_encounter[$encounter_id]['a'] = $amount;
+  }
+
+  if (!empty($child_data_by_encounter)) {
+    // Batch-load parent encounters to read each entry's scheduled date.
+    // We need the encounter's date, not the measurement's
+    // field_date_measured, for consistency with the way the rest of this
+    // function dates encounters.
+    $parent_encounters = node_load_multiple(array_keys($child_data_by_encounter));
+    foreach ($child_data_by_encounter as $encounter_id => $values) {
+      if (empty($parent_encounters[$encounter_id])) {
+        continue;
+      }
+      $parent = $parent_encounters[$encounter_id];
       $encounter_date = date("Y-m-d", strtotime($parent->field_scheduled_date[LANGUAGE_NONE][0]['value']));
-      $encounters_data['family-nutrition-muac'][$person->nid][] = "$encounter_date $muac_value";
+      $muac_part = isset($values['m']) ? $values['m'] : '';
+      if (isset($values['a'])) {
+        $wire = "$encounter_date $muac_part|" . $values['a'];
+      }
+      else {
+        // MUAC only: preserve legacy "YYYY-MM-DD <muac>" wire format.
+        $wire = "$encounter_date $muac_part";
+      }
+      $encounters_data['family-nutrition-muac'][$person->nid][] = $wire;
     }
   }
 
@@ -1162,7 +1217,27 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
   }
 
   // Load group data.
-  $sessions_ids = array_unique($sessions_ids);
+  // FBF distribution amounts (child_fbf and mother_fbf) live on session-level
+  // measurements; collect them ahead of the group-nutrition emission so we
+  // can embed the child amount in the existing wire and emit the mother
+  // amount under its own key. Sessions referenced only by an FBF record (no
+  // anthropometry at all) still need to flow through the loop, so merge
+  // their ids into $sessions_ids before loading the session nodes.
+  $child_fbf_amount_by_session = hedley_reports_collect_distributed_amounts_by_parent(
+    $person->nid,
+    HEDLEY_ACTIVITY_CHILD_FBF_CONTENT_TYPE,
+    'field_session'
+  );
+  $mother_fbf_amount_by_session = hedley_reports_collect_distributed_amounts_by_parent(
+    $person->nid,
+    HEDLEY_ACTIVITY_MOTHER_FBF_CONTENT_TYPE,
+    'field_session'
+  );
+  $sessions_ids = array_unique(array_merge(
+    $sessions_ids,
+    array_keys($child_fbf_amount_by_session),
+    array_keys($mother_fbf_amount_by_session)
+  ));
   $sessions = node_load_multiple($sessions_ids);
   $clinics_ids = [];
   foreach ($sessions as $session) {
@@ -1178,6 +1253,7 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
   }
 
   $sessions_data = [];
+  $mother_sessions_data = [];
   foreach ($sessions as $session) {
     $clinic_id = $session->field_clinic[LANGUAGE_NONE][0]['target_id'];
     $group_type = $group_type_by_clinic[$clinic_id];
@@ -1187,15 +1263,58 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
     $nutrition = hedley_reports_nutrition_metrics_to_string($zscores + $muac_edema);
     $session_data = "$encounter_date $nutrition";
 
-    if (empty($sessions_data[$group_type])) {
-      $sessions_data[$group_type] = [$session_data];
+    // Skip sessions that only carry mother_fbf data: those don't represent a
+    // child encounter, so they must not flow into group_nutrition.<group> as
+    // a child entry. They're emitted separately below under
+    // group_nutrition_mother.<group>.
+    $has_child_data = isset($zscores_by_encounter[$session->nid])
+      || isset($muac_edema_by_encounter[$session->nid])
+      || isset($child_fbf_amount_by_session[$session->nid]);
+
+    if ($has_child_data) {
+      // Embed FBF distributed amount on the wire as a |<amount> tail chunk
+      // appended to the existing space-delimited second segment. The Elm
+      // decoder splits the second segment on '|' to separate anthropometry
+      // (",,,," up to "stunting,wasting,underweight,muac,edema") from the
+      // FBF amount. Wire shapes after this change:
+      // - "YYYY-MM-DD" (unchanged legacy date-only).
+      // - "YYYY-MM-DD <anth>" (unchanged anthropometry only).
+      // - "YYYY-MM-DD <anth>|<amount>" (anthropometry + FBF).
+      // - "YYYY-MM-DD ,,,,|<amount>" (FBF only -- empty anth chunk).
+      // Stays in sync with decodeNutritionEncounterData in
+      // server/elm/src/Backend/Reports/Decoder.elm; update both together.
+      if (isset($child_fbf_amount_by_session[$session->nid])) {
+        $session_data .= '|' . $child_fbf_amount_by_session[$session->nid];
+      }
+
+      if (empty($sessions_data[$group_type])) {
+        $sessions_data[$group_type] = [$session_data];
+      }
+      else {
+        $sessions_data[$group_type][] = $session_data;
+      }
     }
-    else {
-      $sessions_data[$group_type][] = $session_data;
+
+    // Mother FBF: per (session, mother) wire "YYYY-MM-DD <amount>" emitted
+    // under group_nutrition_mother.<group>. In practice only Fbf clinics
+    // produce mother distributions, but we key by group_type defensively so
+    // any future clinic type carrying mother distributions surfaces under a
+    // matching key without code changes.
+    if (isset($mother_fbf_amount_by_session[$session->nid])) {
+      $mother_session_data = "$encounter_date " . $mother_fbf_amount_by_session[$session->nid];
+      if (empty($mother_sessions_data[$group_type])) {
+        $mother_sessions_data[$group_type] = [$mother_session_data];
+      }
+      else {
+        $mother_sessions_data[$group_type][] = $mother_session_data;
+      }
     }
   }
   if (!empty($sessions_data)) {
     $data['group_nutrition'] = $sessions_data;
+  }
+  if (!empty($mother_sessions_data)) {
+    $data['group_nutrition_mother'] = $mother_sessions_data;
   }
 
   $encoded_data = json_encode($data);
@@ -1350,6 +1469,66 @@ function hedley_reports_family_nutrition_metrics_to_string($values) {
   }
 
   return (string) $values['m'];
+}
+
+/**
+ * Collects distributed_amount values from FBF / AHEZA records for one person.
+ *
+ * Stays in sync with decodeNutritionEncounterData,
+ * decodeFamilyNutritionEncounterData,
+ * decodeFamilyNutritionMotherEncounterData, and
+ * decodeMotherFbfEncounterData in
+ * server/elm/src/Backend/Reports/Decoder.elm; update both together.
+ *
+ * @param int $person_id
+ *   The person node id whose distribution records to read.
+ * @param string $bundle
+ *   The distribution bundle: child_fbf, mother_fbf, aheza_child, aheza_mother.
+ * @param string $parent_field_name
+ *   The entityreference field on the bundle that points at the parent
+ *   encounter / session: field_session for FBF bundles,
+ *   field_family_nutrition_encounter for AHEZA bundles.
+ *
+ * @return array
+ *   Associative array keyed by parent encounter / session nid; value is the
+ *   field_distributed_amount on the distribution measurement node. Records
+ *   with no parent reference or no amount are skipped. If multiple records
+ *   share the same parent for this person (not expected in practice), the
+ *   last one read wins, matching the existing per-encounter "last write
+ *   wins" pattern used elsewhere in this function (e.g. MUAC at line 658).
+ */
+function hedley_reports_collect_distributed_amounts_by_parent($person_id, $bundle, $parent_field_name) {
+  $query = hedley_general_create_entity_field_query_excluding_deleted();
+  $result = $query
+    ->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', $bundle)
+    ->fieldCondition('field_person', 'target_id', $person_id)
+    ->propertyCondition('status', NODE_PUBLISHED)
+    ->execute();
+
+  if (empty($result['node'])) {
+    return [];
+  }
+
+  $records = node_load_multiple(array_keys($result['node']));
+  $amounts = [];
+  foreach ($records as $record) {
+    $parent_field = isset($record->{$parent_field_name}) ? $record->{$parent_field_name} : NULL;
+    $parent_id = !empty($parent_field[LANGUAGE_NONE][0]['target_id'])
+      ? $parent_field[LANGUAGE_NONE][0]['target_id']
+      : NULL;
+    if (empty($parent_id)) {
+      continue;
+    }
+    $amount = isset($record->field_distributed_amount[LANGUAGE_NONE][0]['value'])
+      ? $record->field_distributed_amount[LANGUAGE_NONE][0]['value']
+      : NULL;
+    if (is_null($amount) || $amount === '') {
+      continue;
+    }
+    $amounts[$parent_id] = $amount;
+  }
+  return $amounts;
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1695,6 +1695,7 @@ function hedley_reports_build_statistical_queries_results_app($province = NULL, 
   }
 
   $data['site'] = variable_get('hedley_general_site_name', '');
+  $data['features'] = hedley_admin_get_enabled_features_string();
 
   if (in_array($data['entity_type'], ['sector', 'cell', 'village'])) {
     // For smaller data sets, we generate results on fly.

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1263,36 +1263,34 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
     $nutrition = hedley_reports_nutrition_metrics_to_string($zscores + $muac_edema);
     $session_data = "$encounter_date $nutrition";
 
-    // Skip sessions that only carry mother_fbf data: those don't represent a
-    // child encounter, so they must not flow into group_nutrition.<group> as
-    // a child entry. They're emitted separately below under
-    // group_nutrition_mother.<group>.
-    $has_child_data = isset($zscores_by_encounter[$session->nid])
-      || isset($muac_edema_by_encounter[$session->nid])
-      || isset($child_fbf_amount_by_session[$session->nid]);
+    // Embed FBF distributed amount on the wire as a |<amount> tail chunk
+    // appended to the existing space-delimited second segment. The Elm
+    // decoder splits the second segment on '|' to separate anthropometry
+    // (",,,," up to "stunting,wasting,underweight,muac,edema") from the
+    // FBF amount. Wire shapes after this change:
+    // - "YYYY-MM-DD" (unchanged legacy date-only).
+    // - "YYYY-MM-DD <anth>" (unchanged anthropometry only).
+    // - "YYYY-MM-DD <anth>|<amount>" (anthropometry + FBF).
+    // - "YYYY-MM-DD ,,,,|<amount>" (FBF only -- empty anth chunk).
+    // Stays in sync with decodeNutritionEncounterData in
+    // server/elm/src/Backend/Reports/Decoder.elm; update both together.
+    //
+    // Every session in $sessions_ids gets emitted under
+    // group_nutrition.<group> regardless of whether the person is the
+    // child or the mother at that session: the Demographics encounter
+    // table counts these as session attendance for both. A mother who
+    // attended an FBF session (e.g. via family_planning / lactation /
+    // mother_fbf) appears here with empty anthropometry; a child shows
+    // whatever measurements were recorded.
+    if (isset($child_fbf_amount_by_session[$session->nid])) {
+      $session_data .= '|' . $child_fbf_amount_by_session[$session->nid];
+    }
 
-    if ($has_child_data) {
-      // Embed FBF distributed amount on the wire as a |<amount> tail chunk
-      // appended to the existing space-delimited second segment. The Elm
-      // decoder splits the second segment on '|' to separate anthropometry
-      // (",,,," up to "stunting,wasting,underweight,muac,edema") from the
-      // FBF amount. Wire shapes after this change:
-      // - "YYYY-MM-DD" (unchanged legacy date-only).
-      // - "YYYY-MM-DD <anth>" (unchanged anthropometry only).
-      // - "YYYY-MM-DD <anth>|<amount>" (anthropometry + FBF).
-      // - "YYYY-MM-DD ,,,,|<amount>" (FBF only -- empty anth chunk).
-      // Stays in sync with decodeNutritionEncounterData in
-      // server/elm/src/Backend/Reports/Decoder.elm; update both together.
-      if (isset($child_fbf_amount_by_session[$session->nid])) {
-        $session_data .= '|' . $child_fbf_amount_by_session[$session->nid];
-      }
-
-      if (empty($sessions_data[$group_type])) {
-        $sessions_data[$group_type] = [$session_data];
-      }
-      else {
-        $sessions_data[$group_type][] = $session_data;
-      }
+    if (empty($sessions_data[$group_type])) {
+      $sessions_data[$group_type] = [$session_data];
+    }
+    else {
+      $sessions_data[$group_type][] = $session_data;
     }
 
     // Mother FBF: per (session, mother) wire "YYYY-MM-DD <amount>" emitted

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/HedleyRestfulSync.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/HedleyRestfulSync.class.php
@@ -175,32 +175,12 @@ class HedleyRestfulSync extends \RestfulBase implements \RestfulDataProviderInte
       $output = array_merge($output, $rendered_items);
     }
 
-    // Generate list of enabled features.
-    $available_features = [
-      'family_nutrition',
-      'gps_coordinates',
-      'group_education',
-      'healthy_start',
-      'hiv_management',
-      'ncda',
-      'report_to_whatsapp',
-      'stock_management_hc',
-      'stock_management_village',
-      'tuberculosis_management',
-    ];
-    $enabled_features = array_filter(
-      $available_features,
-      function ($feature) {
-        return variable_get("hedley_admin_feature_{$feature}_enabled", FALSE);
-      }
-    );
-
     $return = [
       'base_revision' => $base,
       'revision_count' => $count,
       'rollbar_token' => variable_get('hedley_general_rollbar_token', ''),
       'site' => variable_get('hedley_general_site_name', ''),
-      'features' => implode(' ', $enabled_features),
+      'features' => hedley_admin_get_enabled_features_string(),
     ];
 
     if (!empty($request['access_token'])) {


### PR DESCRIPTION
Issue: #1732 , #1733

## Summary

Adds a new **FBF Distribution** report to Statistical Queries (`admin/reports/statistical-queries`). The report shows total nutrition supplement distributions in a date range, grouped by recipient and program:

| Type | Total |
| --- | --- |
| FBF Child | sum of `child_fbf` `distributed_amount` (Fbf-clinic only) |
| FBF Mother | sum of `mother_fbf` `distributed_amount` (Fbf-clinic only) |
| Aheza Child | sum of `aheza_child` `distributed_amount` |
| Aheza Mother | sum of `aheza_mother` `distributed_amount` |

Uses the same start-date / limit-date filters as the other date-filtered reports. Includes a CSV download button.

## What's in the PR

Three commits, each cleanly scoped:

### 1. Data-layer plumbing — `99c3a8c01`

Extends per-person `field_reports_data` JSON to carry FBF and AHEZA `distributed_amount` values, embedded in existing per-encounter wires (backwards-compatible) plus one new top-level key for mother FBF.

| JSON key | Before | After |
| --- | --- | --- |
| `group_nutrition.{fbf,achi,…}` | `"YYYY-MM-DD <anth>"` | adds optional `\|<amount>` tail; FBF-only emits `",,,,\|<amount>"` |
| `individual.family-nutrition` (mother) | `"YYYY-MM-DD"` | `"YYYY-MM-DD <amount>"` when AHEZA recorded |
| `individual.family-nutrition-muac` (child) | `"YYYY-MM-DD <muac>"` | adds `\|<amount>` tail; AHEZA-only emits `"YYYY-MM-DD \|<amount>"` |
| `group_nutrition_mother.<group_type>` | _(new key)_ | `"YYYY-MM-DD <amount>"` per (session, mother) |

Backend changes (`hedley_reports.module` + bundle constants):
- New bundle constants `HEDLEY_ACTIVITY_MOTHER_FBF_CONTENT_TYPE`, `HEDLEY_FAMILY_NUTRITION_AHEZA_{CHILD,MOTHER}_CONTENT_TYPE`.
- AQ recalc triggers on insert/update of all four bundles.
- New helper `hedley_reports_collect_distributed_amounts_by_parent()` collects per-person amounts indexed by parent encounter / session.
- Existing emission blocks extended in place; new top-level `group_nutrition_mother.<group_type>` for mother FBF.

Admin Elm app (`server/elm`):
- `NutritionEncounterData.fbfAmount`, `FamilyNutritionEncounterData.ahezaAmount` added.
- New types `FamilyNutritionMotherEncounterData`, `MotherFbfEncounterData` with matching decoders.
- `PatientData.familyNutritionData` retyped to mother-side; new `PatientData.groupNutritionFbfMotherData`.
- Cross-referenced docstrings on both PHP emission and Elm decoding sites tied together by the wire-format contract.

### 2. Report UI — `70e2d9a32`

- New `ReportFBFDistribution` value in `Pages.Reports.Model.ReportType` and matching slug `"fbf-distribution"` in `Pages.Reports.Utils`.
- New `viewFBFDistributionReport` rendering a 2-column table (Type / Total) modelled on `viewPrenatalDiagnosesReport`. Whole-number totals print as integers; fractional totals as up to 2 dp.
- New `FbfDistributionCategory` type drives the four row labels via `Translate.FbfDistributionCategory`. New `Translate.FbfDistributionType` for the column header. New `Translate.ReportType ReportFBFDistribution → "FBF Distribution"`.
- Centralised `recordsTillLimitDate` filter extended to include `groupNutritionFbfMotherData`, `familyNutritionData`, `familyNutritionMuacData` so the new fields are date-filtered alongside the others.
- **Drive-by**: notice guards in `hedley_reports_load_results_data()` and `hedley_reports_create_or_update_results_data_node()` against stub `report_data` nodes with no attached file. Pre-existing bug from May 2024; surfaced while testing this feature locally and easy to harden in passing.

### 3. E2E test + regression fix — `b8167d368`

- Adds an FBF Distribution assertion to the integration test in `client/e2e/reporting.spec.ts`. The encounters created by Phase 1a (`completeChildFbf '1'` + `completeMotherFbf '1'` at an Fbf clinic) and Phase 1b (`completeAhezaMother '3'` + `completeAhezaChild '2'`) drive the four expected deltas; we capture baseline totals in Phase 0 and assert deltas of +1 / +1 / +2 / +3 in a new Phase 3b step.
- New helpers in `client/e2e/helpers/reports.ts`: `navigateToGlobalReportsPage` (for the `/admin/reports/statistical-queries/all` route) and `readFBFDistributionTable` (wraps the existing `readSimpleTable` for `div.report.fbf-distribution`).
- **Regression fix in `hedley_reports.module`**: commit 1 added a `$has_child_data` filter that excluded mother-only sessions from `group_nutrition.<group>` emission, breaking the pre-existing Demographics `'FBF', +2` assertion which depends on both mother and child encounter rows. Restored the original "every session in `$sessions_ids` emits one entry" behaviour; `mother_fbf` data continues to flow into the new `group_nutrition_mother.<group>` key separately.

## Out of scope

- Changes to the offline PWA at `client/` — already encodes/decodes FBF and AHEZA correctly.
- Surfacing FBF distribution **notice** (full / lack-of-stock / other) or AHEZA mother **distribution reason** (breastfeeding / pregnant / other). Per the issue, only the distributed amount is needed for this report.

## Test plan

- [x] `ddev phpcs server/hedley/modules/custom/hedley_{reports,activity,family_nutrition}/...` — zero errors and zero warnings.
- [x] `cd server/elm && elm make src/Main.elm --output ../hedley/modules/custom/hedley_general/js/elm-main.js` — compiles cleanly (82 modules).
- [x] `cd server/elm && rm -rf elm-stuff && npx elm-review` — clean.
- [x] `ddev drush cc all` then run `hedley_reports/scripts/generate-data-for-all.php` and inspect `field_reports_data` on persons with FBF and AHEZA records — new keys/wires appear correctly.
- [x] CI `e2e_reporting` job passes with the new FBF Distribution assertion + regression fix.
- [x] Open `admin/reports/statistical-queries/global` and `…/health-center/<id>` for scopes containing persons whose JSON predates this work — page renders without decode errors (backward-compat on legacy entries lacking `|`).
- [ ] In the offline PWA, create a new FBF distribution → after sync, force the AQ to drain and confirm `field_reports_data` reflects the new record. Repeat for an AHEZA record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
