### PR TITLE
[Hotfix] Fix empty Nutrition report at Entire population scope

### DIFF
--- a/client/e2e/reporting.spec.ts
+++ b/client/e2e/reporting.spec.ts
@@ -10,6 +10,7 @@ import {
   processAdvancedQueue,
   recalculateLargeDatasets,
   navigateToHCReportsPage,
+  navigateToGlobalReportsPage,
   navigateToReportsMenu,
   selectReportType,
   setDateRange,
@@ -1883,6 +1884,81 @@ test.describe('Admin Reports', () => {
       await expect(
         page.locator('button.download-csv'),
         'FBF Distribution CSV download button should be visible',
+      ).toBeVisible();
+    });
+
+    // ── Phase 3c: Nutrition report at Global scope ──
+    //
+    // Global scope reads from the pre-aggregated Report Data node produced
+    // by recalculate-large-datasets.php (scope='global'). The Elm side
+    // treats EntityGlobal as a "wide scope" (Pages/Reports/Utils.elm
+    // isWideScope) and skips client-side computation, so all 8 tables
+    // come from the backend `additional.nutrition_report_data` JSON.
+    // Guards against regressions where the PHP gate excludes 'global'
+    // and the report renders empty.
+
+    await step('Verify Nutrition report at Global scope', async () => {
+      await navigateToGlobalReportsPage(page);
+      await selectReportType(page, 'nutrition');
+      await page.waitForTimeout(WAIT.pageNavigation);
+
+      await expect(
+        page.locator('div.report.nutrition'),
+        'Nutrition report container should be visible at Global scope',
+      ).toBeVisible();
+
+      console.log('\n=== NUTRITION (GLOBAL) ===');
+
+      const columnHeaders = await readNutritionColumnHeaders(page, 0);
+      console.log(`Columns (${columnHeaders.length}): ${columnHeaders.join(' | ')}`);
+      expect(
+        columnHeaders.length,
+        'Global Nutrition report should have at least one data column',
+      ).toBeGreaterThan(0);
+
+      const allNutritionTables = [
+        ...NUTRITION_ONE_VISIT_TABLES,
+        ...NUTRITION_TWO_VISIT_TABLES,
+      ];
+      let totalNonZeroCells = 0;
+      for (const { index, name } of allNutritionTables) {
+        const rows = await readNutritionTable(page, index);
+        expect(rows.length, `Global ${name}: should have 8 metric rows`).toBe(8);
+
+        const colCount = rows[0]?.values.length ?? 0;
+        expect(colCount, `Global ${name}: should have data columns`).toBeGreaterThan(0);
+
+        expect(
+          findNutritionMetric(rows, 'MAM'),
+          `Global ${name}: MAM row should be present`,
+        ).toBeDefined();
+        expect(
+          findNutritionMetric(rows, 'SAM'),
+          `Global ${name}: SAM row should be present`,
+        ).toBeDefined();
+
+        for (const row of rows) {
+          for (const v of row.values) {
+            if (v > 0) totalNonZeroCells++;
+          }
+        }
+      }
+
+      // Across all 8 tables × 8 rows × N columns, at least one cell must
+      // be non-zero. Test-created nutrition encounters (Phase 1) are
+      // backdated and recalculated into the global aggregate (Phase 2),
+      // so the matrix can never be entirely empty here. An all-zero
+      // matrix indicates the backend additional.nutrition_report_data
+      // payload is missing or malformed — exactly the regression this
+      // step guards against.
+      expect(
+        totalNonZeroCells,
+        'Global Nutrition report should have at least one non-zero cell across all tables',
+      ).toBeGreaterThan(0);
+
+      await expect(
+        page.locator('button.download-csv'),
+        'Nutrition CSV download button should be visible at Global scope',
       ).toBeVisible();
     });
 

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1717,7 +1717,7 @@ function hedley_reports_build_statistical_queries_results_app($province = NULL, 
   $data['features'] = hedley_admin_get_enabled_features_string();
   $data['params'] = $params;
 
-  if (in_array($data['entity_type'], ['province', 'district', 'health-center'])) {
+  if (in_array($data['entity_type'], ['global', 'province', 'district', 'health-center'])) {
     // For large data sets, try loading additional data.
     $data['additional'] = hedley_reports_load_results_additional_data('statistical-query', $data['entity_type'], $province, $district, $health_center);
   }

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1717,7 +1717,8 @@ function hedley_reports_build_statistical_queries_results_app($province = NULL, 
   $data['features'] = hedley_admin_get_enabled_features_string();
   $data['params'] = $params;
 
-  if (in_array($data['entity_type'], ['global', 'province', 'district', 'health-center'])) {
+  $wide_scopes = ['global', 'province', 'district', 'health-center'];
+  if (in_array($data['entity_type'], $wide_scopes)) {
     // For large data sets, try loading additional data.
     $data['additional'] = hedley_reports_load_results_additional_data('statistical-query', $data['entity_type'], $province, $district, $health_center);
   }

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -2256,7 +2256,7 @@ function hedley_reports_generate_results_data_node_title($report_variant, $scope
       break;
 
     default:
-      $suffix = 'Glodal';
+      $suffix = 'Global';
   }
 
   return "$prefix report data - $suffix";


### PR DESCRIPTION
## Summary

- Statistical Queries → Entire population → Nutrition was rendering empty. PHP gate that attaches the pre-aggregated `additional.nutrition_report_data` to the Elm app skipped `'global'` scope, while Elm's `isWideScope` treats `EntityGlobal` as wide and skips client-side computation — so neither side filled the tables.
- Fix: add `'global'` to the gate in `hedley_reports_build_statistical_queries_results_app()`. The `recalculate-large-datasets.php` script already produces the `'global'`-scope Report Data node.
- E2E: add a Global-scope Nutrition step to `reporting.spec.ts` so this regression is caught next time. Asserts 8 tables × 8 metric rows (incl. MAM/SAM) and at least one non-zero cell across the whole matrix.

Closes #1739

## Test plan

- [ ] On a freshly synced env: run `drush scr profiles/hedley/modules/custom/hedley_reports/scripts/recalculate-large-datasets.php --scope=global`
- [ ] Open Statistical Queries → Entire population → Nutrition, verify all 8 tables render with data and CSV download is visible
- [ ] Reporting e2e test (`reporting.spec.ts`) passes through the new "Verify Nutrition report at Global scope" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)