### PR TITLE
Hoist node_load_multiple in group session completion loop

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -3543,8 +3543,9 @@ function hedley_reports_generate_completion_data_for_nutrition_group_encounter($
   $fbf_launch_date_obj = new DateTime($fbf_launch_date);
 
   // Processing measurements by participant type.
+  $persons = node_load_multiple(array_keys($measurements_by_participant));
   foreach ($measurements_by_participant as $person_id => $measurements) {
-    $person = node_load($person_id);
+    $person = $persons[$person_id];
     // Ordering measurements by type.
     $measurements_by_type = [];
     foreach ($measurements as $measurement) {


### PR DESCRIPTION
## Summary

- Eliminates an N+1 in `hedley_reports_generate_completion_data_for_nutrition_group_encounter`: per-iteration `node_load($person_id)` replaced with one hoisted `node_load_multiple(array_keys($measurements_by_participant))`.
- With typical group sessions of ~50 participants this drops ~50 single-row entity loads per encounter to one.

## Test plan

- [ ] Run an in-progress group session through completion-data generation and confirm the resulting `field_reports_data` value matches the pre-change output.
- [ ] Run `ddev phpcs` on `hedley_reports.module` — confirm no errors and no warnings (verified locally).

Issue #1745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)