### PR TITLE
Fix Family Nutrition row ignoring date filter in Demographic report

### DIFF
--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -276,6 +276,8 @@ viewReportsData language currentDate themePath data model =
                                                         , groupNutritionSorwatheData = filterGroupBy .startDate record.groupNutritionSorwatheData
                                                         , groupNutritionChwData = filterGroupBy .startDate record.groupNutritionChwData
                                                         , groupNutritionAchiData = filterGroupBy .startDate record.groupNutritionAchiData
+                                                        , familyNutritionData = filterIndividualBy .startDate record.familyNutritionData
+                                                        , familyNutritionMuacData = filterIndividualBy .startDate record.familyNutritionMuacData
                                                     }
 
                                             else

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -20263,6 +20263,18 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 													},
 													record.acuteIllnessData),
 												childScorecardData: A2(filterIndividualBy, $elm$core$Basics$identity, record.childScorecardData),
+												familyNutritionData: A2(
+													filterIndividualBy,
+													function ($) {
+														return $.startDate;
+													},
+													record.familyNutritionData),
+												familyNutritionMuacData: A2(
+													filterIndividualBy,
+													function ($) {
+														return $.startDate;
+													},
+													record.familyNutritionMuacData),
 												groupNutritionAchiData: A2(
 													filterGroupBy,
 													function ($) {


### PR DESCRIPTION
Issue #1734.

## Summary

Hotfix on top of `main`. In `server/elm/src/Pages/Reports/View.elm`, the date-filter pipeline in `viewReportsData` rebuilds each `PatientData` record with every encounter type filtered by `.startDate` — but it was forgetting `familyNutritionData` and `familyNutritionMuacData`, so the Family Nutrition row in the Statistical Queries → Demographic → Encounters table always showed the lifetime total regardless of the selected window.

Two new lines run those fields through the same `filterIndividualBy .startDate` filter used by the other doubly-nested encounter lists (e.g. `acuteIllnessData`, `individualNutritionData`).

Affected downstream consumers (both now correct):
- Demographic report's Encounters table (the row the bug was reported against).
- Nutrition report's `NutritionMetrics` aggregation in `Update.elm`, which also reads both fields via `countTotalNutritionEncounters`.

Second commit just rebuilds `server/hedley/modules/custom/hedley_general/js/elm-main.js` to match.

## Test plan

- [x] Pull this branch, run `ddev elm:watch` (or refresh the bundle), open Statistical Queries → Demographic at any scope.
- [x] Confirm the **Family Nutrition** row in the Encounters table responds to the FROM/TO range — try a narrow window (e.g. yesterday → today) and a wide one.
- [x] Confirm the other rows still behave as before (no regression in ANC / Acute Illness / Pediatric / NCD / HIV / Tuberculosis / nutrition variants).
- [x] Confirm the Nutrition report's totals still reconcile against the (now-filtered) family-nutrition counts.
- [x] CircleCI green.

## Follow-up

This same fix needs to land on `develop` after merge — happy to either cherry-pick or do a `main → develop` merge after this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
