### PR TITLE
Gate admin Reports views by enabled site features

### DIFF
--- a/client/e2e/acute-illness-encounter-chw.spec.ts
+++ b/client/e2e/acute-illness-encounter-chw.spec.ts
@@ -38,9 +38,16 @@ test.describe('CHW: Acute Illness Initial Encounter — Uncomplicated Pneumonia'
     await setupDevice(page, '2345', 'Akanduga');
   });
 
-  test('complete CHW initial encounter with respiratory symptoms, verify backend sync', async ({ page }) => {
-    // Verify FeatureAcuteIllness flag gates the "Acute Illness" button.
-    await verifyFeatureGatesEncounterButton(page, 'acute_illness', 'Acute Illness');
+  test('complete CHW initial encounter with respiratory symptoms, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureAcuteIllness flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'acute_illness', 'Acute Illness', {
+      browser,
+      admin: {
+        sqOptions: ['acute-illness'],
+        sqDemographicsRows: ['Acute Illness Total'],
+        completionOptions: ['acute-illness'],
+      },
+    });
 
     const { fullName } = await createAdultAndStartEncounter(page, {
       isChw: true,

--- a/client/e2e/acute-illness-encounter-chw.spec.ts
+++ b/client/e2e/acute-illness-encounter-chw.spec.ts
@@ -44,7 +44,7 @@ test.describe('CHW: Acute Illness Initial Encounter — Uncomplicated Pneumonia'
       browser,
       admin: {
         sqOptions: ['acute-illness'],
-        sqDemographicsRows: ['Acute Illness Total'],
+        sqDemographicsRows: ['Acute Illness (total)'],
         completionOptions: ['acute-illness'],
       },
     });

--- a/client/e2e/acute-illness-encounter-nurse.spec.ts
+++ b/client/e2e/acute-illness-encounter-nurse.spec.ts
@@ -42,7 +42,7 @@ test.describe('Nurse: Acute Illness Initial + Subsequent Encounter — Malaria U
       browser,
       admin: {
         sqOptions: ['acute-illness'],
-        sqDemographicsRows: ['Acute Illness Total'],
+        sqDemographicsRows: ['Acute Illness (total)'],
         completionOptions: ['acute-illness'],
       },
     });

--- a/client/e2e/acute-illness-encounter-nurse.spec.ts
+++ b/client/e2e/acute-illness-encounter-nurse.spec.ts
@@ -36,9 +36,16 @@ test.describe('Nurse: Acute Illness Initial + Subsequent Encounter — Malaria U
     await setupDevice(page, '1234', 'Nyange Health Center');
   });
 
-  test('complete initial and subsequent encounters, verify backend sync', async ({ page }) => {
-    // Verify FeatureAcuteIllness flag gates the "Acute Illness" button.
-    await verifyFeatureGatesEncounterButton(page, 'acute_illness', 'Acute Illness');
+  test('complete initial and subsequent encounters, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureAcuteIllness flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'acute_illness', 'Acute Illness', {
+      browser,
+      admin: {
+        sqOptions: ['acute-illness'],
+        sqDemographicsRows: ['Acute Illness Total'],
+        completionOptions: ['acute-illness'],
+      },
+    });
 
     // =====================================================================
     // PART 1: Nurse Initial Encounter — Malaria Uncomplicated

--- a/client/e2e/child-scoreboard-encounter-chw.spec.ts
+++ b/client/e2e/child-scoreboard-encounter-chw.spec.ts
@@ -38,9 +38,15 @@ test.describe('CHW: Child Scoreboard Encounter — First NCDA + Vaccination Hist
   //             ChildBehindOnVaccination → "No" triggers VaccinationHistory activity.
   // Backend: Verifies child_scoreboard_ncda + 7 vaccination nodes created,
   //          confirms child_scoreboard_dtp_sa_iz absent (Burundi-only).
-  test('complete NCDA and vaccination history, verify backend sync', async ({ page }) => {
-    // Verify FeatureNCDA flag gates the "Child Scorecard" button.
-    await verifyFeatureGatesEncounterButton(page, 'ncda', 'Child Scorecard');
+  test('complete NCDA and vaccination history, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureNCDA flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'ncda', 'Child Scorecard', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['Child Scorecard'],
+        completionOptions: ['child-scoreboard'],
+      },
+    });
 
     // 1. Register a 10-month-old child and start the encounter.
     const { fullName } = await createChildAndStartEncounter(page, {

--- a/client/e2e/family-nutrition-encounter-chw.spec.ts
+++ b/client/e2e/family-nutrition-encounter-chw.spec.ts
@@ -32,7 +32,7 @@ test.describe('CHW: Family Nutrition Encounter', () => {
     await setupDevice(page, '2345', 'Akanduga');
   });
 
-  test('Case 1: Mother only — complete Aheza and MUAC', async ({ page }) => {
+  test('Case 1: Mother only — complete Aheza and MUAC', async ({ page, browser }) => {
     // Scenario: Family nutrition encounter with mother only (no children added).
     // Activities: Aheza Mother (with distribution reason), MUAC Mother.
     // Conditions: No children → only mother activities shown.
@@ -42,8 +42,13 @@ test.describe('CHW: Family Nutrition Encounter', () => {
     //   Confirms aheza_child, family_nutrition_muac_child,
     //   family_nutrition_photo absent (no children).
 
-    // Verify FeatureFamilyNutrition flag gates the "Family Assessment" button on Clinical (CHW only).
-    await verifyFeatureGatesClinicalAssessmentButton(page, 'family_nutrition', 'family-assessment');
+    // Verify FeatureFamilyNutrition flag gates client UI + admin Demographics row.
+    await verifyFeatureGatesClinicalAssessmentButton(page, 'family_nutrition', 'family-assessment', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['Family Nutrition'],
+      },
+    });
 
     // 1. Register mother, skip adding children, go straight to participant page.
     const mother = await createMotherAndNavigateToPersonPage(page);

--- a/client/e2e/group-session-chw.spec.ts
+++ b/client/e2e/group-session-chw.spec.ts
@@ -40,6 +40,7 @@ test.describe('CHW: Group Nutrition Session', () => {
 
   test('CHW group session: register mother+child, complete basic activities', async ({
     page,
+    browser,
   }) => {
     // Scenario: CHW creates a group session via GroupEncounterTypesPage,
     //   registers a new mother and child (<24mo), completes basic child
@@ -53,9 +54,15 @@ test.describe('CHW: Group Nutrition Session', () => {
     //   muac, nutrition, family_planning).
     //   Confirms child_fbf, mother_fbf, lactation absent.
 
-    // Verify FeatureNutritionGroup flag gates the "Child Nutrition" button on Group Encounter Types.
+    // Verify FeatureNutritionGroup flag gates client UI + admin Reports surfaces.
     // (Keep group_education ON so the Group Assessment entry button on Clinical stays reachable.)
-    await verifyFeatureGatesGroupEncounterButton(page, 'nutrition_group', 'Child Nutrition', 'group_education');
+    await verifyFeatureGatesGroupEncounterButton(page, 'nutrition_group', 'Child Nutrition', 'group_education', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['PMTCT', 'FBF', 'Sorwathe', 'CBNP', 'ACHI'],
+        completionOptions: ['nutrition-group'],
+      },
+    });
 
     // 1. Navigate to CHW group session.
     await navigateToChwGroupSession(page);

--- a/client/e2e/group-session-chw.spec.ts
+++ b/client/e2e/group-session-chw.spec.ts
@@ -58,7 +58,8 @@ test.describe('CHW: Group Nutrition Session', () => {
     // (Keep group_education ON so the Group Assessment entry button on Clinical stays reachable.)
     //
     // family_nutrition is dropped for this gate-check so the on/off cycle of
-    // nutrition_group exercises both new Stock Management gates in one pass:
+    // nutrition_group exercises both admin Reports gates for FBF data
+    // in one pass:
     //   - OFF phase (both flags off): SQ dropdown drops 'fbf-distribution'
     //     entirely (visibleReportTypes gate, both contributing features off).
     //   - ON phase (nutrition_group on, family_nutrition off): dropdown

--- a/client/e2e/group-session-chw.spec.ts
+++ b/client/e2e/group-session-chw.spec.ts
@@ -3,7 +3,7 @@ import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
-import { verifyFeatureGatesGroupEncounterButton } from './helpers/feature-flags';
+import { setFeatureFlag, verifyFeatureGatesGroupEncounterButton } from './helpers/feature-flags';
 import {
   navigateToChwGroupSession,
   createMotherOnAttendancePage,
@@ -56,13 +56,30 @@ test.describe('CHW: Group Nutrition Session', () => {
 
     // Verify FeatureNutritionGroup flag gates client UI + admin Reports surfaces.
     // (Keep group_education ON so the Group Assessment entry button on Clinical stays reachable.)
-    await verifyFeatureGatesGroupEncounterButton(page, 'nutrition_group', 'Child Nutrition', 'group_education', {
-      browser,
-      admin: {
-        sqDemographicsRows: ['PMTCT', 'FBF', 'Sorwathe', 'CBNP', 'ACHI'],
-        completionOptions: ['nutrition-group'],
-      },
-    });
+    //
+    // family_nutrition is dropped for this gate-check so the on/off cycle of
+    // nutrition_group exercises both new Stock Management gates in one pass:
+    //   - OFF phase (both flags off): SQ dropdown drops 'fbf-distribution'
+    //     entirely (visibleReportTypes gate, both contributing features off).
+    //   - ON phase (nutrition_group on, family_nutrition off): dropdown
+    //     reappears and the 3 FBF rows render
+    //     (visibleFbfDistributionCategories gate, FBF rows track
+    //     nutrition_group; Aheza rows correctly absent under family_nutrition).
+    try {
+      setFeatureFlag('family_nutrition', false);
+      await verifyFeatureGatesGroupEncounterButton(page, 'nutrition_group', 'Child Nutrition', 'group_education', {
+        browser,
+        admin: {
+          sqOptions: ['fbf-distribution'],
+          sqDemographicsRows: ['PMTCT', 'FBF', 'Sorwathe', 'CBNP', 'ACHI'],
+          sqFbfDistributionRows: ['fbf-child', 'fbf-mother', 'fbf-child-achi'],
+          completionOptions: ['nutrition-group'],
+        },
+      });
+    } finally {
+      setFeatureFlag('family_nutrition', true);
+      await syncAndWait(page);
+    }
 
     // 1. Navigate to CHW group session.
     await navigateToChwGroupSession(page);

--- a/client/e2e/group-session-nurse.spec.ts
+++ b/client/e2e/group-session-nurse.spec.ts
@@ -48,6 +48,7 @@ test.describe('Nurse: FBF Group Nutrition Session', () => {
 
   test('FBF group session: all activities including NextSteps', async ({
     page,
+    browser,
   }) => {
     // Scenario: Nurse creates an FBF group session with abnormal nutrition
     //   values (Edema sign + low MUAC) to trigger all activities including
@@ -58,9 +59,15 @@ test.describe('Nurse: FBF Group Nutrition Session', () => {
     // Mother activities: FamilyPlanning, Lactation, MotherFbf.
     // Backend: Verifies 14 node types (all group session content types).
 
-    // Verify FeatureNutritionGroup flag gates the "Group Assessment" button on Clinical (nurse only).
+    // Verify FeatureNutritionGroup flag gates client UI + admin Reports surfaces.
     // (On nurse the gate is unambiguous: group_education isn't part of the compound for non-CHW.)
-    await verifyFeatureGatesClinicalAssessmentButton(page, 'nutrition_group', 'group-assessment');
+    await verifyFeatureGatesClinicalAssessmentButton(page, 'nutrition_group', 'group-assessment', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['PMTCT', 'FBF', 'Sorwathe', 'CBNP', 'ACHI'],
+        completionOptions: ['nutrition-group'],
+      },
+    });
 
     // 1. Navigate to FBF group session.
     await navigateToNurseGroupSession(page, 'FBF', 'Nyange I');

--- a/client/e2e/group-session-nurse.spec.ts
+++ b/client/e2e/group-session-nurse.spec.ts
@@ -63,7 +63,8 @@ test.describe('Nurse: FBF Group Nutrition Session', () => {
     // (On nurse the gate is unambiguous: group_education isn't part of the compound for non-CHW.)
     //
     // family_nutrition is dropped for this gate-check so the on/off cycle of
-    // nutrition_group exercises both new Stock Management gates in one pass:
+    // nutrition_group exercises both admin Reports gates for FBF data
+    // in one pass:
     //   - OFF phase (both flags off): SQ dropdown drops 'fbf-distribution'
     //     entirely (visibleReportTypes gate, both contributing features off).
     //   - ON phase (nutrition_group on, family_nutrition off): dropdown

--- a/client/e2e/group-session-nurse.spec.ts
+++ b/client/e2e/group-session-nurse.spec.ts
@@ -3,7 +3,7 @@ import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { syncAndWait } from './helpers/common';
-import { verifyFeatureGatesClinicalAssessmentButton } from './helpers/feature-flags';
+import { setFeatureFlag, verifyFeatureGatesClinicalAssessmentButton } from './helpers/feature-flags';
 import {
   navigateToNurseGroupSession,
   createMotherOnAttendancePage,
@@ -61,13 +61,30 @@ test.describe('Nurse: FBF Group Nutrition Session', () => {
 
     // Verify FeatureNutritionGroup flag gates client UI + admin Reports surfaces.
     // (On nurse the gate is unambiguous: group_education isn't part of the compound for non-CHW.)
-    await verifyFeatureGatesClinicalAssessmentButton(page, 'nutrition_group', 'group-assessment', {
-      browser,
-      admin: {
-        sqDemographicsRows: ['PMTCT', 'FBF', 'Sorwathe', 'CBNP', 'ACHI'],
-        completionOptions: ['nutrition-group'],
-      },
-    });
+    //
+    // family_nutrition is dropped for this gate-check so the on/off cycle of
+    // nutrition_group exercises both new Stock Management gates in one pass:
+    //   - OFF phase (both flags off): SQ dropdown drops 'fbf-distribution'
+    //     entirely (visibleReportTypes gate, both contributing features off).
+    //   - ON phase (nutrition_group on, family_nutrition off): dropdown
+    //     reappears and the 3 FBF rows render
+    //     (visibleFbfDistributionCategories gate, FBF rows track
+    //     nutrition_group; Aheza rows correctly absent under family_nutrition).
+    try {
+      setFeatureFlag('family_nutrition', false);
+      await verifyFeatureGatesClinicalAssessmentButton(page, 'nutrition_group', 'group-assessment', {
+        browser,
+        admin: {
+          sqOptions: ['fbf-distribution'],
+          sqDemographicsRows: ['PMTCT', 'FBF', 'Sorwathe', 'CBNP', 'ACHI'],
+          sqFbfDistributionRows: ['fbf-child', 'fbf-mother', 'fbf-child-achi'],
+          completionOptions: ['nutrition-group'],
+        },
+      });
+    } finally {
+      setFeatureFlag('family_nutrition', true);
+      await syncAndWait(page);
+    }
 
     // 1. Navigate to FBF group session.
     await navigateToNurseGroupSession(page, 'FBF', 'Nyange I');

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -9,7 +9,14 @@ import {
   navigateToCompletionReportPage,
   navigateToHCReportsPage,
   selectReportType,
+  setDateRange,
 } from './reports';
+
+// Wide date window so Demographics counts include every migration-seeded
+// encounter regardless of its created/updated timestamp. Constructed in
+// UTC so the calendar popup (which reads via getUTC*) lands on the
+// intended day in any timezone — see REPORT_START_DATE in reporting.spec.ts.
+const ADMIN_REPORT_START_DATE = new Date(Date.UTC(2018, 0, 1));
 
 /**
  * What admin-Reports surfaces a given SiteFeature flag is expected to gate.
@@ -112,6 +119,13 @@ export async function assertAdminGates(
 
       if (sqRows.length > 0) {
         await selectReportType(adminPage, 'demographics');
+        // Health-center scope is "wide" (Pages.Reports.Utils.isWideScope),
+        // so the Demographics rows are gated behind a date range. Without
+        // setting it, the page only shows the WideScopeNote and no rows
+        // render -- making both presence and absence assertions fail
+        // ambiguously. Pick a wide window covering all migration-seeded
+        // encounters; the rows themselves render independently of count.
+        await setDateRange(adminPage, ADMIN_REPORT_START_DATE, new Date());
         for (const rowLabel of sqRows) {
           const row = adminPage.locator('.page-content.reports .row', {
             hasText: rowLabel,

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -35,6 +35,15 @@ const ADMIN_REPORT_START_DATE = new Date(Date.UTC(2018, 0, 1));
 export interface AdminReportsExpectations {
   sqOptions?: string[];
   sqDemographicsRows?: string[];
+  /**
+   * FBF Distribution rows to assert by CSS class
+   * (`fbf-child` | `fbf-mother` | `fbf-child-achi` | `aheza-child` | `aheza-mother`).
+   *
+   * When the same call lists `fbf-distribution` in `sqOptions` and `phase` is
+   * `'hidden'` the report is unreachable, so the row assertion is skipped —
+   * the dropdown assertion already proves the rows are gone.
+   */
+  sqFbfDistributionRows?: string[];
   completionOptions?: string[];
 }
 
@@ -88,8 +97,15 @@ export async function assertAdminGates(
 ): Promise<void> {
   const sqOptions = expectations.sqOptions ?? [];
   const sqRows = expectations.sqDemographicsRows ?? [];
+  const sqFbfRows = expectations.sqFbfDistributionRows ?? [];
   const completionOptions = expectations.completionOptions ?? [];
-  const needsSQ = sqOptions.length > 0 || sqRows.length > 0;
+  // Only navigate into fbf-distribution when the dropdown still lists it.
+  // If sqOptions already asserts the option is hidden, the report is
+  // unreachable and the dropdown assertion subsumes the row check.
+  const fbfRowsReachable =
+    sqFbfRows.length > 0
+    && !(phase === 'hidden' && sqOptions.includes('fbf-distribution'));
+  const needsSQ = sqOptions.length > 0 || sqRows.length > 0 || fbfRowsReachable;
   const needsCompletion = completionOptions.length > 0;
 
   if (!needsSQ && !needsCompletion) {
@@ -134,6 +150,24 @@ export async function assertAdminGates(
             await expect(row, `Demographics row "${rowLabel}" absent`).toHaveCount(0);
           } else {
             await expect(row.first(), `Demographics row "${rowLabel}" visible`).toBeVisible();
+          }
+        }
+      }
+
+      if (fbfRowsReachable) {
+        await selectReportType(adminPage, 'fbf-distribution');
+        // Same wide-scope date-gating as the Demographics block above.
+        // setDateRange is idempotent so calling it again after the
+        // Demographics path is harmless.
+        await setDateRange(adminPage, ADMIN_REPORT_START_DATE, new Date());
+        for (const rowClass of sqFbfRows) {
+          const row = adminPage.locator(
+            `div.report.fbf-distribution div.row.${rowClass}`,
+          );
+          if (phase === 'hidden') {
+            await expect(row, `FBF row ".${rowClass}" absent`).toHaveCount(0);
+          } else {
+            await expect(row.first(), `FBF row ".${rowClass}" visible`).toBeVisible();
           }
         }
       }

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -1,8 +1,46 @@
-import { Page, expect } from '@playwright/test';
+import { Browser, Page, expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import { click } from './auth';
 import { syncAndWait } from './common';
 import { drushEnv } from './device';
+import {
+  NYANGE_HC_ID,
+  drupalLogin,
+  navigateToCompletionReportPage,
+  navigateToHCReportsPage,
+  selectReportType,
+} from './reports';
+
+/**
+ * What admin-Reports surfaces a given SiteFeature flag is expected to gate.
+ *
+ * Lists are dropdown-option `value` attributes (not translated labels), so
+ * matches are exact and stable across translation churn:
+ *
+ *   sqOptions: ['acute-illness']  -> Statistical Queries dropdown drops the
+ *                                     option whose value="acute-illness".
+ *   completionOptions: ['prenatal'] -> same idea on the Completion dropdown.
+ *
+ * Demographics rows have no value attribute so are matched by visible text;
+ * use a substring unique to one row (e.g. "ANC Total", "Standard Pediatric
+ * Visit").
+ */
+export interface AdminReportsExpectations {
+  sqOptions?: string[];
+  sqDemographicsRows?: string[];
+  completionOptions?: string[];
+}
+
+/**
+ * Optional admin-side coverage layered onto the four PR #1411
+ * verifyFeatureGates* helpers. Pass the test's `browser` fixture and an
+ * `admin` payload to interleave server-side asserts inside the helper's
+ * existing off/on cycle; omit to keep client-only behaviour.
+ */
+export interface FeatureGateOptions {
+  browser?: Browser;
+  admin?: AdminReportsExpectations;
+}
 
 /**
  * Toggle a `hedley_admin_feature_<name>_enabled` Drupal variable.
@@ -36,6 +74,78 @@ export function setFeatureFlag(name: string, enabled: boolean) {
   });
 }
 
+export async function assertAdminGates(
+  browser: Browser,
+  expectations: AdminReportsExpectations,
+  phase: 'hidden' | 'visible',
+): Promise<void> {
+  const sqOptions = expectations.sqOptions ?? [];
+  const sqRows = expectations.sqDemographicsRows ?? [];
+  const completionOptions = expectations.completionOptions ?? [];
+  const needsSQ = sqOptions.length > 0 || sqRows.length > 0;
+  const needsCompletion = completionOptions.length > 0;
+
+  if (!needsSQ && !needsCompletion) {
+    return;
+  }
+
+  const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+  try {
+    const adminPage = await ctx.newPage();
+    await drupalLogin(adminPage);
+
+    if (needsSQ) {
+      await navigateToHCReportsPage(adminPage, NYANGE_HC_ID);
+      const sqDropdown = adminPage
+        .locator('.page-content.reports .select-input-wrapper')
+        .first()
+        .locator('select.select-input');
+
+      for (const value of sqOptions) {
+        const option = sqDropdown.locator(`option[value="${value}"]`);
+        if (phase === 'hidden') {
+          await expect(option, `SQ option "${value}" absent`).toHaveCount(0);
+        } else {
+          await expect(option, `SQ option "${value}" present`).toHaveCount(1);
+        }
+      }
+
+      if (sqRows.length > 0) {
+        await selectReportType(adminPage, 'demographics');
+        for (const rowLabel of sqRows) {
+          const row = adminPage.locator('.page-content.reports .row', {
+            hasText: rowLabel,
+          });
+          if (phase === 'hidden') {
+            await expect(row, `Demographics row "${rowLabel}" absent`).toHaveCount(0);
+          } else {
+            await expect(row.first(), `Demographics row "${rowLabel}" visible`).toBeVisible();
+          }
+        }
+      }
+    }
+
+    if (needsCompletion) {
+      await navigateToCompletionReportPage(adminPage, NYANGE_HC_ID);
+      const completionDropdown = adminPage
+        .locator('.page-content.completion .select-input-wrapper')
+        .first()
+        .locator('select.select-input');
+
+      for (const value of completionOptions) {
+        const option = completionDropdown.locator(`option[value="${value}"]`);
+        if (phase === 'hidden') {
+          await expect(option, `Completion option "${value}" absent`).toHaveCount(0);
+        } else {
+          await expect(option, `Completion option "${value}" present`).toHaveCount(1);
+        }
+      }
+    }
+  } finally {
+    await ctx.close();
+  }
+}
+
 /**
  * Verify that a SiteFeature flag actually gates an encounter-type
  * button on the Individual Encounter Types page.
@@ -63,40 +173,57 @@ export async function verifyFeatureGatesEncounterButton(
   page: Page,
   flagName: string,
   buttonText: string,
+  opts: FeatureGateOptions = {},
 ) {
-  // 1. Force feature OFF on backend, sync.
-  setFeatureFlag(flagName, false);
-  await syncAndWait(page);
+  try {
+    // 1. Force feature OFF on backend, sync.
+    setFeatureFlag(flagName, false);
+    await syncAndWait(page);
 
-  // 2. Navigate Dashboard → Clinical → Individual Assessment.
-  await click(page.locator('.icon-task-clinical'), page);
-  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
-  await click(page.locator('button.individual-assessment'), page);
-  await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
+    // 2. Navigate Dashboard → Clinical → Individual Assessment.
+    await click(page.locator('.icon-task-clinical'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('button.individual-assessment'), page);
+    await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
 
-  // 3. Button must be hidden.
-  const button = page.locator('button.encounter-type', { hasText: buttonText });
-  await expect(
-    button,
-    `"${buttonText}" button must be hidden when feature ${flagName} is off`,
-  ).toBeHidden();
+    // 3. Button must be hidden.
+    const button = page.locator('button.encounter-type', { hasText: buttonText });
+    await expect(
+      button,
+      `"${buttonText}" button must be hidden when feature ${flagName} is off`,
+    ).toBeHidden();
 
-  // 4. Re-enable feature and sync. After syncAndWait we land back on
-  //    the encounter-types page (page.goBack from device status).
-  setFeatureFlag(flagName, true);
-  await syncAndWait(page);
+    // 3a. Server-side admin gate (when caller asked).
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'hidden');
+    }
 
-  // 5. Button must now be visible.
-  await expect(
-    button,
-    `"${buttonText}" button must be visible when feature ${flagName} is on`,
-  ).toBeVisible();
+    // 4. Re-enable feature and sync. After syncAndWait we land back on
+    //    the encounter-types page (page.goBack from device status).
+    setFeatureFlag(flagName, true);
+    await syncAndWait(page);
 
-  // 6. Navigate back to PinCode so callers can resume from the dashboard.
-  await click(page.locator('.link-back .icon-back'), page);
-  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
-  await click(page.locator('.link-back .icon-back'), page);
-  await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+    // 5. Button must now be visible.
+    await expect(
+      button,
+      `"${buttonText}" button must be visible when feature ${flagName} is on`,
+    ).toBeVisible();
+
+    // 5a. Server-side admin gate (when caller asked).
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'visible');
+    }
+
+    // 6. Navigate back to PinCode so callers can resume from the dashboard.
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+  } finally {
+    // Always restore the flag so a mid-cycle assertion failure can't
+    // leak feature state into subsequent tests.
+    setFeatureFlag(flagName, true);
+  }
 }
 
 /**
@@ -120,29 +247,42 @@ export async function verifyFeatureGatesClinicalAssessmentButton(
   page: Page,
   flagName: string,
   buttonClass: string,
+  opts: FeatureGateOptions = {},
 ) {
-  setFeatureFlag(flagName, false);
-  await syncAndWait(page);
+  try {
+    setFeatureFlag(flagName, false);
+    await syncAndWait(page);
 
-  await click(page.locator('.icon-task-clinical'), page);
-  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('.icon-task-clinical'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
 
-  const button = page.locator(`button.${buttonClass}`);
-  await expect(
-    button,
-    `button.${buttonClass} must be hidden when feature ${flagName} is off`,
-  ).toBeHidden();
+    const button = page.locator(`button.${buttonClass}`);
+    await expect(
+      button,
+      `button.${buttonClass} must be hidden when feature ${flagName} is off`,
+    ).toBeHidden();
 
-  setFeatureFlag(flagName, true);
-  await syncAndWait(page);
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'hidden');
+    }
 
-  await expect(
-    button,
-    `button.${buttonClass} must be visible when feature ${flagName} is on`,
-  ).toBeVisible();
+    setFeatureFlag(flagName, true);
+    await syncAndWait(page);
 
-  await click(page.locator('.link-back .icon-back'), page);
-  await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+    await expect(
+      button,
+      `button.${buttonClass} must be visible when feature ${flagName} is on`,
+    ).toBeVisible();
+
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'visible');
+    }
+
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+  } finally {
+    setFeatureFlag(flagName, true);
+  }
 }
 
 /**
@@ -169,36 +309,49 @@ export async function verifyFeatureGatesGroupEncounterButton(
   flagName: string,
   buttonText: string,
   partnerFlag: string,
+  opts: FeatureGateOptions = {},
 ) {
-  setFeatureFlag(partnerFlag, true);
-  setFeatureFlag(flagName, false);
-  await syncAndWait(page);
+  try {
+    setFeatureFlag(partnerFlag, true);
+    setFeatureFlag(flagName, false);
+    await syncAndWait(page);
 
-  // Navigate Clinical → Group Assessment → Group Encounter Types.
-  await click(page.locator('.icon-task-clinical'), page);
-  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
-  await click(page.locator('button.group-assessment'), page);
-  await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
+    // Navigate Clinical → Group Assessment → Group Encounter Types.
+    await click(page.locator('.icon-task-clinical'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('button.group-assessment'), page);
+    await page.locator('div.page-encounter-types').waitFor({ timeout: 10000 });
 
-  const button = page.locator('button.encounter-type', { hasText: buttonText });
-  await expect(
-    button,
-    `"${buttonText}" button must be hidden when feature ${flagName} is off`,
-  ).toBeHidden();
+    const button = page.locator('button.encounter-type', { hasText: buttonText });
+    await expect(
+      button,
+      `"${buttonText}" button must be hidden when feature ${flagName} is off`,
+    ).toBeHidden();
 
-  setFeatureFlag(flagName, true);
-  await syncAndWait(page);
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'hidden');
+    }
 
-  await expect(
-    button,
-    `"${buttonText}" button must be visible when feature ${flagName} is on`,
-  ).toBeVisible();
+    setFeatureFlag(flagName, true);
+    await syncAndWait(page);
 
-  // Back: Group Encounter Types → Clinical → PinCode.
-  await click(page.locator('.link-back .icon-back'), page);
-  await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
-  await click(page.locator('.link-back .icon-back'), page);
-  await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+    await expect(
+      button,
+      `"${buttonText}" button must be visible when feature ${flagName} is on`,
+    ).toBeVisible();
+
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'visible');
+    }
+
+    // Back: Group Encounter Types → Clinical → PinCode.
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-clinical').waitFor({ timeout: 10000 });
+    await click(page.locator('.link-back .icon-back'), page);
+    await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
+  } finally {
+    setFeatureFlag(flagName, true);
+  }
 }
 
 /**
@@ -218,21 +371,34 @@ export async function verifyFeatureGatesPinCodeMenuIcon(
   page: Page,
   flagName: string,
   iconKey: string,
+  opts: FeatureGateOptions = {},
 ) {
-  setFeatureFlag(flagName, false);
-  await syncAndWait(page);
+  try {
+    setFeatureFlag(flagName, false);
+    await syncAndWait(page);
 
-  const icon = page.locator(`.icon-task-${iconKey}`);
-  await expect(
-    icon,
-    `.icon-task-${iconKey} must be hidden when feature ${flagName} is off`,
-  ).toBeHidden();
+    const icon = page.locator(`.icon-task-${iconKey}`);
+    await expect(
+      icon,
+      `.icon-task-${iconKey} must be hidden when feature ${flagName} is off`,
+    ).toBeHidden();
 
-  setFeatureFlag(flagName, true);
-  await syncAndWait(page);
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'hidden');
+    }
 
-  await expect(
-    icon,
-    `.icon-task-${iconKey} must be visible when feature ${flagName} is on`,
-  ).toBeVisible();
+    setFeatureFlag(flagName, true);
+    await syncAndWait(page);
+
+    await expect(
+      icon,
+      `.icon-task-${iconKey} must be visible when feature ${flagName} is on`,
+    ).toBeVisible();
+
+    if (opts.browser && opts.admin) {
+      await assertAdminGates(opts.browser, opts.admin, 'visible');
+    }
+  } finally {
+    setFeatureFlag(flagName, true);
+  }
 }

--- a/client/e2e/helpers/feature-flags.ts
+++ b/client/e2e/helpers/feature-flags.ts
@@ -398,7 +398,11 @@ export async function verifyFeatureGatesGroupEncounterButton(
     await click(page.locator('.link-back .icon-back'), page);
     await page.locator('div.page-pincode').waitFor({ timeout: 10000 });
   } finally {
+    // Restore both flags so cross-spec state doesn't leak. The helper
+    // forces partnerFlag ON for navigation, so we restore it alongside
+    // flagName to the project's default "all-on" state.
     setFeatureFlag(flagName, true);
+    setFeatureFlag(partnerFlag, true);
   }
 }
 

--- a/client/e2e/helpers/reports.ts
+++ b/client/e2e/helpers/reports.ts
@@ -7,6 +7,17 @@ import { WAIT } from './common';
 import { drushEnv } from './device';
 
 // ---------------------------------------------------------------------------
+// Health-center fixture IDs
+// ---------------------------------------------------------------------------
+
+/**
+ * Nyange Health Center node ID — fixed by the migration CSV
+ * (`hedley_migrate/csv/health_center_rwanda.csv`). Reused across specs that
+ * need a stable HC scope for admin Reports navigation.
+ */
+export const NYANGE_HC_ID = 4;
+
+// ---------------------------------------------------------------------------
 // DDEV URL resolution
 // ---------------------------------------------------------------------------
 

--- a/client/e2e/hiv-encounter-chw.spec.ts
+++ b/client/e2e/hiv-encounter-chw.spec.ts
@@ -44,9 +44,15 @@ test.describe('CHW: HIV Initial Encounter — Positive Diagnosis', () => {
   // Conditions: Initial encounter -> Diagnostics shown, SymptomReview NOT shown. No symptoms/adverse events -> Referral NOT triggered.
   // Backend: Verifies 5 node types created (diagnostics, medication, treatment_review, health_education, follow_up),
   //          confirms hiv_referral and hiv_symptom_review absent.
-  test('complete initial HIV encounter with positive diagnosis, verify backend sync', async ({ page }) => {
-    // Verify FeatureHIVManagement flag gates the "HIV Management" button.
-    await verifyFeatureGatesEncounterButton(page, 'hiv_management', 'HIV Management');
+  test('complete initial HIV encounter with positive diagnosis, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureHIVManagement flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'hiv_management', 'HIV Management', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['HIV'],
+        completionOptions: ['hiv'],
+      },
+    });
 
     const { fullName } = await createAdultAndStartHIVEncounter(page, {
       isFemale: false,

--- a/client/e2e/ncd-encounter-nurse.spec.ts
+++ b/client/e2e/ncd-encounter-nurse.spec.ts
@@ -43,9 +43,15 @@ test.describe('Nurse: NCD First Encounter — Male, Stage 1 Hypertension', () =>
     await setupDevice(page, '1234', 'Nyange Health Center');
   });
 
-  test('complete first NCD encounter with Stage 1 hypertension, verify backend sync', async ({ page }) => {
-    // Verify FeatureNCD flag gates the "Noncommunicable Diseases" button.
-    await verifyFeatureGatesEncounterButton(page, 'ncd', 'Noncommunicable Diseases');
+  test('complete first NCD encounter with Stage 1 hypertension, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureNCD flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'ncd', 'Noncommunicable Diseases', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['NCD'],
+        completionOptions: ['ncd'],
+      },
+    });
 
     const { fullName } = await createAdultAndStartNCDEncounter(page, {
       isFemale: false,

--- a/client/e2e/nutrition-encounter-chw.spec.ts
+++ b/client/e2e/nutrition-encounter-chw.spec.ts
@@ -46,9 +46,16 @@ test.describe('CHW: Individual Nutrition Encounter', () => {
   // since the measurement was explicitly skipped.
   test('normal encounter with height skipped via "Unable to take measurement" and backend sync', async ({
     page,
+    browser,
   }) => {
-    // Verify FeatureNutritionIndividual flag gates the "Child Nutrition" button.
-    await verifyFeatureGatesEncounterButton(page, 'nutrition_individual', 'Child Nutrition');
+    // Verify FeatureNutritionIndividual flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'nutrition_individual', 'Child Nutrition', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['Individual', 'Home Visit'],
+        completionOptions: ['nutrition-individual', 'home-visit'],
+      },
+    });
 
     const { fullName } = await createChildAndStartEncounter(page, {
       ageMonths: 24,

--- a/client/e2e/nutrition-encounter.spec.ts
+++ b/client/e2e/nutrition-encounter.spec.ts
@@ -3,7 +3,7 @@ import { click, setupDevice } from './helpers/auth';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
 import { WAIT, syncAndWait } from './helpers/common';
-import { verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
+import { assertAdminGates, setFeatureFlag, verifyFeatureGatesEncounterButton } from './helpers/feature-flags';
 import {
   createChildAndStartEncounter,
   completeNCDA,
@@ -35,9 +35,16 @@ test.describe('Nurse: Individual Nutrition Encounter', () => {
 
   test('complete normal encounter with NCDA and verify backend sync', async ({
     page,
+    browser,
   }) => {
-    // Verify FeatureNutritionIndividual flag gates the "Child Nutrition" button.
-    await verifyFeatureGatesEncounterButton(page, 'nutrition_individual', 'Child Nutrition');
+    // Verify FeatureNutritionIndividual flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'nutrition_individual', 'Child Nutrition', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['Individual', 'Home Visit'],
+        completionOptions: ['nutrition-individual', 'home-visit'],
+      },
+    });
 
     // Use age 10 months (< 24) so NCDA activity appears for nurse.
     const { fullName } = await createChildAndStartEncounter(page, {
@@ -197,5 +204,44 @@ test.describe('Nurse: Individual Nutrition Encounter', () => {
     expect(nodes.healthEducation, 'healthEducation node should exist').toBe(true);
     expect(nodes.contributingFactors, 'contributingFactors node should exist').toBe(true);
     expect(nodes.followUp, 'followUp node should exist').toBe(true);
+  });
+
+  // Compound gate: ReportNutrition (SQ dropdown value="nutrition") is hidden
+  // ONLY when ALL FOUR contributing data sources are off — Well Child,
+  // Nutrition Individual, Nutrition Group, Family Nutrition. Flipping any
+  // one of them back on must restore the dropdown entry. (See
+  // `visibleReportTypes` in server/elm/src/Pages/Reports/Utils.elm.)
+  test('Compound: SQ Nutrition dropdown gates on all four contributing sources', async ({ browser }) => {
+    const allFour = [
+      'well_child',
+      'nutrition_individual',
+      'nutrition_group',
+      'family_nutrition',
+    ] as const;
+
+    try {
+      // 1. All four OFF -> Nutrition option must disappear.
+      for (const flag of allFour) {
+        setFeatureFlag(flag, false);
+      }
+      await assertAdminGates(
+        browser,
+        { sqOptions: ['nutrition'] },
+        'hidden',
+      );
+
+      // 2. Flip ONE back ON -> Nutrition option must return.
+      setFeatureFlag('nutrition_individual', true);
+      await assertAdminGates(
+        browser,
+        { sqOptions: ['nutrition'] },
+        'visible',
+      );
+    } finally {
+      // Restore all four to ON regardless of assertion outcome.
+      for (const flag of allFour) {
+        setFeatureFlag(flag, true);
+      }
+    }
   });
 });

--- a/client/e2e/prenatal-encounter-chw.spec.ts
+++ b/client/e2e/prenatal-encounter-chw.spec.ts
@@ -42,7 +42,7 @@ test.describe('CHW: Prenatal First Encounter', () => {
       browser,
       admin: {
         sqOptions: ['peripartum', 'prenatal', 'prenatal-contacts', 'prenatal-diagnoses'],
-        sqDemographicsRows: ['ANC Total'],
+        sqDemographicsRows: ['ANC (total)'],
         completionOptions: ['prenatal'],
       },
     });

--- a/client/e2e/prenatal-encounter-chw.spec.ts
+++ b/client/e2e/prenatal-encounter-chw.spec.ts
@@ -36,9 +36,16 @@ test.describe('CHW: Prenatal First Encounter', () => {
     await setupDevice(page, '2345', 'Akanduga');
   });
 
-  test('complete all activities and verify backend sync', async ({ page }) => {
-    // Verify FeatureAntenatal flag gates the "Antenatal Care" button.
-    await verifyFeatureGatesEncounterButton(page, 'antenatal', 'Antenatal Care');
+  test('complete all activities and verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureAntenatal flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'antenatal', 'Antenatal Care', {
+      browser,
+      admin: {
+        sqOptions: ['peripartum', 'prenatal', 'prenatal-contacts', 'prenatal-diagnoses'],
+        sqDemographicsRows: ['ANC Total'],
+        completionOptions: ['prenatal'],
+      },
+    });
 
     // LMP date ~30 weeks ago.
     const lmpDate = new Date();

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -48,12 +48,19 @@ test.describe('Nurse: Prenatal Initial Encounter', () => {
     await setupDevice(page, '1234', 'Nyange Health Center');
   });
 
-  test('complete all activities and verify backend sync', async ({ page }) => {
+  test('complete all activities and verify backend sync', async ({ page, browser }) => {
     // Nurse initial encounter completes 12+ activities; needs more than the default 2m.
     test.setTimeout(600000);
 
-    // Verify FeatureAntenatal flag gates the "Antenatal Care" button.
-    await verifyFeatureGatesEncounterButton(page, 'antenatal', 'Antenatal Care');
+    // Verify FeatureAntenatal flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'antenatal', 'Antenatal Care', {
+      browser,
+      admin: {
+        sqOptions: ['peripartum', 'prenatal', 'prenatal-contacts', 'prenatal-diagnoses'],
+        sqDemographicsRows: ['ANC Total'],
+        completionOptions: ['prenatal'],
+      },
+    });
 
     // LMP date ~30 weeks ago — ensures EGA >= 28w for MentalHealth,
     // >= 13w for MalariaPrevention, and triggers all Medication tabs.

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -57,7 +57,7 @@ test.describe('Nurse: Prenatal Initial Encounter', () => {
       browser,
       admin: {
         sqOptions: ['peripartum', 'prenatal', 'prenatal-contacts', 'prenatal-diagnoses'],
-        sqDemographicsRows: ['ANC Total'],
+        sqDemographicsRows: ['ANC (total)'],
         completionOptions: ['prenatal'],
       },
     });

--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -59,6 +59,7 @@ import {
   findScoreboardValue,
   getCurrentMonthColumnIndex,
   ScoreboardPaneData,
+  NYANGE_HC_ID,
 } from './helpers/reports';
 
 // Encounter creation helpers.
@@ -208,9 +209,6 @@ import {
 } from './helpers/group-session';
 
 const pwaBaseUrl = `http://localhost:${getClientPort()}`;
-
-// Nyange Health Center node ID (from migration CSV).
-const NYANGE_HC_ID = 4;
 
 // Start date for report filtering — early enough to include all data.
 // Constructed in UTC because the calendar helper reads via getUTC*; using

--- a/client/e2e/tuberculosis-encounter-chw.spec.ts
+++ b/client/e2e/tuberculosis-encounter-chw.spec.ts
@@ -46,9 +46,15 @@ test.describe('CHW: Tuberculosis Initial Encounter — Positive Diagnosis', () =
   //             No symptoms/adverse events -> Referral NOT triggered.
   // Backend: Verifies 6 node types created (diagnostics, medication, dot, treatment_review,
   //          health_education, follow_up), confirms symptom_review and referral absent.
-  test('complete initial TB encounter with positive pulmonary diagnosis, verify backend sync', async ({ page }) => {
-    // Verify FeatureTuberculosisManagement flag gates the "TB Management" button.
-    await verifyFeatureGatesEncounterButton(page, 'tuberculosis_management', 'TB Management');
+  test('complete initial TB encounter with positive pulmonary diagnosis, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureTuberculosisManagement flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'tuberculosis_management', 'TB Management', {
+      browser,
+      admin: {
+        sqDemographicsRows: ['Tuberculosis'],
+        completionOptions: ['tuberculosis'],
+      },
+    });
 
     const { fullName } = await createAdultAndStartTBEncounter(page, {
       isFemale: false,

--- a/client/e2e/well-child-encounter-chw.spec.ts
+++ b/client/e2e/well-child-encounter-chw.spec.ts
@@ -41,9 +41,16 @@ test.describe('CHW: Well Child NewbornExam Encounter', () => {
     await setupDevice(page, '2345', 'Akanduga');
   });
 
-  test('complete newborn exam with PregnancySummary, NutritionAssessment, Immunisation, verify backend sync', async ({ page }) => {
-    // Verify FeatureWellChild flag gates the "Well Child Visit" button (CHW-side).
-    await verifyFeatureGatesEncounterButton(page, 'well_child', 'Well Child Visit');
+  test('complete newborn exam with PregnancySummary, NutritionAssessment, Immunisation, verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureWellChild flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'well_child', 'Well Child Visit', {
+      browser,
+      admin: {
+        sqOptions: ['postnatal-care'],
+        sqDemographicsRows: ['Standard Pediatric Visit'],
+        completionOptions: ['newborn-exam', 'well-child'],
+      },
+    });
 
     const { fullName } = await createChildAndStartWellChildEncounter(page, {
       ageMonths: 1,

--- a/client/e2e/well-child-encounter-nurse.spec.ts
+++ b/client/e2e/well-child-encounter-nurse.spec.ts
@@ -35,9 +35,16 @@ test.describe('Nurse: Well Child PediatricCare — Normal Encounter', () => {
     await setupDevice(page, '1234', 'Nyange Health Center');
   });
 
-  test('complete normal encounter with all mandatory activities and verify backend sync', async ({ page }) => {
-    // Verify FeatureWellChild flag gates the "Standard Pediatric Visit" button (nurse-side).
-    await verifyFeatureGatesEncounterButton(page, 'well_child', 'Standard Pediatric Visit');
+  test('complete normal encounter with all mandatory activities and verify backend sync', async ({ page, browser }) => {
+    // Verify FeatureWellChild flag gates client UI + admin Reports surfaces.
+    await verifyFeatureGatesEncounterButton(page, 'well_child', 'Standard Pediatric Visit', {
+      browser,
+      admin: {
+        sqOptions: ['postnatal-care'],
+        sqDemographicsRows: ['Standard Pediatric Visit'],
+        completionOptions: ['newborn-exam', 'well-child'],
+      },
+    });
 
     // Use 23 months (< 24) so NCDA activity appears for nurse.
     const { fullName } = await createChildAndStartWellChildEncounter(page, {

--- a/server/elm/src/Backend/Completion/Decoder.elm
+++ b/server/elm/src/Backend/Completion/Decoder.elm
@@ -3,7 +3,7 @@ module Backend.Completion.Decoder exposing (decodeCompletionData, decodeSyncResp
 import Backend.Completion.Model exposing (ActivitiesCompletionData, CompletionData, EncounterData, NutritionGroupEncounterData, SyncResponse, TakenBy(..), WellChildEncounterData, WellChildEncounterType(..))
 import Backend.Completion.Utils exposing (acuteIllnessActivityFromMapping, childScoreboardActivityFromMapping, hivActivityFromMapping, homeVisitActivityFromMapping, ncdActivityFromMapping, nutritionChildActivityFromMapping, nutritionMotherActivityFromMapping, prenatalActivityFromMapping, takenByFromString, tuberculosisActivityFromMapping, wellChildActivityFromMapping)
 import Backend.Components.Decoder exposing (decodeReportParams, decodeSelectedEntity)
-import Backend.Decoder exposing (decodeSite, decodeWithFallback)
+import Backend.Decoder exposing (decodeSite, decodeSiteFeatures, decodeWithFallback)
 import Gizra.Json exposing (decodeInt)
 import Gizra.NominalDate exposing (decodeYYYYMMDD)
 import Json.Decode exposing (Decoder, andThen, fail, field, list, map, nullable, oneOf, string, succeed)
@@ -14,6 +14,7 @@ decodeCompletionData : Decoder CompletionData
 decodeCompletionData =
     succeed CompletionData
         |> required "site" decodeSite
+        |> required "features" decodeSiteFeatures
         |> required "entity_name" string
         |> required "entity_type" decodeSelectedEntity
         |> required "params" decodeReportParams

--- a/server/elm/src/Backend/Completion/Model.elm
+++ b/server/elm/src/Backend/Completion/Model.elm
@@ -1,7 +1,8 @@
 module Backend.Completion.Model exposing (ActivitiesCompletionData, AcuteIllnessActivity(..), ChildScoreboardActivity(..), CompletionData, EncounterData, HIVActivity(..), HomeVisitActivity(..), Msg(..), NCDActivity(..), NutritionChildActivity(..), NutritionGroupEncounterData, NutritionMotherActivity(..), PrenatalActivity(..), SyncResponse, TakenBy(..), TuberculosisActivity(..), WellChildActivity(..), WellChildEncounterData, WellChildEncounterType(..))
 
-import App.Types exposing (Site)
+import App.Types exposing (Site, SiteFeature)
 import Backend.Components.Model exposing (ReportParams, SelectedEntity)
+import EverySet exposing (EverySet)
 import Gizra.NominalDate exposing (NominalDate)
 import Json.Encode exposing (Value)
 import RemoteData exposing (WebData)
@@ -9,6 +10,7 @@ import RemoteData exposing (WebData)
 
 type alias CompletionData =
     { site : Site
+    , features : EverySet SiteFeature
     , entityName : String
     , entityType : SelectedEntity
     , params : ReportParams

--- a/server/elm/src/Pages/Completion/Utils.elm
+++ b/server/elm/src/Pages/Completion/Utils.elm
@@ -1,6 +1,6 @@
-module Pages.Completion.Utils exposing (allAcuteIllnessActivities, allHIVActivities, allHomeVisitActivities, allNCDActivities, allNutritionChildGroupActivities, allNutritionIndividualActivities, allNutritionMotherGroupActivities, allPrenatalActivities, allTuberculosisActivities, newbornExamActivities, reportTypeFromString, reportTypeToString, resolveChildScoreboardActivities, resolveSPVActivities)
+module Pages.Completion.Utils exposing (allAcuteIllnessActivities, allHIVActivities, allHomeVisitActivities, allNCDActivities, allNutritionChildGroupActivities, allNutritionIndividualActivities, allNutritionMotherGroupActivities, allPrenatalActivities, allTuberculosisActivities, newbornExamActivities, reportTypeFromString, reportTypeToString, resolveChildScoreboardActivities, resolveSPVActivities, visibleReportTypes)
 
-import App.Types exposing (Site(..))
+import App.Types exposing (Site(..), SiteFeature(..))
 import Backend.Completion.Model
     exposing
         ( AcuteIllnessActivity(..)
@@ -14,6 +14,7 @@ import Backend.Completion.Model
         , TuberculosisActivity(..)
         , WellChildActivity(..)
         )
+import EverySet exposing (EverySet)
 import Pages.Completion.Model exposing (ReportType(..))
 
 
@@ -357,3 +358,63 @@ allPrenatalActivities =
     , PrenatalVitals
     , PrenatalVitalsRecheck
     ]
+
+
+{-| Filter the Completion report-type list down to entries whose driving
+encounter feature is enabled. Each Completion subtype maps to a single
+encounter type, so gating is one feature per entry.
+-}
+visibleReportTypes : EverySet SiteFeature -> List ReportType
+visibleReportTypes features =
+    let
+        member f =
+            EverySet.member f features
+    in
+    List.filter
+        (\reportType ->
+            case reportType of
+                ReportAcuteIllness ->
+                    member FeatureAcuteIllness
+
+                ReportPrenatal ->
+                    member FeatureAntenatal
+
+                ReportChildScoreboard ->
+                    member FeatureNCDA
+
+                ReportHIV ->
+                    member FeatureHIVManagement
+
+                ReportHomeVisit ->
+                    member FeatureNutritionIndividual
+
+                ReportNCD ->
+                    member FeatureNCD
+
+                ReportNewbornExam ->
+                    member FeatureWellChild
+
+                ReportNutritionGroup ->
+                    member FeatureNutritionGroup
+
+                ReportNutritionIndividual ->
+                    member FeatureNutritionIndividual
+
+                ReportWellChild ->
+                    member FeatureWellChild
+
+                ReportTuberculosis ->
+                    member FeatureTuberculosisManagement
+        )
+        [ ReportAcuteIllness
+        , ReportPrenatal
+        , ReportChildScoreboard
+        , ReportHIV
+        , ReportHomeVisit
+        , ReportNCD
+        , ReportNewbornExam
+        , ReportNutritionGroup
+        , ReportNutritionIndividual
+        , ReportWellChild
+        , ReportTuberculosis
+        ]

--- a/server/elm/src/Pages/Completion/View.elm
+++ b/server/elm/src/Pages/Completion/View.elm
@@ -32,7 +32,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 import Maybe.Extra exposing (isJust, isNothing)
 import Pages.Completion.Model exposing (Model, Msg(..), ReportType(..))
-import Pages.Completion.Utils exposing (allAcuteIllnessActivities, allHIVActivities, allHomeVisitActivities, allNCDActivities, allNutritionChildGroupActivities, allNutritionIndividualActivities, allNutritionMotherGroupActivities, allPrenatalActivities, allTuberculosisActivities, newbornExamActivities, reportTypeToString, resolveChildScoreboardActivities, resolveSPVActivities)
+import Pages.Completion.Utils exposing (allAcuteIllnessActivities, allHIVActivities, allHomeVisitActivities, allNCDActivities, allNutritionChildGroupActivities, allNutritionIndividualActivities, allNutritionMotherGroupActivities, allPrenatalActivities, allTuberculosisActivities, newbornExamActivities, reportTypeToString, resolveChildScoreboardActivities, resolveSPVActivities, visibleReportTypes)
 import Pages.Components.Utils exposing (isSyncComplete, viewSyncingPlaceholder)
 import Pages.Components.View exposing (viewMetricsResultsTable)
 import Pages.Model exposing (MetricsResultsTableData)
@@ -247,18 +247,7 @@ viewCompletionData language currentDate data model =
                 div [ class "inputs" ] <|
                     [ viewSelectListInput language
                         model.reportType
-                        [ ReportAcuteIllness
-                        , ReportPrenatal
-                        , ReportChildScoreboard
-                        , ReportHIV
-                        , ReportHomeVisit
-                        , ReportNCD
-                        , ReportNewbornExam
-                        , ReportNutritionGroup
-                        , ReportNutritionIndividual
-                        , ReportWellChild
-                        , ReportTuberculosis
-                        ]
+                        (visibleReportTypes data.features)
                         reportTypeToString
                         SetReportType
                         Translate.CompletionReportType

--- a/server/elm/src/Pages/Reports/Update.elm
+++ b/server/elm/src/Pages/Reports/Update.elm
@@ -2,11 +2,13 @@ module Pages.Reports.Update exposing (update)
 
 import App.Model exposing (PagesReturn)
 import App.Ports
+import App.Types exposing (SiteFeature(..))
 import AssocList as Dict
 import Backend.Model exposing (ModelBackend)
 import Backend.Reports.Model exposing (PatientData)
 import Date exposing (Unit(..))
 import Error.Utils exposing (noError)
+import EverySet exposing (EverySet)
 import Gizra.NominalDate exposing (NominalDate)
 import Maybe.Extra
 import Pages.Reports.Model exposing (Model, Msg(..), NutritionReportData, ReportType(..))
@@ -36,7 +38,7 @@ update currentDate modelBackend msg model =
                                     ( model.nutritionReportData, Cmd.none )
 
                                 else
-                                    ( Loading, performNutritionReportDataCalculation currentDate data.records )
+                                    ( Loading, performNutritionReportDataCalculation currentDate data.features data.records )
 
                             _ ->
                                 ( model.nutritionReportData, Cmd.none )
@@ -106,16 +108,31 @@ update currentDate modelBackend msg model =
                 []
 
 
-performNutritionReportDataCalculation : NominalDate -> List PatientData -> Cmd Msg
-performNutritionReportDataCalculation currentDate data =
+performNutritionReportDataCalculation : NominalDate -> EverySet SiteFeature -> List PatientData -> Cmd Msg
+performNutritionReportDataCalculation currentDate features data =
     Task.perform (Result.mapError (always "Calculations failed") >> NutritionReportDataCalculationCompleted)
-        (wrapInResultTask <| calculateNutritionReportDataTask currentDate data)
+        (wrapInResultTask <| calculateNutritionReportDataTask currentDate features data)
 
 
-calculateNutritionReportDataTask : NominalDate -> List PatientData -> Task String NutritionReportData
-calculateNutritionReportDataTask currentDate data =
+calculateNutritionReportDataTask : NominalDate -> EverySet SiteFeature -> List PatientData -> Task String NutritionReportData
+calculateNutritionReportDataTask currentDate features data =
     Task.succeed
         (let
+            memberFeature f =
+                EverySet.member f features
+
+            wellChildEnabled =
+                memberFeature FeatureWellChild
+
+            nutritionIndividualEnabled =
+                memberFeature FeatureNutritionIndividual
+
+            nutritionGroupEnabled =
+                memberFeature FeatureNutritionGroup
+
+            familyNutritionEnabled =
+                memberFeature FeatureFamilyNutrition
+
             records =
                 List.filter
                     (\record ->
@@ -143,60 +160,74 @@ calculateNutritionReportDataTask currentDate data =
             filterByYear encounter =
                 Date.year encounter.startDate >= startingYear
 
+            seriesIf flag series =
+                if flag then
+                    series
+
+                else
+                    Nothing
+
             allEncounters =
                 List.concatMap
                     (\record ->
-                        [ Maybe.map
-                            (List.concat
-                                >> List.filter filterByYear
-                                >> List.map
-                                    (\item ->
-                                        -- WellChildEncounterData mirrors NutritionEncounterData's
-                                        -- shape (date, nutritionData, muacCm) plus immunisationData;
-                                        -- well-child wire doesn't carry edema or FBF distribution
-                                        -- today, so default both to absent.
-                                        ( record.id
-                                        , { startDate = item.startDate
-                                          , nutritionData = item.nutritionData
-                                          , muacCm = item.muacCm
-                                          , hasEdema = False
-                                          , fbfAmount = Nothing
-                                          }
+                        [ seriesIf wellChildEnabled <|
+                            Maybe.map
+                                (List.concat
+                                    >> List.filter filterByYear
+                                    >> List.map
+                                        (\item ->
+                                            -- WellChildEncounterData mirrors NutritionEncounterData's
+                                            -- shape (date, nutritionData, muacCm) plus immunisationData;
+                                            -- well-child wire doesn't carry edema or FBF distribution
+                                            -- today, so default both to absent.
+                                            ( record.id
+                                            , { startDate = item.startDate
+                                              , nutritionData = item.nutritionData
+                                              , muacCm = item.muacCm
+                                              , hasEdema = False
+                                              , fbfAmount = Nothing
+                                              }
+                                            )
                                         )
-                                    )
-                            )
-                            record.wellChildData
-                        , Maybe.map
-                            (List.concat
-                                >> List.filter filterByYear
-                                >> List.map (Tuple.pair record.id)
-                            )
-                            record.individualNutritionData
-                        , Maybe.map
-                            (List.filter filterByYear
-                                >> List.map (Tuple.pair record.id)
-                            )
-                            record.groupNutritionPmtctData
-                        , Maybe.map
-                            (List.filter filterByYear
-                                >> List.map (Tuple.pair record.id)
-                            )
-                            record.groupNutritionFbfData
-                        , Maybe.map
-                            (List.filter filterByYear
-                                >> List.map (Tuple.pair record.id)
-                            )
-                            record.groupNutritionSorwatheData
-                        , Maybe.map
-                            (List.filter filterByYear
-                                >> List.map (Tuple.pair record.id)
-                            )
-                            record.groupNutritionChwData
-                        , Maybe.map
-                            (List.filter filterByYear
-                                >> List.map (Tuple.pair record.id)
-                            )
-                            record.groupNutritionAchiData
+                                )
+                                record.wellChildData
+                        , seriesIf nutritionIndividualEnabled <|
+                            Maybe.map
+                                (List.concat
+                                    >> List.filter filterByYear
+                                    >> List.map (Tuple.pair record.id)
+                                )
+                                record.individualNutritionData
+                        , seriesIf nutritionGroupEnabled <|
+                            Maybe.map
+                                (List.filter filterByYear
+                                    >> List.map (Tuple.pair record.id)
+                                )
+                                record.groupNutritionPmtctData
+                        , seriesIf nutritionGroupEnabled <|
+                            Maybe.map
+                                (List.filter filterByYear
+                                    >> List.map (Tuple.pair record.id)
+                                )
+                                record.groupNutritionFbfData
+                        , seriesIf nutritionGroupEnabled <|
+                            Maybe.map
+                                (List.filter filterByYear
+                                    >> List.map (Tuple.pair record.id)
+                                )
+                                record.groupNutritionSorwatheData
+                        , seriesIf nutritionGroupEnabled <|
+                            Maybe.map
+                                (List.filter filterByYear
+                                    >> List.map (Tuple.pair record.id)
+                                )
+                                record.groupNutritionChwData
+                        , seriesIf nutritionGroupEnabled <|
+                            Maybe.map
+                                (List.filter filterByYear
+                                    >> List.map (Tuple.pair record.id)
+                                )
+                                record.groupNutritionAchiData
                         ]
                             |> Maybe.Extra.values
                             |> List.concat
@@ -213,17 +244,21 @@ calculateNutritionReportDataTask currentDate data =
             -- above, and the Demographics row already counts them
             -- elsewhere.
             familyNutritionEncounters =
-                List.concatMap
-                    (\record ->
-                        record.familyNutritionMuacData
-                            |> Maybe.map
-                                (List.concat
-                                    >> List.filter filterByYear
-                                    >> List.map (Tuple.pair record.id)
-                                )
-                            |> Maybe.withDefault []
-                    )
-                    records
+                if familyNutritionEnabled then
+                    List.concatMap
+                        (\record ->
+                            record.familyNutritionMuacData
+                                |> Maybe.map
+                                    (List.concat
+                                        >> List.filter filterByYear
+                                        >> List.map (Tuple.pair record.id)
+                                    )
+                                |> Maybe.withDefault []
+                        )
+                        records
+
+                else
+                    []
 
             insertMetricsForMonth ( year, month ) encounterMetrics accum =
                 let

--- a/server/elm/src/Pages/Reports/Utils.elm
+++ b/server/elm/src/Pages/Reports/Utils.elm
@@ -571,8 +571,13 @@ allVaccineTypes site =
 have a meaningful data domain on this deployment. Reports whose sole data
 source is feature-gated drop out when that feature is disabled.
 
-`ReportDemographics` and `ReportFBFDistribution` always show — they are
-multi-source and apply row-level filters internally.
+`ReportDemographics` always shows — it is multi-source and applies row-level
+filters internally.
+
+`ReportFBFDistribution` shows when at least one of its two contributing
+sources (`FeatureNutritionGroup` for FBF rows, `FeatureFamilyNutrition` for
+Aheza rows) is enabled; rows are filtered per feature inside
+`visibleFbfDistributionCategories`.
 
 `ReportNutrition` shows when at least one of its four contributing sources
 is enabled.
@@ -594,7 +599,7 @@ visibleReportTypes features =
                     True
 
                 ReportFBFDistribution ->
-                    True
+                    member FeatureNutritionGroup || member FeatureFamilyNutrition
 
                 ReportNutrition ->
                     member FeatureWellChild

--- a/server/elm/src/Pages/Reports/Utils.elm
+++ b/server/elm/src/Pages/Reports/Utils.elm
@@ -1,11 +1,12 @@
-module Pages.Reports.Utils exposing (allVaccineTypes, countTotalEncounters, countTotalNutritionEncounters, eddToLmpDate, familyNutritionEncounterToMetrics, generateIncidenceNutritionMetricsResults, generatePrevalenceNutritionMetricsResults, isWideScope, nutritionEncounterDataToNutritionMetrics, prenatalContactTypeToEncountersAtWeek, reportTypeFromString, reportTypeToString, resolveDataSetForMonth, resolveDataSetForQuarter, resolveDataSetForYear, resolvePregnancyTrimester, resolvePreviousDataSetForMonth, sumNutritionMetrics)
+module Pages.Reports.Utils exposing (allVaccineTypes, countTotalEncounters, countTotalNutritionEncounters, eddToLmpDate, familyNutritionEncounterToMetrics, generateIncidenceNutritionMetricsResults, generatePrevalenceNutritionMetricsResults, isWideScope, nutritionEncounterDataToNutritionMetrics, prenatalContactTypeToEncountersAtWeek, reportTypeFromString, reportTypeToString, resolveDataSetForMonth, resolveDataSetForQuarter, resolveDataSetForYear, resolvePregnancyTrimester, resolvePreviousDataSetForMonth, sumNutritionMetrics, visibleReportTypes)
 
-import App.Types exposing (Site(..))
+import App.Types exposing (Site(..), SiteFeature(..))
 import AssocList as Dict exposing (Dict)
 import Backend.Components.Model exposing (PersonId, SelectedEntity(..))
 import Backend.Reports.Model exposing (FamilyNutritionEncounterData, NutritionEncounterData, PatientData)
 import Backend.Scoreboard.Model exposing (VaccineType(..))
 import Date exposing (Unit(..))
+import EverySet exposing (EverySet)
 import Gizra.NominalDate exposing (NominalDate, diffDays)
 import List.Extra exposing (unique)
 import Maybe.Extra
@@ -564,3 +565,65 @@ allVaccineTypes site =
 
         _ ->
             common ++ [ VaccineHPV ]
+
+
+{-| Filter the Statistical Queries report-type list down to the entries that
+have a meaningful data domain on this deployment. Reports whose sole data
+source is feature-gated drop out when that feature is disabled.
+
+`ReportDemographics` and `ReportFBFDistribution` always show — they are
+multi-source and apply row-level filters internally.
+
+`ReportNutrition` shows when at least one of its four contributing sources
+is enabled.
+
+-}
+visibleReportTypes : EverySet SiteFeature -> List ReportType
+visibleReportTypes features =
+    let
+        member f =
+            EverySet.member f features
+    in
+    List.filter
+        (\reportType ->
+            case reportType of
+                ReportAcuteIllness ->
+                    member FeatureAcuteIllness
+
+                ReportDemographics ->
+                    True
+
+                ReportFBFDistribution ->
+                    True
+
+                ReportNutrition ->
+                    member FeatureWellChild
+                        || member FeatureNutritionIndividual
+                        || member FeatureNutritionGroup
+                        || member FeatureFamilyNutrition
+
+                ReportPeripartum ->
+                    member FeatureAntenatal
+
+                ReportPostnatalCare ->
+                    member FeatureWellChild
+
+                ReportPrenatal ->
+                    member FeatureAntenatal
+
+                ReportPrenatalContacts ->
+                    member FeatureAntenatal
+
+                ReportPrenatalDiagnoses ->
+                    member FeatureAntenatal
+        )
+        [ ReportAcuteIllness
+        , ReportDemographics
+        , ReportFBFDistribution
+        , ReportNutrition
+        , ReportPeripartum
+        , ReportPostnatalCare
+        , ReportPrenatal
+        , ReportPrenatalContacts
+        , ReportPrenatalDiagnoses
+        ]

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -2900,14 +2900,19 @@ viewFBFDistributionReport language features limitDate scopeLabel records =
         ]
 
 
-{-| Aheza categories are family-nutrition-only, so they are dropped when the
-feature is disabled. FBF categories always show.
+{-| FBF categories are group-nutrition-only and Aheza categories are
+family-nutrition-only; each set drops out when its driving feature is off.
+The dropdown itself is hidden when both features are off — see
+`visibleReportTypes`.
 -}
 visibleFbfDistributionCategories : EverySet SiteFeature -> List FbfDistributionCategory
 visibleFbfDistributionCategories features =
     let
         familyNutritionEnabled =
             EverySet.member FeatureFamilyNutrition features
+
+        nutritionGroupEnabled =
+            EverySet.member FeatureNutritionGroup features
     in
     List.filter
         (\category ->
@@ -2919,13 +2924,13 @@ visibleFbfDistributionCategories features =
                     familyNutritionEnabled
 
                 FbfDistributionFbfChild ->
-                    True
+                    nutritionGroupEnabled
 
                 FbfDistributionFbfChildAchi ->
-                    True
+                    nutritionGroupEnabled
 
                 FbfDistributionFbfMother ->
-                    True
+                    nutritionGroupEnabled
         )
         allFbfDistributionCategories
 

--- a/server/elm/src/Pages/Reports/View.elm
+++ b/server/elm/src/Pages/Reports/View.elm
@@ -44,7 +44,7 @@ import Pages.Components.Utils exposing (isSyncComplete, viewSyncingPlaceholder)
 import Pages.Components.View exposing (viewMetricsResultsTable, viewStandardCells, viewStandardRow)
 import Pages.Model exposing (MetricsResultsTableData)
 import Pages.Reports.Model exposing (FbfDistributionCategory(..), Model, Msg(..), NutritionMetrics, NutritionMetricsResults, NutritionReportData, PregnancyTrimester(..), PrenatalContactType(..), ReportType(..), allFbfDistributionCategories, emptyNutritionMetrics)
-import Pages.Reports.Utils exposing (allVaccineTypes, countTotalEncounters, eddToLmpDate, generateIncidenceNutritionMetricsResults, generatePrevalenceNutritionMetricsResults, isWideScope, prenatalContactTypeToEncountersAtWeek, reportTypeToString, resolveDataSetForMonth, resolveDataSetForQuarter, resolveDataSetForYear, resolvePregnancyTrimester, resolvePreviousDataSetForMonth)
+import Pages.Reports.Utils exposing (allVaccineTypes, countTotalEncounters, eddToLmpDate, generateIncidenceNutritionMetricsResults, generatePrevalenceNutritionMetricsResults, isWideScope, prenatalContactTypeToEncountersAtWeek, reportTypeToString, resolveDataSetForMonth, resolveDataSetForQuarter, resolveDataSetForYear, resolvePregnancyTrimester, resolvePreviousDataSetForMonth, visibleReportTypes)
 import Pages.Scoreboard.Utils exposing (generateFutureVaccinationsData)
 import Pages.Utils
     exposing
@@ -345,16 +345,7 @@ viewReportsData language currentDate themePath data model =
                 div [ class "inputs" ] <|
                     (viewSelectListInput language
                         model.reportType
-                        ([ ReportAcuteIllness
-                         , ReportDemographics
-                         , ReportFBFDistribution
-                         , ReportNutrition
-                         , ReportPeripartum
-                         , ReportPostnatalCare
-                         , ReportPrenatal
-                         , ReportPrenatalContacts
-                         , ReportPrenatalDiagnoses
-                         ]
+                        (visibleReportTypes data.features
                             |> List.sortBy (\rt -> String.toLower (translate language (Translate.ReportType rt)))
                         )
                         reportTypeToString
@@ -707,31 +698,74 @@ generateDemographicsReportEncountersData :
         }
 generateDemographicsReportEncountersData language features records =
     let
+        memberFeature f =
+            EverySet.member f features
+
+        antenatalEnabled =
+            memberFeature FeatureAntenatal
+
+        acuteIllnessEnabled =
+            memberFeature FeatureAcuteIllness
+
+        wellChildEnabled =
+            memberFeature FeatureWellChild
+
+        nutritionIndividualEnabled =
+            memberFeature FeatureNutritionIndividual
+
+        nutritionGroupEnabled =
+            memberFeature FeatureNutritionGroup
+
+        ncdEnabled =
+            memberFeature FeatureNCD
+
+        ncdaEnabled =
+            memberFeature FeatureNCDA
+
+        hivEnabled =
+            memberFeature FeatureHIVManagement
+
+        tuberculosisEnabled =
+            memberFeature FeatureTuberculosisManagement
+
+        familyNutritionEnabled =
+            memberFeature FeatureFamilyNutrition
+
+        nutritionAggregateEnabled =
+            nutritionIndividualEnabled || nutritionGroupEnabled
+
+        loadEncountersIf flag loader =
+            if flag then
+                loader records
+
+            else
+                []
+
         prenatalDataNurseEncounters =
-            List.filterMap
-                (.prenatalData
-                    >> Maybe.map
-                        (List.concatMap .encounters
-                            >> List.filter
-                                (\encounter ->
-                                    List.member encounter.encounterType [ NurseEncounter, NursePostpartumEncounter ]
-                                )
-                        )
-                )
-                records
+            loadEncountersIf antenatalEnabled <|
+                List.filterMap
+                    (.prenatalData
+                        >> Maybe.map
+                            (List.concatMap .encounters
+                                >> List.filter
+                                    (\encounter ->
+                                        List.member encounter.encounterType [ NurseEncounter, NursePostpartumEncounter ]
+                                    )
+                            )
+                    )
 
         prenatalDataChwEncounters =
-            List.filterMap
-                (.prenatalData
-                    >> Maybe.map
-                        (List.concatMap .encounters
-                            >> List.filter
-                                (\encounter ->
-                                    not <| List.member encounter.encounterType [ NurseEncounter, NursePostpartumEncounter ]
-                                )
-                        )
-                )
-                records
+            loadEncountersIf antenatalEnabled <|
+                List.filterMap
+                    (.prenatalData
+                        >> Maybe.map
+                            (List.concatMap .encounters
+                                >> List.filter
+                                    (\encounter ->
+                                        not <| List.member encounter.encounterType [ NurseEncounter, NursePostpartumEncounter ]
+                                    )
+                            )
+                    )
 
         prenatalDataNurseEncountersTotal =
             countTotal prenatalDataNurseEncounters
@@ -746,30 +780,30 @@ generateDemographicsReportEncountersData language features records =
             countUnique prenatalDataChwEncounters
 
         acuteIllnessDataNurseEncounters =
-            List.filterMap
-                (.acuteIllnessData
-                    >> Maybe.map
-                        (List.concat
-                            >> List.filter
-                                (\encounter ->
-                                    List.member encounter.encounterType [ AcuteIllnessEncounterNurse, AcuteIllnessEncounterNurseSubsequent ]
-                                )
-                        )
-                )
-                records
+            loadEncountersIf acuteIllnessEnabled <|
+                List.filterMap
+                    (.acuteIllnessData
+                        >> Maybe.map
+                            (List.concat
+                                >> List.filter
+                                    (\encounter ->
+                                        List.member encounter.encounterType [ AcuteIllnessEncounterNurse, AcuteIllnessEncounterNurseSubsequent ]
+                                    )
+                            )
+                    )
 
         acuteIllnessDataChwEncounters =
-            List.filterMap
-                (.acuteIllnessData
-                    >> Maybe.map
-                        (List.concat
-                            >> List.filter
-                                (\encounter ->
-                                    not <| List.member encounter.encounterType [ AcuteIllnessEncounterNurse, AcuteIllnessEncounterNurseSubsequent ]
-                                )
-                        )
-                )
-                records
+            loadEncountersIf acuteIllnessEnabled <|
+                List.filterMap
+                    (.acuteIllnessData
+                        >> Maybe.map
+                            (List.concat
+                                >> List.filter
+                                    (\encounter ->
+                                        not <| List.member encounter.encounterType [ AcuteIllnessEncounterNurse, AcuteIllnessEncounterNurseSubsequent ]
+                                    )
+                            )
+                    )
 
         acuteIllnessDataNurseEncountersTotal =
             countTotal acuteIllnessDataNurseEncounters
@@ -784,9 +818,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique acuteIllnessDataChwEncounters
 
         wellChildEncountersData =
-            List.filterMap
-                (.wellChildData >> Maybe.map List.concat)
-                records
+            loadEncountersIf wellChildEnabled <|
+                List.filterMap
+                    (.wellChildData >> Maybe.map List.concat)
 
         wellChildDataEncountersTotal =
             countTotal wellChildEncountersData
@@ -795,9 +829,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique wellChildEncountersData
 
         homeVisitEncountersData =
-            List.filterMap
-                (.homeVisitData >> Maybe.map List.concat)
-                records
+            loadEncountersIf nutritionIndividualEnabled <|
+                List.filterMap
+                    (.homeVisitData >> Maybe.map List.concat)
 
         homeVisitDataEncountersTotal =
             countTotal homeVisitEncountersData
@@ -806,9 +840,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique homeVisitEncountersData
 
         childScorecardEncountersData =
-            List.filterMap
-                (.childScorecardData >> Maybe.map List.concat)
-                records
+            loadEncountersIf ncdaEnabled <|
+                List.filterMap
+                    (.childScorecardData >> Maybe.map List.concat)
 
         childScorecardDataEncountersTotal =
             countTotal childScorecardEncountersData
@@ -817,9 +851,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique childScorecardEncountersData
 
         ncdEncountersData =
-            List.filterMap
-                (.ncdData >> Maybe.map List.concat)
-                records
+            loadEncountersIf ncdEnabled <|
+                List.filterMap
+                    (.ncdData >> Maybe.map List.concat)
 
         ncdDataEncountersTotal =
             countTotal ncdEncountersData
@@ -828,9 +862,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique ncdEncountersData
 
         hivEncountersData =
-            List.filterMap
-                (.hivData >> Maybe.map List.concat)
-                records
+            loadEncountersIf hivEnabled <|
+                List.filterMap
+                    (.hivData >> Maybe.map List.concat)
 
         hivDataEncountersTotal =
             countTotal hivEncountersData
@@ -839,9 +873,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique hivEncountersData
 
         tuberculosisEncountersData =
-            List.filterMap
-                (.tuberculosisData >> Maybe.map List.concat)
-                records
+            loadEncountersIf tuberculosisEnabled <|
+                List.filterMap
+                    (.tuberculosisData >> Maybe.map List.concat)
 
         tuberculosisDataEncountersTotal =
             countTotal tuberculosisEncountersData
@@ -850,9 +884,9 @@ generateDemographicsReportEncountersData language features records =
             countUnique tuberculosisEncountersData
 
         nutritionIndividualEncountersData =
-            List.filterMap
-                (.individualNutritionData >> Maybe.map List.concat)
-                records
+            loadEncountersIf nutritionIndividualEnabled <|
+                List.filterMap
+                    (.individualNutritionData >> Maybe.map List.concat)
 
         nutritionIndividualEncountersTotal =
             countTotal nutritionIndividualEncountersData
@@ -861,9 +895,8 @@ generateDemographicsReportEncountersData language features records =
             countUnique nutritionIndividualEncountersData
 
         nutritionGroupPmtctEncountersData =
-            List.filterMap
-                .groupNutritionPmtctData
-                records
+            loadEncountersIf nutritionGroupEnabled <|
+                List.filterMap .groupNutritionPmtctData
 
         nutritionGroupPmtctEncountersTotal =
             countTotal nutritionGroupPmtctEncountersData
@@ -872,9 +905,8 @@ generateDemographicsReportEncountersData language features records =
             countUnique nutritionGroupPmtctEncountersData
 
         nutritionGroupFbfEncountersData =
-            List.filterMap
-                .groupNutritionFbfData
-                records
+            loadEncountersIf nutritionGroupEnabled <|
+                List.filterMap .groupNutritionFbfData
 
         nutritionGroupFbfEncountersTotal =
             countTotal nutritionGroupFbfEncountersData
@@ -883,9 +915,8 @@ generateDemographicsReportEncountersData language features records =
             countUnique nutritionGroupFbfEncountersData
 
         nutritionGroupSorwatheEncountersData =
-            List.filterMap
-                .groupNutritionSorwatheData
-                records
+            loadEncountersIf nutritionGroupEnabled <|
+                List.filterMap .groupNutritionSorwatheData
 
         nutritionGroupSorwatheEncountersTotal =
             countTotal nutritionGroupSorwatheEncountersData
@@ -894,9 +925,8 @@ generateDemographicsReportEncountersData language features records =
             countUnique nutritionGroupSorwatheEncountersData
 
         nutritionGroupChwEncountersData =
-            List.filterMap
-                .groupNutritionChwData
-                records
+            loadEncountersIf nutritionGroupEnabled <|
+                List.filterMap .groupNutritionChwData
 
         nutritionGroupChwEncountersTotal =
             countTotal nutritionGroupChwEncountersData
@@ -905,9 +935,8 @@ generateDemographicsReportEncountersData language features records =
             countUnique nutritionGroupChwEncountersData
 
         nutritionGroupAchiEncountersData =
-            List.filterMap
-                .groupNutritionAchiData
-                records
+            loadEncountersIf nutritionGroupEnabled <|
+                List.filterMap .groupNutritionAchiData
 
         nutritionGroupAchiEncountersTotal =
             countTotal nutritionGroupAchiEncountersData
@@ -915,17 +944,10 @@ generateDemographicsReportEncountersData language features records =
         nutritionGroupAchiEncountersUnique =
             countUnique nutritionGroupAchiEncountersData
 
-        familyNutritionEnabled =
-            EverySet.member FeatureFamilyNutrition features
-
         familyNutritionEncountersData =
-            if familyNutritionEnabled then
+            loadEncountersIf familyNutritionEnabled <|
                 List.filterMap
                     (.familyNutritionData >> Maybe.map List.concat)
-                    records
-
-            else
-                []
 
         familyNutritionEncountersTotal =
             countTotal familyNutritionEncountersData
@@ -985,42 +1007,60 @@ generateDemographicsReportEncountersData language features records =
 
         generateRow labelTransId all unique shiftLeft =
             ( [ translate language labelTransId, String.fromInt all, String.fromInt unique ], shiftLeft )
+
+        rowsIf flag rows =
+            if flag then
+                rows
+
+            else
+                []
     in
     { heading = translate language Translate.Encounters ++ ":"
     , captions = List.map (translate language) [ Translate.EncounterType, Translate.All, Translate.Unique ]
     , rows =
-        [ generateRow Translate.ANCTotal
-            (prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal)
-            (prenatalDataNurseEncountersUnique + prenatalDataChwEncountersUnique)
-            False
-        , generateRow Translate.HealthCenter prenatalDataNurseEncountersTotal prenatalDataNurseEncountersUnique True
-        , generateRow Translate.CHW prenatalDataChwEncountersTotal prenatalDataChwEncountersUnique True
-        , generateRow Translate.AcuteIllnessTotal
-            (acuteIllnessDataNurseEncountersTotal + acuteIllnessDataChwEncountersTotal)
-            (acuteIllnessDataNurseEncountersUnique + acuteIllnessDataChwEncountersUnique)
-            False
-        , generateRow Translate.HealthCenter acuteIllnessDataNurseEncountersTotal acuteIllnessDataNurseEncountersUnique True
-        , generateRow Translate.CHW acuteIllnessDataChwEncountersTotal acuteIllnessDataChwEncountersUnique True
-        , generateRow Translate.StandardPediatricVisit wellChildDataEncountersTotal wellChildDataEncountersUnique False
-        , generateRow Translate.HomeVisit homeVisitDataEncountersTotal homeVisitDataEncountersUnique False
-        , generateRow Translate.ChildScorecard childScorecardDataEncountersTotal childScorecardDataEncountersUnique False
-        , generateRow Translate.NCD ncdDataEncountersTotal ncdDataEncountersUnique False
-        , generateRow Translate.HIV hivDataEncountersTotal hivDataEncountersUnique False
-        , generateRow Translate.Tuberculosis tuberculosisDataEncountersTotal tuberculosisDataEncountersUnique False
-        , generateRow Translate.NutritionTotal overallNutritionTotal overallNutritionUnique False
-        , generateRow Translate.PMTCT nutritionGroupPmtctEncountersTotal nutritionGroupPmtctEncountersUnique True
-        , generateRow Translate.FBF nutritionGroupFbfEncountersTotal nutritionGroupFbfEncountersUnique True
-        , generateRow Translate.Sorwathe nutritionGroupSorwatheEncountersTotal nutritionGroupSorwatheEncountersUnique True
-        , generateRow Translate.CBNP nutritionGroupChwEncountersTotal nutritionGroupChwEncountersUnique True
-        , generateRow Translate.ACHI nutritionGroupAchiEncountersTotal nutritionGroupAchiEncountersUnique True
-        , generateRow Translate.Individual nutritionIndividualEncountersTotal nutritionIndividualEncountersUnique True
-        ]
-            ++ (if familyNutritionEnabled then
-                    [ generateRow Translate.FamilyNutrition familyNutritionEncountersTotal familyNutritionEncountersUnique False ]
-
-                else
-                    []
-               )
+        List.concat
+            [ rowsIf antenatalEnabled
+                [ generateRow Translate.ANCTotal
+                    (prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal)
+                    (prenatalDataNurseEncountersUnique + prenatalDataChwEncountersUnique)
+                    False
+                , generateRow Translate.HealthCenter prenatalDataNurseEncountersTotal prenatalDataNurseEncountersUnique True
+                , generateRow Translate.CHW prenatalDataChwEncountersTotal prenatalDataChwEncountersUnique True
+                ]
+            , rowsIf acuteIllnessEnabled
+                [ generateRow Translate.AcuteIllnessTotal
+                    (acuteIllnessDataNurseEncountersTotal + acuteIllnessDataChwEncountersTotal)
+                    (acuteIllnessDataNurseEncountersUnique + acuteIllnessDataChwEncountersUnique)
+                    False
+                , generateRow Translate.HealthCenter acuteIllnessDataNurseEncountersTotal acuteIllnessDataNurseEncountersUnique True
+                , generateRow Translate.CHW acuteIllnessDataChwEncountersTotal acuteIllnessDataChwEncountersUnique True
+                ]
+            , rowsIf wellChildEnabled
+                [ generateRow Translate.StandardPediatricVisit wellChildDataEncountersTotal wellChildDataEncountersUnique False ]
+            , rowsIf nutritionIndividualEnabled
+                [ generateRow Translate.HomeVisit homeVisitDataEncountersTotal homeVisitDataEncountersUnique False ]
+            , rowsIf ncdaEnabled
+                [ generateRow Translate.ChildScorecard childScorecardDataEncountersTotal childScorecardDataEncountersUnique False ]
+            , rowsIf ncdEnabled
+                [ generateRow Translate.NCD ncdDataEncountersTotal ncdDataEncountersUnique False ]
+            , rowsIf hivEnabled
+                [ generateRow Translate.HIV hivDataEncountersTotal hivDataEncountersUnique False ]
+            , rowsIf tuberculosisEnabled
+                [ generateRow Translate.Tuberculosis tuberculosisDataEncountersTotal tuberculosisDataEncountersUnique False ]
+            , rowsIf nutritionAggregateEnabled
+                [ generateRow Translate.NutritionTotal overallNutritionTotal overallNutritionUnique False ]
+            , rowsIf nutritionGroupEnabled
+                [ generateRow Translate.PMTCT nutritionGroupPmtctEncountersTotal nutritionGroupPmtctEncountersUnique True
+                , generateRow Translate.FBF nutritionGroupFbfEncountersTotal nutritionGroupFbfEncountersUnique True
+                , generateRow Translate.Sorwathe nutritionGroupSorwatheEncountersTotal nutritionGroupSorwatheEncountersUnique True
+                , generateRow Translate.CBNP nutritionGroupChwEncountersTotal nutritionGroupChwEncountersUnique True
+                , generateRow Translate.ACHI nutritionGroupAchiEncountersTotal nutritionGroupAchiEncountersUnique True
+                ]
+            , rowsIf nutritionIndividualEnabled
+                [ generateRow Translate.Individual nutritionIndividualEncountersTotal nutritionIndividualEncountersUnique True ]
+            , rowsIf familyNutritionEnabled
+                [ generateRow Translate.FamilyNutrition familyNutritionEncountersTotal familyNutritionEncountersUnique False ]
+            ]
     , totals =
         { label = translate language Translate.Total
         , total = String.fromInt overallTotal

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -6314,6 +6314,10 @@ var $author$project$Pages$Reports$Utils$isWideScope = function (selectedEntity) 
 var $author$project$Pages$Reports$Model$NutritionReportDataCalculationCompleted = function (a) {
 	return {$: 'NutritionReportDataCalculationCompleted', a: a};
 };
+var $author$project$App$Types$FeatureFamilyNutrition = {$: 'FeatureFamilyNutrition'};
+var $author$project$App$Types$FeatureNutritionGroup = {$: 'FeatureNutritionGroup'};
+var $author$project$App$Types$FeatureNutritionIndividual = {$: 'FeatureNutritionIndividual'};
+var $author$project$App$Types$FeatureWellChild = {$: 'FeatureWellChild'};
 var $justinmimbs$date$Date$Years = {$: 'Years'};
 var $elm$core$List$concat = function (lists) {
 	return A3($elm$core$List$foldr, $elm$core$List$append, _List_Nil, lists);
@@ -6607,6 +6611,20 @@ var $pzp1997$assoc_list$AssocList$insert = F3(
 				_Utils_Tuple2(key, value),
 				alteredAlist));
 	});
+var $pzp1997$assoc_list$AssocList$member = F2(
+	function (targetKey, dict) {
+		var _v0 = A2($pzp1997$assoc_list$AssocList$get, targetKey, dict);
+		if (_v0.$ === 'Just') {
+			return true;
+		} else {
+			return false;
+		}
+	});
+var $Gizra$elm_all_set$EverySet$member = F2(
+	function (k, _v0) {
+		var d = _v0.a;
+		return A2($pzp1997$assoc_list$AssocList$member, k, d);
+	});
 var $justinmimbs$date$Date$month = A2(
 	$elm$core$Basics$composeR,
 	$justinmimbs$date$Date$toCalendarDate,
@@ -6723,16 +6741,26 @@ var $elm_community$maybe_extra$Maybe$Extra$foldrValues = F2(
 		}
 	});
 var $elm_community$maybe_extra$Maybe$Extra$values = A2($elm$core$List$foldr, $elm_community$maybe_extra$Maybe$Extra$foldrValues, _List_Nil);
-var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F2(
-	function (currentDate, data) {
+var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F3(
+	function (currentDate, features, data) {
 		return $elm$core$Task$succeed(
 			function () {
+				var seriesIf = F2(
+					function (flag, series) {
+						return flag ? series : $elm$core$Maybe$Nothing;
+					});
 				var records = A2(
 					$elm$core$List$filter,
 					function (record) {
 						return A3($justinmimbs$date$Date$diff, $justinmimbs$date$Date$Years, record.birthDate, currentDate) < 6;
 					},
 					data);
+				var memberFeature = function (f) {
+					return A2($Gizra$elm_all_set$EverySet$member, f, features);
+				};
+				var nutritionGroupEnabled = memberFeature($author$project$App$Types$FeatureNutritionGroup);
+				var nutritionIndividualEnabled = memberFeature($author$project$App$Types$FeatureNutritionIndividual);
+				var wellChildEnabled = memberFeature($author$project$App$Types$FeatureWellChild);
 				var insertMetricsForMonth = F3(
 					function (_v2, encounterMetrics, accum) {
 						var year = _v2.a;
@@ -6763,6 +6791,7 @@ var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F2(
 						return ($author$project$Pages$Reports$Utils$countTotalNutritionEncounters(record) > 1) ? $elm$core$Maybe$Just(record.id) : $elm$core$Maybe$Nothing;
 					},
 					records);
+				var familyNutritionEnabled = memberFeature($author$project$App$Types$FeatureFamilyNutrition);
 				var currentYear = $justinmimbs$date$Date$year(currentDate);
 				var startingYear = currentYear - 3;
 				var filterByYear = function (encounter) {
@@ -6770,7 +6799,7 @@ var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F2(
 						$justinmimbs$date$Date$year(encounter.startDate),
 						startingYear) > -1;
 				};
-				var familyNutritionEncounters = A2(
+				var familyNutritionEncounters = familyNutritionEnabled ? A2(
 					$elm$core$List$concatMap,
 					function (record) {
 						return A2(
@@ -6788,7 +6817,7 @@ var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F2(
 											$elm$core$Tuple$pair(record.id)))),
 								record.familyNutritionMuacData));
 					},
-					records);
+					records) : _List_Nil;
 				var allEncounters = A2(
 					$elm$core$List$concatMap,
 					function (record) {
@@ -6797,71 +6826,92 @@ var $author$project$Pages$Reports$Update$calculateNutritionReportDataTask = F2(
 								_List_fromArray(
 									[
 										A2(
-										$elm$core$Maybe$map,
+										seriesIf,
+										wellChildEnabled,
 										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$concat,
+											$elm$core$Maybe$map,
+											A2(
+												$elm$core$Basics$composeR,
+												$elm$core$List$concat,
+												A2(
+													$elm$core$Basics$composeR,
+													$elm$core$List$filter(filterByYear),
+													$elm$core$List$map(
+														function (item) {
+															return _Utils_Tuple2(
+																record.id,
+																{fbfAmount: $elm$core$Maybe$Nothing, hasEdema: false, muacCm: item.muacCm, nutritionData: item.nutritionData, startDate: item.startDate});
+														}))),
+											record.wellChildData)),
+										A2(
+										seriesIf,
+										nutritionIndividualEnabled,
+										A2(
+											$elm$core$Maybe$map,
+											A2(
+												$elm$core$Basics$composeR,
+												$elm$core$List$concat,
+												A2(
+													$elm$core$Basics$composeR,
+													$elm$core$List$filter(filterByYear),
+													$elm$core$List$map(
+														$elm$core$Tuple$pair(record.id)))),
+											record.individualNutritionData)),
+										A2(
+										seriesIf,
+										nutritionGroupEnabled,
+										A2(
+											$elm$core$Maybe$map,
 											A2(
 												$elm$core$Basics$composeR,
 												$elm$core$List$filter(filterByYear),
 												$elm$core$List$map(
-													function (item) {
-														return _Utils_Tuple2(
-															record.id,
-															{fbfAmount: $elm$core$Maybe$Nothing, hasEdema: false, muacCm: item.muacCm, nutritionData: item.nutritionData, startDate: item.startDate});
-													}))),
-										record.wellChildData),
+													$elm$core$Tuple$pair(record.id))),
+											record.groupNutritionPmtctData)),
 										A2(
-										$elm$core$Maybe$map,
+										seriesIf,
+										nutritionGroupEnabled,
 										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$concat,
+											$elm$core$Maybe$map,
 											A2(
 												$elm$core$Basics$composeR,
 												$elm$core$List$filter(filterByYear),
 												$elm$core$List$map(
-													$elm$core$Tuple$pair(record.id)))),
-										record.individualNutritionData),
+													$elm$core$Tuple$pair(record.id))),
+											record.groupNutritionFbfData)),
 										A2(
-										$elm$core$Maybe$map,
+										seriesIf,
+										nutritionGroupEnabled,
 										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$filter(filterByYear),
-											$elm$core$List$map(
-												$elm$core$Tuple$pair(record.id))),
-										record.groupNutritionPmtctData),
+											$elm$core$Maybe$map,
+											A2(
+												$elm$core$Basics$composeR,
+												$elm$core$List$filter(filterByYear),
+												$elm$core$List$map(
+													$elm$core$Tuple$pair(record.id))),
+											record.groupNutritionSorwatheData)),
 										A2(
-										$elm$core$Maybe$map,
+										seriesIf,
+										nutritionGroupEnabled,
 										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$filter(filterByYear),
-											$elm$core$List$map(
-												$elm$core$Tuple$pair(record.id))),
-										record.groupNutritionFbfData),
+											$elm$core$Maybe$map,
+											A2(
+												$elm$core$Basics$composeR,
+												$elm$core$List$filter(filterByYear),
+												$elm$core$List$map(
+													$elm$core$Tuple$pair(record.id))),
+											record.groupNutritionChwData)),
 										A2(
-										$elm$core$Maybe$map,
+										seriesIf,
+										nutritionGroupEnabled,
 										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$filter(filterByYear),
-											$elm$core$List$map(
-												$elm$core$Tuple$pair(record.id))),
-										record.groupNutritionSorwatheData),
-										A2(
-										$elm$core$Maybe$map,
-										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$filter(filterByYear),
-											$elm$core$List$map(
-												$elm$core$Tuple$pair(record.id))),
-										record.groupNutritionChwData),
-										A2(
-										$elm$core$Maybe$map,
-										A2(
-											$elm$core$Basics$composeR,
-											$elm$core$List$filter(filterByYear),
-											$elm$core$List$map(
-												$elm$core$Tuple$pair(record.id))),
-										record.groupNutritionAchiData)
+											$elm$core$Maybe$map,
+											A2(
+												$elm$core$Basics$composeR,
+												$elm$core$List$filter(filterByYear),
+												$elm$core$List$map(
+													$elm$core$Tuple$pair(record.id))),
+											record.groupNutritionAchiData))
 									])));
 					},
 					records);
@@ -6920,8 +6970,8 @@ var $author$project$Pages$Reports$Update$wrapInResultTask = function (task) {
 		A2($elm$core$Basics$composeR, $elm$core$Result$Err, $elm$core$Task$succeed),
 		A2($elm$core$Task$map, $elm$core$Result$Ok, task));
 };
-var $author$project$Pages$Reports$Update$performNutritionReportDataCalculation = F2(
-	function (currentDate, data) {
+var $author$project$Pages$Reports$Update$performNutritionReportDataCalculation = F3(
+	function (currentDate, features, data) {
 		return A2(
 			$elm$core$Task$perform,
 			A2(
@@ -6930,7 +6980,7 @@ var $author$project$Pages$Reports$Update$performNutritionReportDataCalculation =
 					$elm$core$Basics$always('Calculations failed')),
 				$author$project$Pages$Reports$Model$NutritionReportDataCalculationCompleted),
 			$author$project$Pages$Reports$Update$wrapInResultTask(
-				A2($author$project$Pages$Reports$Update$calculateNutritionReportDataTask, currentDate, data)));
+				A3($author$project$Pages$Reports$Update$calculateNutritionReportDataTask, currentDate, features, data)));
 	});
 var $author$project$Pages$Reports$Model$ReportAcuteIllness = {$: 'ReportAcuteIllness'};
 var $author$project$Pages$Reports$Model$ReportDemographics = {$: 'ReportDemographics'};
@@ -6981,7 +7031,7 @@ var $author$project$Pages$Reports$Update$update = F4(
 							var _v3 = _v2.b.a;
 							return $author$project$Pages$Reports$Utils$isWideScope(data.entityType) ? _Utils_Tuple2(model.nutritionReportData, $elm$core$Platform$Cmd$none) : _Utils_Tuple2(
 								$krisajenkins$remotedata$RemoteData$Loading,
-								A2($author$project$Pages$Reports$Update$performNutritionReportDataCalculation, currentDate, data.records));
+								A3($author$project$Pages$Reports$Update$performNutritionReportDataCalculation, currentDate, data.features, data.records));
 						} else {
 							return _Utils_Tuple2(model.nutritionReportData, $elm$core$Platform$Cmd$none);
 						}
@@ -7184,21 +7234,23 @@ var $author$project$Backend$Completion$Model$HandleSyncResponse = function (a) {
 	return {$: 'HandleSyncResponse', a: a};
 };
 var $author$project$Backend$Completion$Model$CompletionData = function (site) {
-	return function (entityName) {
-		return function (entityType) {
-			return function (params) {
-				return function (acuteIllnessData) {
-					return function (childScoreboardData) {
-						return function (hivData) {
-							return function (homeVisitData) {
-								return function (ncdData) {
-									return function (nutritionIndividualData) {
-										return function (nutritionGroupData) {
-											return function (prenatalData) {
-												return function (tuberculosisData) {
-													return function (wellChildData) {
-														return function (remainingForDownload) {
-															return {acuteIllnessData: acuteIllnessData, childScoreboardData: childScoreboardData, entityName: entityName, entityType: entityType, hivData: hivData, homeVisitData: homeVisitData, ncdData: ncdData, nutritionGroupData: nutritionGroupData, nutritionIndividualData: nutritionIndividualData, params: params, prenatalData: prenatalData, remainingForDownload: remainingForDownload, site: site, tuberculosisData: tuberculosisData, wellChildData: wellChildData};
+	return function (features) {
+		return function (entityName) {
+			return function (entityType) {
+				return function (params) {
+					return function (acuteIllnessData) {
+						return function (childScoreboardData) {
+							return function (hivData) {
+								return function (homeVisitData) {
+									return function (ncdData) {
+										return function (nutritionIndividualData) {
+											return function (nutritionGroupData) {
+												return function (prenatalData) {
+													return function (tuberculosisData) {
+														return function (wellChildData) {
+															return function (remainingForDownload) {
+																return {acuteIllnessData: acuteIllnessData, childScoreboardData: childScoreboardData, entityName: entityName, entityType: entityType, features: features, hivData: hivData, homeVisitData: homeVisitData, ncdData: ncdData, nutritionGroupData: nutritionGroupData, nutritionIndividualData: nutritionIndividualData, params: params, prenatalData: prenatalData, remainingForDownload: remainingForDownload, site: site, tuberculosisData: tuberculosisData, wellChildData: wellChildData};
+															};
 														};
 													};
 												};
@@ -7370,6 +7422,80 @@ var $author$project$Backend$Decoder$siteFromString = function (str) {
 	}
 };
 var $author$project$Backend$Decoder$decodeSite = A2($elm$json$Json$Decode$map, $author$project$Backend$Decoder$siteFromString, $elm$json$Json$Decode$string);
+var $Gizra$elm_all_set$EverySet$EverySet = function (a) {
+	return {$: 'EverySet', a: a};
+};
+var $Gizra$elm_all_set$EverySet$empty = $Gizra$elm_all_set$EverySet$EverySet($pzp1997$assoc_list$AssocList$empty);
+var $Gizra$elm_all_set$EverySet$insert = F2(
+	function (k, _v0) {
+		var d = _v0.a;
+		return $Gizra$elm_all_set$EverySet$EverySet(
+			A3($pzp1997$assoc_list$AssocList$insert, k, _Utils_Tuple0, d));
+	});
+var $Gizra$elm_all_set$EverySet$fromList = function (xs) {
+	return A3($elm$core$List$foldl, $Gizra$elm_all_set$EverySet$insert, $Gizra$elm_all_set$EverySet$empty, xs);
+};
+var $author$project$App$Types$FeatureAcuteIllness = {$: 'FeatureAcuteIllness'};
+var $author$project$App$Types$FeatureAntenatal = {$: 'FeatureAntenatal'};
+var $author$project$App$Types$FeatureGPSCoordinates = {$: 'FeatureGPSCoordinates'};
+var $author$project$App$Types$FeatureGroupEducation = {$: 'FeatureGroupEducation'};
+var $author$project$App$Types$FeatureHIVManagement = {$: 'FeatureHIVManagement'};
+var $author$project$App$Types$FeatureHealthyStart = {$: 'FeatureHealthyStart'};
+var $author$project$App$Types$FeatureNCD = {$: 'FeatureNCD'};
+var $author$project$App$Types$FeatureNCDA = {$: 'FeatureNCDA'};
+var $author$project$App$Types$FeatureReportToWhatsApp = {$: 'FeatureReportToWhatsApp'};
+var $author$project$App$Types$FeatureStockManagementHC = {$: 'FeatureStockManagementHC'};
+var $author$project$App$Types$FeatureStockManagementVillage = {$: 'FeatureStockManagementVillage'};
+var $author$project$App$Types$FeatureTuberculosisManagement = {$: 'FeatureTuberculosisManagement'};
+var $author$project$Backend$Decoder$siteFeatureFromString = function (str) {
+	var _v0 = $elm$core$String$toLower(str);
+	switch (_v0) {
+		case 'acute_illness':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureAcuteIllness);
+		case 'antenatal':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureAntenatal);
+		case 'family_nutrition':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureFamilyNutrition);
+		case 'gps_coordinates':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureGPSCoordinates);
+		case 'group_education':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureGroupEducation);
+		case 'healthy_start':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureHealthyStart);
+		case 'hiv_management':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureHIVManagement);
+		case 'ncd':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureNCD);
+		case 'ncda':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureNCDA);
+		case 'nutrition_group':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureNutritionGroup);
+		case 'nutrition_individual':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureNutritionIndividual);
+		case 'report_to_whatsapp':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureReportToWhatsApp);
+		case 'stock_management_hc':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureStockManagementHC);
+		case 'stock_management_village':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureStockManagementVillage);
+		case 'tuberculosis_management':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureTuberculosisManagement);
+		case 'well_child':
+			return $elm$core$Maybe$Just($author$project$App$Types$FeatureWellChild);
+		default:
+			return $elm$core$Maybe$Nothing;
+	}
+};
+var $elm$core$String$words = _String_words;
+var $author$project$Backend$Decoder$siteFeaturesFromString = function (str) {
+	return $Gizra$elm_all_set$EverySet$fromList(
+		$elm_community$maybe_extra$Maybe$Extra$values(
+			A2(
+				$elm$core$List$map,
+				$author$project$Backend$Decoder$siteFeatureFromString,
+				$elm$core$String$words(str))));
+};
+var $author$project$Backend$Decoder$decodeSiteFeatures = A2($elm$json$Json$Decode$map, $author$project$Backend$Decoder$siteFeaturesFromString, $elm$json$Json$Decode$string);
 var $NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$hardcoded = A2($elm$core$Basics$composeR, $elm$json$Json$Decode$succeed, $NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$custom);
 var $NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required = F3(
 	function (key, valDecoder, decoder) {
@@ -7425,9 +7551,13 @@ var $author$project$Backend$Completion$Decoder$decodeCompletionData = A2(
 														$elm$json$Json$Decode$string,
 														A3(
 															$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-															'site',
-															$author$project$Backend$Decoder$decodeSite,
-															$elm$json$Json$Decode$succeed($author$project$Backend$Completion$Model$CompletionData))))))))))))))));
+															'features',
+															$author$project$Backend$Decoder$decodeSiteFeatures,
+															A3(
+																$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
+																'site',
+																$author$project$Backend$Decoder$decodeSite,
+																$elm$json$Json$Decode$succeed($author$project$Backend$Completion$Model$CompletionData)))))))))))))))));
 var $author$project$Backend$Completion$Model$SyncResponse = function (acuteIllnessData) {
 	return function (childScoreboardData) {
 		return function (hivData) {
@@ -10251,66 +10381,6 @@ var $author$project$Backend$Reports$Decoder$decodeBackendGeneratedNutritionRepor
 										'type',
 										$author$project$Backend$Reports$Decoder$decodeNutritionReportTableType,
 										$elm$json$Json$Decode$succeed($author$project$Backend$Reports$Model$BackendGeneratedNutritionReportTableDate)))))))))));
-var $Gizra$elm_all_set$EverySet$EverySet = function (a) {
-	return {$: 'EverySet', a: a};
-};
-var $Gizra$elm_all_set$EverySet$empty = $Gizra$elm_all_set$EverySet$EverySet($pzp1997$assoc_list$AssocList$empty);
-var $Gizra$elm_all_set$EverySet$insert = F2(
-	function (k, _v0) {
-		var d = _v0.a;
-		return $Gizra$elm_all_set$EverySet$EverySet(
-			A3($pzp1997$assoc_list$AssocList$insert, k, _Utils_Tuple0, d));
-	});
-var $Gizra$elm_all_set$EverySet$fromList = function (xs) {
-	return A3($elm$core$List$foldl, $Gizra$elm_all_set$EverySet$insert, $Gizra$elm_all_set$EverySet$empty, xs);
-};
-var $author$project$App$Types$FeatureFamilyNutrition = {$: 'FeatureFamilyNutrition'};
-var $author$project$App$Types$FeatureGPSCoordinates = {$: 'FeatureGPSCoordinates'};
-var $author$project$App$Types$FeatureGroupEducation = {$: 'FeatureGroupEducation'};
-var $author$project$App$Types$FeatureHIVManagement = {$: 'FeatureHIVManagement'};
-var $author$project$App$Types$FeatureHealthyStart = {$: 'FeatureHealthyStart'};
-var $author$project$App$Types$FeatureNCDA = {$: 'FeatureNCDA'};
-var $author$project$App$Types$FeatureReportToWhatsApp = {$: 'FeatureReportToWhatsApp'};
-var $author$project$App$Types$FeatureStockManagementHC = {$: 'FeatureStockManagementHC'};
-var $author$project$App$Types$FeatureStockManagementVillage = {$: 'FeatureStockManagementVillage'};
-var $author$project$App$Types$FeatureTuberculosisManagement = {$: 'FeatureTuberculosisManagement'};
-var $author$project$Backend$Decoder$siteFeatureFromString = function (str) {
-	var _v0 = $elm$core$String$toLower(str);
-	switch (_v0) {
-		case 'family_nutrition':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureFamilyNutrition);
-		case 'gps_coordinates':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureGPSCoordinates);
-		case 'group_education':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureGroupEducation);
-		case 'healthy_start':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureHealthyStart);
-		case 'hiv_management':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureHIVManagement);
-		case 'ncda':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureNCDA);
-		case 'report_to_whatsapp':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureReportToWhatsApp);
-		case 'stock_management_hc':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureStockManagementHC);
-		case 'stock_management_village':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureStockManagementVillage);
-		case 'tuberculosis_management':
-			return $elm$core$Maybe$Just($author$project$App$Types$FeatureTuberculosisManagement);
-		default:
-			return $elm$core$Maybe$Nothing;
-	}
-};
-var $elm$core$String$words = _String_words;
-var $author$project$Backend$Decoder$siteFeaturesFromString = function (str) {
-	return $Gizra$elm_all_set$EverySet$fromList(
-		$elm_community$maybe_extra$Maybe$Extra$values(
-			A2(
-				$elm$core$List$map,
-				$author$project$Backend$Decoder$siteFeatureFromString,
-				$elm$core$String$words(str))));
-};
-var $author$project$Backend$Decoder$decodeSiteFeatures = A2($elm$json$Json$Decode$map, $author$project$Backend$Decoder$siteFeaturesFromString, $elm$json$Json$Decode$string);
 var $NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optionalAt = F4(
 	function (path, valDecoder, fallback, decoder) {
 		return A2(
@@ -18154,6 +18224,41 @@ var $author$project$Pages$Completion$View$viewTuberculosisReport = F5(
 						mTakenBy,
 						$author$project$Pages$Completion$View$eliminateEmptyEncounters(reportData)))));
 	});
+var $author$project$Pages$Completion$Utils$visibleReportTypes = function (features) {
+	var member = function (f) {
+		return A2($Gizra$elm_all_set$EverySet$member, f, features);
+	};
+	return A2(
+		$elm$core$List$filter,
+		function (reportType) {
+			switch (reportType.$) {
+				case 'ReportAcuteIllness':
+					return member($author$project$App$Types$FeatureAcuteIllness);
+				case 'ReportPrenatal':
+					return member($author$project$App$Types$FeatureAntenatal);
+				case 'ReportChildScoreboard':
+					return member($author$project$App$Types$FeatureNCDA);
+				case 'ReportHIV':
+					return member($author$project$App$Types$FeatureHIVManagement);
+				case 'ReportHomeVisit':
+					return member($author$project$App$Types$FeatureNutritionIndividual);
+				case 'ReportNCD':
+					return member($author$project$App$Types$FeatureNCD);
+				case 'ReportNewbornExam':
+					return member($author$project$App$Types$FeatureWellChild);
+				case 'ReportNutritionGroup':
+					return member($author$project$App$Types$FeatureNutritionGroup);
+				case 'ReportNutritionIndividual':
+					return member($author$project$App$Types$FeatureNutritionIndividual);
+				case 'ReportWellChild':
+					return member($author$project$App$Types$FeatureWellChild);
+				default:
+					return member($author$project$App$Types$FeatureTuberculosisManagement);
+			}
+		},
+		_List_fromArray(
+			[$author$project$Pages$Completion$Model$ReportAcuteIllness, $author$project$Pages$Completion$Model$ReportPrenatal, $author$project$Pages$Completion$Model$ReportChildScoreboard, $author$project$Pages$Completion$Model$ReportHIV, $author$project$Pages$Completion$Model$ReportHomeVisit, $author$project$Pages$Completion$Model$ReportNCD, $author$project$Pages$Completion$Model$ReportNewbornExam, $author$project$Pages$Completion$Model$ReportNutritionGroup, $author$project$Pages$Completion$Model$ReportNutritionIndividual, $author$project$Pages$Completion$Model$ReportWellChild, $author$project$Pages$Completion$Model$ReportTuberculosis]));
+};
 var $author$project$Pages$Utils$viewCustomLabel = F4(
 	function (language, translationId, suffix, class_) {
 		return A2(
@@ -18443,8 +18548,7 @@ var $author$project$Pages$Completion$View$viewCompletionData = F4(
 									$author$project$Pages$Utils$viewSelectListInput,
 									language,
 									model.reportType,
-									_List_fromArray(
-										[$author$project$Pages$Completion$Model$ReportAcuteIllness, $author$project$Pages$Completion$Model$ReportPrenatal, $author$project$Pages$Completion$Model$ReportChildScoreboard, $author$project$Pages$Completion$Model$ReportHIV, $author$project$Pages$Completion$Model$ReportHomeVisit, $author$project$Pages$Completion$Model$ReportNCD, $author$project$Pages$Completion$Model$ReportNewbornExam, $author$project$Pages$Completion$Model$ReportNutritionGroup, $author$project$Pages$Completion$Model$ReportNutritionIndividual, $author$project$Pages$Completion$Model$ReportWellChild, $author$project$Pages$Completion$Model$ReportTuberculosis]),
+									$author$project$Pages$Completion$Utils$visibleReportTypes(data.features),
 									$author$project$Pages$Completion$Utils$reportTypeToString,
 									$author$project$Pages$Completion$Model$SetReportType,
 									$author$project$Translate$CompletionReportType,
@@ -19051,152 +19155,122 @@ var $author$project$Translate$NutritionTotal = {$: 'NutritionTotal'};
 var $author$project$Translate$PMTCT = {$: 'PMTCT'};
 var $author$project$Translate$Sorwathe = {$: 'Sorwathe'};
 var $author$project$Translate$Unique = {$: 'Unique'};
-var $pzp1997$assoc_list$AssocList$member = F2(
-	function (targetKey, dict) {
-		var _v0 = A2($pzp1997$assoc_list$AssocList$get, targetKey, dict);
-		if (_v0.$ === 'Just') {
-			return true;
-		} else {
-			return false;
-		}
-	});
-var $Gizra$elm_all_set$EverySet$member = F2(
-	function (k, _v0) {
-		var d = _v0.a;
-		return A2($pzp1997$assoc_list$AssocList$member, k, d);
-	});
 var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData = F3(
 	function (language, features, records) {
-		var wellChildEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.wellChildData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
-		var tuberculosisEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.tuberculosisData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
-		var prenatalDataNurseEncounters = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.prenatalData;
-				},
-				$elm$core$Maybe$map(
-					A2(
-						$elm$core$Basics$composeR,
-						$elm$core$List$concatMap(
-							function ($) {
-								return $.encounters;
-							}),
-						$elm$core$List$filter(
-							function (encounter) {
-								return A2(
-									$elm$core$List$member,
-									encounter.encounterType,
-									_List_fromArray(
-										[$author$project$Backend$Reports$Model$NurseEncounter, $author$project$Backend$Reports$Model$NursePostpartumEncounter]));
-							})))),
-			records);
-		var prenatalDataChwEncounters = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.prenatalData;
-				},
-				$elm$core$Maybe$map(
-					A2(
-						$elm$core$Basics$composeR,
-						$elm$core$List$concatMap(
-							function ($) {
-								return $.encounters;
-							}),
-						$elm$core$List$filter(
-							function (encounter) {
-								return !A2(
-									$elm$core$List$member,
-									encounter.encounterType,
-									_List_fromArray(
-										[$author$project$Backend$Reports$Model$NurseEncounter, $author$project$Backend$Reports$Model$NursePostpartumEncounter]));
-							})))),
-			records);
-		var nutritionIndividualEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.individualNutritionData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
-		var nutritionGroupSorwatheEncountersData = A2(
-			$elm$core$List$filterMap,
-			function ($) {
-				return $.groupNutritionSorwatheData;
-			},
-			records);
-		var nutritionGroupPmtctEncountersData = A2(
-			$elm$core$List$filterMap,
-			function ($) {
-				return $.groupNutritionPmtctData;
-			},
-			records);
-		var nutritionGroupFbfEncountersData = A2(
-			$elm$core$List$filterMap,
-			function ($) {
-				return $.groupNutritionFbfData;
-			},
-			records);
-		var nutritionGroupChwEncountersData = A2(
-			$elm$core$List$filterMap,
-			function ($) {
-				return $.groupNutritionChwData;
-			},
-			records);
-		var nutritionGroupAchiEncountersData = A2(
-			$elm$core$List$filterMap,
-			function ($) {
-				return $.groupNutritionAchiData;
-			},
-			records);
+		var rowsIf = F2(
+			function (flag, rows) {
+				return flag ? rows : _List_Nil;
+			});
+		var memberFeature = function (f) {
+			return A2($Gizra$elm_all_set$EverySet$member, f, features);
+		};
+		var ncdEnabled = memberFeature($author$project$App$Types$FeatureNCD);
+		var ncdaEnabled = memberFeature($author$project$App$Types$FeatureNCDA);
+		var nutritionGroupEnabled = memberFeature($author$project$App$Types$FeatureNutritionGroup);
+		var nutritionIndividualEnabled = memberFeature($author$project$App$Types$FeatureNutritionIndividual);
+		var nutritionAggregateEnabled = nutritionIndividualEnabled || nutritionGroupEnabled;
+		var tuberculosisEnabled = memberFeature($author$project$App$Types$FeatureTuberculosisManagement);
+		var wellChildEnabled = memberFeature($author$project$App$Types$FeatureWellChild);
+		var loadEncountersIf = F2(
+			function (flag, loader) {
+				return flag ? loader(records) : _List_Nil;
+			});
 		var ncdEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
+			loadEncountersIf,
+			ncdEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.ncdData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
+		var nutritionGroupAchiEncountersData = A2(
+			loadEncountersIf,
+			nutritionGroupEnabled,
+			$elm$core$List$filterMap(
 				function ($) {
-					return $.ncdData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
+					return $.groupNutritionAchiData;
+				}));
+		var nutritionGroupChwEncountersData = A2(
+			loadEncountersIf,
+			nutritionGroupEnabled,
+			$elm$core$List$filterMap(
+				function ($) {
+					return $.groupNutritionChwData;
+				}));
+		var nutritionGroupFbfEncountersData = A2(
+			loadEncountersIf,
+			nutritionGroupEnabled,
+			$elm$core$List$filterMap(
+				function ($) {
+					return $.groupNutritionFbfData;
+				}));
+		var nutritionGroupPmtctEncountersData = A2(
+			loadEncountersIf,
+			nutritionGroupEnabled,
+			$elm$core$List$filterMap(
+				function ($) {
+					return $.groupNutritionPmtctData;
+				}));
+		var nutritionGroupSorwatheEncountersData = A2(
+			loadEncountersIf,
+			nutritionGroupEnabled,
+			$elm$core$List$filterMap(
+				function ($) {
+					return $.groupNutritionSorwatheData;
+				}));
+		var nutritionIndividualEncountersData = A2(
+			loadEncountersIf,
+			nutritionIndividualEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.individualNutritionData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
+		var tuberculosisEncountersData = A2(
+			loadEncountersIf,
+			tuberculosisEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.tuberculosisData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
+		var wellChildEncountersData = A2(
+			loadEncountersIf,
+			wellChildEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.wellChildData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
 		var homeVisitEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.homeVisitData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
+			loadEncountersIf,
+			nutritionIndividualEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.homeVisitData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
+		var hivEnabled = memberFeature($author$project$App$Types$FeatureHIVManagement);
 		var hivEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.hivData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
+			loadEncountersIf,
+			hivEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.hivData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
 		var generateRow = F4(
 			function (labelTransId, all, unique, shiftLeft) {
 				return _Utils_Tuple2(
@@ -19208,16 +19282,17 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 						]),
 					shiftLeft);
 			});
-		var familyNutritionEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureFamilyNutrition, features);
-		var familyNutritionEncountersData = familyNutritionEnabled ? A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.familyNutritionData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records) : _List_Nil;
+		var familyNutritionEnabled = memberFeature($author$project$App$Types$FeatureFamilyNutrition);
+		var familyNutritionEncountersData = A2(
+			loadEncountersIf,
+			familyNutritionEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.familyNutritionData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
 		var countUnique = A2(
 			$elm$core$Basics$composeR,
 			$elm$core$List$filter(
@@ -19234,8 +19309,6 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 		var nutritionGroupSorwatheEncountersUnique = countUnique(nutritionGroupSorwatheEncountersData);
 		var nutritionIndividualEncountersUnique = countUnique(nutritionIndividualEncountersData);
 		var overallNutritionUnique = ((((nutritionIndividualEncountersUnique + nutritionGroupPmtctEncountersUnique) + nutritionGroupFbfEncountersUnique) + nutritionGroupSorwatheEncountersUnique) + nutritionGroupChwEncountersUnique) + nutritionGroupAchiEncountersUnique;
-		var prenatalDataChwEncountersUnique = countUnique(prenatalDataChwEncounters);
-		var prenatalDataNurseEncountersUnique = countUnique(prenatalDataNurseEncounters);
 		var tuberculosisDataEncountersUnique = countUnique(tuberculosisEncountersData);
 		var wellChildDataEncountersUnique = countUnique(wellChildEncountersData);
 		var countTotal = A2(
@@ -19253,63 +19326,118 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 		var nutritionGroupSorwatheEncountersTotal = countTotal(nutritionGroupSorwatheEncountersData);
 		var nutritionIndividualEncountersTotal = countTotal(nutritionIndividualEncountersData);
 		var overallNutritionTotal = ((((nutritionIndividualEncountersTotal + nutritionGroupPmtctEncountersTotal) + nutritionGroupFbfEncountersTotal) + nutritionGroupSorwatheEncountersTotal) + nutritionGroupChwEncountersTotal) + nutritionGroupAchiEncountersTotal;
-		var prenatalDataChwEncountersTotal = countTotal(prenatalDataChwEncounters);
-		var prenatalDataNurseEncountersTotal = countTotal(prenatalDataNurseEncounters);
 		var tuberculosisDataEncountersTotal = countTotal(tuberculosisEncountersData);
 		var wellChildDataEncountersTotal = countTotal(wellChildEncountersData);
 		var childScorecardEncountersData = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.childScorecardData;
-				},
-				$elm$core$Maybe$map($elm$core$List$concat)),
-			records);
+			loadEncountersIf,
+			ncdaEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.childScorecardData;
+					},
+					$elm$core$Maybe$map($elm$core$List$concat))));
 		var childScorecardDataEncountersUnique = countUnique(childScorecardEncountersData);
 		var childScorecardDataEncountersTotal = countTotal(childScorecardEncountersData);
+		var antenatalEnabled = memberFeature($author$project$App$Types$FeatureAntenatal);
+		var prenatalDataChwEncounters = A2(
+			loadEncountersIf,
+			antenatalEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.prenatalData;
+					},
+					$elm$core$Maybe$map(
+						A2(
+							$elm$core$Basics$composeR,
+							$elm$core$List$concatMap(
+								function ($) {
+									return $.encounters;
+								}),
+							$elm$core$List$filter(
+								function (encounter) {
+									return !A2(
+										$elm$core$List$member,
+										encounter.encounterType,
+										_List_fromArray(
+											[$author$project$Backend$Reports$Model$NurseEncounter, $author$project$Backend$Reports$Model$NursePostpartumEncounter]));
+								}))))));
+		var prenatalDataChwEncountersTotal = countTotal(prenatalDataChwEncounters);
+		var prenatalDataChwEncountersUnique = countUnique(prenatalDataChwEncounters);
+		var prenatalDataNurseEncounters = A2(
+			loadEncountersIf,
+			antenatalEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.prenatalData;
+					},
+					$elm$core$Maybe$map(
+						A2(
+							$elm$core$Basics$composeR,
+							$elm$core$List$concatMap(
+								function ($) {
+									return $.encounters;
+								}),
+							$elm$core$List$filter(
+								function (encounter) {
+									return A2(
+										$elm$core$List$member,
+										encounter.encounterType,
+										_List_fromArray(
+											[$author$project$Backend$Reports$Model$NurseEncounter, $author$project$Backend$Reports$Model$NursePostpartumEncounter]));
+								}))))));
+		var prenatalDataNurseEncountersTotal = countTotal(prenatalDataNurseEncounters);
+		var prenatalDataNurseEncountersUnique = countUnique(prenatalDataNurseEncounters);
+		var acuteIllnessEnabled = memberFeature($author$project$App$Types$FeatureAcuteIllness);
 		var acuteIllnessDataNurseEncounters = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.acuteIllnessData;
-				},
-				$elm$core$Maybe$map(
-					A2(
-						$elm$core$Basics$composeR,
-						$elm$core$List$concat,
-						$elm$core$List$filter(
-							function (encounter) {
-								return A2(
-									$elm$core$List$member,
-									encounter.encounterType,
-									_List_fromArray(
-										[$author$project$Backend$Reports$Model$AcuteIllnessEncounterNurse, $author$project$Backend$Reports$Model$AcuteIllnessEncounterNurseSubsequent]));
-							})))),
-			records);
+			loadEncountersIf,
+			acuteIllnessEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.acuteIllnessData;
+					},
+					$elm$core$Maybe$map(
+						A2(
+							$elm$core$Basics$composeR,
+							$elm$core$List$concat,
+							$elm$core$List$filter(
+								function (encounter) {
+									return A2(
+										$elm$core$List$member,
+										encounter.encounterType,
+										_List_fromArray(
+											[$author$project$Backend$Reports$Model$AcuteIllnessEncounterNurse, $author$project$Backend$Reports$Model$AcuteIllnessEncounterNurseSubsequent]));
+								}))))));
 		var acuteIllnessDataNurseEncountersTotal = countTotal(acuteIllnessDataNurseEncounters);
 		var acuteIllnessDataNurseEncountersUnique = countUnique(acuteIllnessDataNurseEncounters);
 		var acuteIllnessDataChwEncounters = A2(
-			$elm$core$List$filterMap,
-			A2(
-				$elm$core$Basics$composeR,
-				function ($) {
-					return $.acuteIllnessData;
-				},
-				$elm$core$Maybe$map(
-					A2(
-						$elm$core$Basics$composeR,
-						$elm$core$List$concat,
-						$elm$core$List$filter(
-							function (encounter) {
-								return !A2(
-									$elm$core$List$member,
-									encounter.encounterType,
-									_List_fromArray(
-										[$author$project$Backend$Reports$Model$AcuteIllnessEncounterNurse, $author$project$Backend$Reports$Model$AcuteIllnessEncounterNurseSubsequent]));
-							})))),
-			records);
+			loadEncountersIf,
+			acuteIllnessEnabled,
+			$elm$core$List$filterMap(
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.acuteIllnessData;
+					},
+					$elm$core$Maybe$map(
+						A2(
+							$elm$core$Basics$composeR,
+							$elm$core$List$concat,
+							$elm$core$List$filter(
+								function (encounter) {
+									return !A2(
+										$elm$core$List$member,
+										encounter.encounterType,
+										_List_fromArray(
+											[$author$project$Backend$Reports$Model$AcuteIllnessEncounterNurse, $author$project$Backend$Reports$Model$AcuteIllnessEncounterNurseSubsequent]));
+								}))))));
 		var acuteIllnessDataChwEncountersTotal = countTotal(acuteIllnessDataChwEncounters);
 		var overallTotal = ((((((((((prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal) + acuteIllnessDataNurseEncountersTotal) + acuteIllnessDataChwEncountersTotal) + wellChildDataEncountersTotal) + homeVisitDataEncountersTotal) + childScorecardDataEncountersTotal) + ncdDataEncountersTotal) + hivDataEncountersTotal) + tuberculosisDataEncountersTotal) + overallNutritionTotal) + familyNutritionEncountersTotal;
 		var acuteIllnessDataChwEncountersUnique = countUnique(acuteIllnessDataChwEncounters);
@@ -19321,33 +19449,102 @@ var $author$project$Pages$Reports$View$generateDemographicsReportEncountersData 
 				_List_fromArray(
 					[$author$project$Translate$EncounterType, $author$project$Translate$All, $author$project$Translate$Unique])),
 			heading: A2($author$project$Translate$translate, language, $author$project$Translate$Encounters) + ':',
-			rows: _Utils_ap(
+			rows: $elm$core$List$concat(
 				_List_fromArray(
 					[
-						A4(generateRow, $author$project$Translate$ANCTotal, prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal, prenatalDataNurseEncountersUnique + prenatalDataChwEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$HealthCenter, prenatalDataNurseEncountersTotal, prenatalDataNurseEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$CHW, prenatalDataChwEncountersTotal, prenatalDataChwEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$AcuteIllnessTotal, acuteIllnessDataNurseEncountersTotal + acuteIllnessDataChwEncountersTotal, acuteIllnessDataNurseEncountersUnique + acuteIllnessDataChwEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$HealthCenter, acuteIllnessDataNurseEncountersTotal, acuteIllnessDataNurseEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$CHW, acuteIllnessDataChwEncountersTotal, acuteIllnessDataChwEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$StandardPediatricVisit, wellChildDataEncountersTotal, wellChildDataEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$HomeVisit, homeVisitDataEncountersTotal, homeVisitDataEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$ChildScorecard, childScorecardDataEncountersTotal, childScorecardDataEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$NCD, ncdDataEncountersTotal, ncdDataEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$HIV, hivDataEncountersTotal, hivDataEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$Tuberculosis, tuberculosisDataEncountersTotal, tuberculosisDataEncountersUnique, false),
-						A4(generateRow, $author$project$Translate$NutritionTotal, overallNutritionTotal, overallNutritionUnique, false),
-						A4(generateRow, $author$project$Translate$PMTCT, nutritionGroupPmtctEncountersTotal, nutritionGroupPmtctEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$FBF, nutritionGroupFbfEncountersTotal, nutritionGroupFbfEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$Sorwathe, nutritionGroupSorwatheEncountersTotal, nutritionGroupSorwatheEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$CBNP, nutritionGroupChwEncountersTotal, nutritionGroupChwEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$ACHI, nutritionGroupAchiEncountersTotal, nutritionGroupAchiEncountersUnique, true),
-						A4(generateRow, $author$project$Translate$Individual, nutritionIndividualEncountersTotal, nutritionIndividualEncountersUnique, true)
-					]),
-				familyNutritionEnabled ? _List_fromArray(
-					[
-						A4(generateRow, $author$project$Translate$FamilyNutrition, familyNutritionEncountersTotal, familyNutritionEncountersUnique, false)
-					]) : _List_Nil),
+						A2(
+						rowsIf,
+						antenatalEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$ANCTotal, prenatalDataNurseEncountersTotal + prenatalDataChwEncountersTotal, prenatalDataNurseEncountersUnique + prenatalDataChwEncountersUnique, false),
+								A4(generateRow, $author$project$Translate$HealthCenter, prenatalDataNurseEncountersTotal, prenatalDataNurseEncountersUnique, true),
+								A4(generateRow, $author$project$Translate$CHW, prenatalDataChwEncountersTotal, prenatalDataChwEncountersUnique, true)
+							])),
+						A2(
+						rowsIf,
+						acuteIllnessEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$AcuteIllnessTotal, acuteIllnessDataNurseEncountersTotal + acuteIllnessDataChwEncountersTotal, acuteIllnessDataNurseEncountersUnique + acuteIllnessDataChwEncountersUnique, false),
+								A4(generateRow, $author$project$Translate$HealthCenter, acuteIllnessDataNurseEncountersTotal, acuteIllnessDataNurseEncountersUnique, true),
+								A4(generateRow, $author$project$Translate$CHW, acuteIllnessDataChwEncountersTotal, acuteIllnessDataChwEncountersUnique, true)
+							])),
+						A2(
+						rowsIf,
+						wellChildEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$StandardPediatricVisit, wellChildDataEncountersTotal, wellChildDataEncountersUnique, false)
+							])),
+						A2(
+						rowsIf,
+						nutritionIndividualEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$HomeVisit, homeVisitDataEncountersTotal, homeVisitDataEncountersUnique, false)
+							])),
+						A2(
+						rowsIf,
+						ncdaEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$ChildScorecard, childScorecardDataEncountersTotal, childScorecardDataEncountersUnique, false)
+							])),
+						A2(
+						rowsIf,
+						ncdEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$NCD, ncdDataEncountersTotal, ncdDataEncountersUnique, false)
+							])),
+						A2(
+						rowsIf,
+						hivEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$HIV, hivDataEncountersTotal, hivDataEncountersUnique, false)
+							])),
+						A2(
+						rowsIf,
+						tuberculosisEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$Tuberculosis, tuberculosisDataEncountersTotal, tuberculosisDataEncountersUnique, false)
+							])),
+						A2(
+						rowsIf,
+						nutritionAggregateEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$NutritionTotal, overallNutritionTotal, overallNutritionUnique, false)
+							])),
+						A2(
+						rowsIf,
+						nutritionGroupEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$PMTCT, nutritionGroupPmtctEncountersTotal, nutritionGroupPmtctEncountersUnique, true),
+								A4(generateRow, $author$project$Translate$FBF, nutritionGroupFbfEncountersTotal, nutritionGroupFbfEncountersUnique, true),
+								A4(generateRow, $author$project$Translate$Sorwathe, nutritionGroupSorwatheEncountersTotal, nutritionGroupSorwatheEncountersUnique, true),
+								A4(generateRow, $author$project$Translate$CBNP, nutritionGroupChwEncountersTotal, nutritionGroupChwEncountersUnique, true),
+								A4(generateRow, $author$project$Translate$ACHI, nutritionGroupAchiEncountersTotal, nutritionGroupAchiEncountersUnique, true)
+							])),
+						A2(
+						rowsIf,
+						nutritionIndividualEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$Individual, nutritionIndividualEncountersTotal, nutritionIndividualEncountersUnique, true)
+							])),
+						A2(
+						rowsIf,
+						familyNutritionEnabled,
+						_List_fromArray(
+							[
+								A4(generateRow, $author$project$Translate$FamilyNutrition, familyNutritionEncountersTotal, familyNutritionEncountersUnique, false)
+							]))
+					])),
 			totals: {
 				label: A2($author$project$Translate$translate, language, $author$project$Translate$Total),
 				total: $elm$core$String$fromInt(overallTotal),
@@ -22693,6 +22890,37 @@ var $author$project$Pages$Reports$View$viewPrenatalReport = F4(
 						A3($author$project$Pages$Reports$View$viewDownloadCSVButton, language, csvFileName, csvContent)
 					])));
 	});
+var $author$project$Pages$Reports$Utils$visibleReportTypes = function (features) {
+	var member = function (f) {
+		return A2($Gizra$elm_all_set$EverySet$member, f, features);
+	};
+	return A2(
+		$elm$core$List$filter,
+		function (reportType) {
+			switch (reportType.$) {
+				case 'ReportAcuteIllness':
+					return member($author$project$App$Types$FeatureAcuteIllness);
+				case 'ReportDemographics':
+					return true;
+				case 'ReportFBFDistribution':
+					return true;
+				case 'ReportNutrition':
+					return member($author$project$App$Types$FeatureWellChild) || (member($author$project$App$Types$FeatureNutritionIndividual) || (member($author$project$App$Types$FeatureNutritionGroup) || member($author$project$App$Types$FeatureFamilyNutrition)));
+				case 'ReportPeripartum':
+					return member($author$project$App$Types$FeatureAntenatal);
+				case 'ReportPostnatalCare':
+					return member($author$project$App$Types$FeatureWellChild);
+				case 'ReportPrenatal':
+					return member($author$project$App$Types$FeatureAntenatal);
+				case 'ReportPrenatalContacts':
+					return member($author$project$App$Types$FeatureAntenatal);
+				default:
+					return member($author$project$App$Types$FeatureAntenatal);
+			}
+		},
+		_List_fromArray(
+			[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportFBFDistribution, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses]));
+};
 var $author$project$Pages$Reports$View$viewReportsData = F5(
 	function (language, currentDate, themePath, data, model) {
 		var scopeLabel = function () {
@@ -23062,8 +23290,7 @@ var $author$project$Pages$Reports$View$viewReportsData = F5(
 												language,
 												$author$project$Translate$ReportType(rt)));
 									},
-									_List_fromArray(
-										[$author$project$Pages$Reports$Model$ReportAcuteIllness, $author$project$Pages$Reports$Model$ReportDemographics, $author$project$Pages$Reports$Model$ReportFBFDistribution, $author$project$Pages$Reports$Model$ReportNutrition, $author$project$Pages$Reports$Model$ReportPeripartum, $author$project$Pages$Reports$Model$ReportPostnatalCare, $author$project$Pages$Reports$Model$ReportPrenatal, $author$project$Pages$Reports$Model$ReportPrenatalContacts, $author$project$Pages$Reports$Model$ReportPrenatalDiagnoses])),
+									$author$project$Pages$Reports$Utils$visibleReportTypes(data.features)),
 								$author$project$Pages$Reports$Utils$reportTypeToString,
 								$author$project$Pages$Reports$Model$SetReportType,
 								$author$project$Translate$ReportType,

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -20096,6 +20096,7 @@ var $author$project$Pages$Reports$Model$FbfDistributionFbfMother = {$: 'FbfDistr
 var $author$project$Pages$Reports$Model$allFbfDistributionCategories = _List_fromArray(
 	[$author$project$Pages$Reports$Model$FbfDistributionFbfChild, $author$project$Pages$Reports$Model$FbfDistributionFbfMother, $author$project$Pages$Reports$Model$FbfDistributionFbfChildAchi, $author$project$Pages$Reports$Model$FbfDistributionAhezaChild, $author$project$Pages$Reports$Model$FbfDistributionAhezaMother]);
 var $author$project$Pages$Reports$View$visibleFbfDistributionCategories = function (features) {
+	var nutritionGroupEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureNutritionGroup, features);
 	var familyNutritionEnabled = A2($Gizra$elm_all_set$EverySet$member, $author$project$App$Types$FeatureFamilyNutrition, features);
 	return A2(
 		$elm$core$List$filter,
@@ -20106,11 +20107,11 @@ var $author$project$Pages$Reports$View$visibleFbfDistributionCategories = functi
 				case 'FbfDistributionAhezaMother':
 					return familyNutritionEnabled;
 				case 'FbfDistributionFbfChild':
-					return true;
+					return nutritionGroupEnabled;
 				case 'FbfDistributionFbfChildAchi':
-					return true;
+					return nutritionGroupEnabled;
 				default:
-					return true;
+					return nutritionGroupEnabled;
 			}
 		},
 		$author$project$Pages$Reports$Model$allFbfDistributionCategories);
@@ -22903,7 +22904,7 @@ var $author$project$Pages$Reports$Utils$visibleReportTypes = function (features)
 				case 'ReportDemographics':
 					return true;
 				case 'ReportFBFDistribution':
-					return true;
+					return member($author$project$App$Types$FeatureNutritionGroup) || member($author$project$App$Types$FeatureFamilyNutrition);
 				case 'ReportNutrition':
 					return member($author$project$App$Types$FeatureWellChild) || (member($author$project$App$Types$FeatureNutritionIndividual) || (member($author$project$App$Types$FeatureNutritionGroup) || member($author$project$App$Types$FeatureFamilyNutrition)));
 				case 'ReportPeripartum':

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -3209,6 +3209,7 @@ function hedley_reports_build_completion_results_app($health_center = NULL) {
   }
 
   $data['site'] = variable_get('hedley_general_site_name', '');
+  $data['features'] = hedley_admin_get_enabled_features_string();
   $data['params'] = $params;
 
   return hedley_general_build_elm_app('completion-results', $data);

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -3281,23 +3281,12 @@ function hedley_reports_generate_completion_data_for_restful($from_nid, $batch, 
   $count_q->addExpression('COUNT(*)', 'cnt');
   $count = (int) $count_q->execute()->fetchField();
 
-  if ($count === 0) {
-    // No more items left -- return the structured shape Elm expects so
-    // its decoder doesn't fail and leave sync stuck at "PENDING".
-    return [
-      'batch' => [],
-      'total_remaining' => 0,
-      'last' => 0,
-    ];
-  }
-
-  $data_q = $build();
-  $data_q->fields('n', ['nid', 'type'])
-    ->fields('fr', ['field_reports_data_value'])
-    ->orderBy('n.nid')
-    ->range(0, $batch);
-  $rows = $data_q->execute()->fetchAll();
-
+  // Bucket map is shared between the empty-batch and populated-batch
+  // returns so both responses emit the same JSON object shape, with all
+  // bundle keys present (each as an empty array when there's no data).
+  // Without this, an empty batch returned `[]` (a JSON list), and the
+  // Elm decoder's `requiredAt ["batch", "<bundle>"]` paths fail, leaving
+  // the admin Reports page stuck on "PENDING".
   $type_to_bucket = [
     'acute_illness_encounter'    => 'acute_illness',
     'attendance'                 => 'nutrition_group',
@@ -3310,7 +3299,24 @@ function hedley_reports_generate_completion_data_for_restful($from_nid, $batch, 
     'tuberculosis_encounter'     => 'tuberculosis',
     'well_child_encounter'       => 'well_child',
   ];
-  $data = array_fill_keys(array_values($type_to_bucket), []);
+  $empty_batch = array_fill_keys(array_values($type_to_bucket), []);
+
+  if ($count === 0) {
+    return [
+      'batch' => $empty_batch,
+      'total_remaining' => 0,
+      'last' => 0,
+    ];
+  }
+
+  $data_q = $build();
+  $data_q->fields('n', ['nid', 'type'])
+    ->fields('fr', ['field_reports_data_value'])
+    ->orderBy('n.nid')
+    ->range(0, $batch);
+  $rows = $data_q->execute()->fetchAll();
+
+  $data = $empty_batch;
 
   $last = 0;
   foreach ($rows as $r) {


### PR DESCRIPTION
Issue #1401 

## Summary

Both **Statistical Queries** and **Completion** report families now filter the report-type dropdown — and, for multi-source reports, individual rows / data series — against the deployment's enabled SiteFeatures. Mirrors the existing `visibleFbfDistributionCategories` / `familyNutritionEnabled` pattern under `FeatureFamilyNutrition`.

Branched off `issue-1401` (PR #1411) to extend the newly-expanded SiteFeature set with admin-Reports awareness.

## Gating logic (server-side Elm + PHP)

**Statistical Queries (`server/elm/src/Pages/Reports/`)**
- New `visibleReportTypes` helper hides single-source reports when their feature is off (Acute Illness → `FeatureAcuteIllness`; Peripartum / Prenatal / Prenatal Contacts / Prenatal Diagnoses → `FeatureAntenatal`; Postnatal Care → `FeatureWellChild`).
- `ReportNutrition` is hidden only when none of `FeatureWellChild | FeatureNutritionIndividual | FeatureNutritionGroup | FeatureFamilyNutrition` are on; otherwise its data series are filtered per feature inside `calculateNutritionReportDataTask`.
- `ReportDemographics` always shows; rows are filtered per encounter type (ANC → `FeatureAntenatal`; Standard Pediatric Visit → `FeatureWellChild`; Home Visit → `FeatureNutritionIndividual` since it lives under the Nutrition Individual participant page; etc.).
- `ReportFBFDistribution` continues to use the existing `visibleFbfDistributionCategories` (Aheza rows under `FeatureFamilyNutrition`).

**Completion (`server/elm/src/Pages/Completion/`)** — previously had **no** feature awareness.
- PHP: `hedley_reports_build_completion_results_app` now emits `features` via `hedley_admin_get_enabled_features_string()`.
- Elm: `CompletionData` carries `features : EverySet SiteFeature`; decoder consumes it.
- New `visibleReportTypes` filters all 11 single-source Completion subtypes against the corresponding feature flag (e.g., `ReportHomeVisit` → `FeatureNutritionIndividual`).

## Additional fixes uncovered along the way

- **PHP — empty-batch JSON shape** (`hedley_reports_generate_completion_data_for_restful`): when the count was zero, `'batch' => []` JSON-encoded as a list, not an object. The Elm `requiredAt ["batch", "<bundle>"]` decoders silently failed, leaving the admin Completion page stuck on PENDING. Now always returns `batch` as an object with all bundle keys present. Latent bug pre-existing this PR; only surfaced because the new admin tests navigate Completion without first seeding `field_reports_data`.
- **Recompiled `server/hedley/modules/custom/hedley_general/js/elm-main.js`** — the server-elm bundle is checked into git and shipped to Pantheon without rebuilding. Source changes alone don't reach prod until the JS is regenerated.

## Test extension

PR #1411 added a client-side feature-flag on/off pattern (`verifyFeatureGatesEncounterButton` and three siblings). PR #1738 folds **server-side** admin-Reports asserts into the same off/on cycle:

- New `assertAdminGates(browser, expectations, phase)` in `helpers/feature-flags.ts` opens its own admin browser context, `drupalLogin`s, then asserts each named dropdown option / Demographics row is absent (hidden phase) or present (visible phase) on both Statistical Queries and Completion. The context is torn down in `finally`.
- Each of the four PR #1411 helpers gains an optional 4th `opts: { browser, admin }` argument. When supplied, `assertAdminGates` runs twice — once after the off-toggle's client assert, once after the on-toggle's. Single flag cycle, four assertions, full coverage.
- 16 existing specs gained their admin payload (acute-illness × nurse/CHW, prenatal × nurse/CHW, ncd, well-child × nurse/CHW, nutrition × nurse/CHW, hiv, tuberculosis, child-scoreboard, family-nutrition, group-session × nurse/CHW). `education-session`, `stock-management-*`, `feature-gps-coordinates` get no extension — their flags have no admin-Reports impact.
- `nutrition-encounter.spec.ts` also gets a new compound test for "`Nutrition` SQ option drops only when ALL of well_child / nutrition_individual / nutrition_group / family_nutrition are off".

## Test plan

- [x] All three CI e2e jobs (`e2e_playwright_1`, `e2e_playwright_2`, `e2e_reporting`) and all four lint jobs (`lint_elm`, `lint_elm_review`, `lint_phpcs`, `lint_shellcheck`), plus `test_simpletest_linux` and `test_zscore`, pass on the final commit.
- [x] Local DDEV smoke: `EHEZA_SITE=rwanda` with all 16 features ON via `config.local.yaml.example`; SQ dropdown lists 9 reports, Completion dropdown lists 11 subtypes.

Issue #1401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
