### PR TITLE
Remove unused InmmunizationEncounter constructor

### DIFF
--- a/client/src/elm/Backend/IndividualEncounterParticipant/Model.elm
+++ b/client/src/elm/Backend/IndividualEncounterParticipant/Model.elm
@@ -74,8 +74,6 @@ type IndividualEncounterType
     | NutritionEncounter
     | TuberculosisEncounter
     | WellChildEncounter
-      -- @todo : can be removed?
-    | InmmunizationEncounter
 
 
 type DeliveryLocation

--- a/client/src/elm/Backend/IndividualEncounterParticipant/Utils.elm
+++ b/client/src/elm/Backend/IndividualEncounterParticipant/Utils.elm
@@ -25,9 +25,6 @@ individualEncounterTypeToString encounterType =
         HomeVisitEncounter ->
             "home-visit"
 
-        InmmunizationEncounter ->
-            "inmmunization"
-
         NCDEncounter ->
             "ncd"
 
@@ -58,9 +55,6 @@ individualEncounterTypeFromString string =
 
         "home-visit" ->
             Just HomeVisitEncounter
-
-        "inmmunization" ->
-            Just InmmunizationEncounter
 
         "ncd" ->
             Just NCDEncounter

--- a/client/src/elm/Backend/Person/Utils.elm
+++ b/client/src/elm/Backend/Person/Utils.elm
@@ -190,9 +190,6 @@ initiatorFromUrlFragment s =
         "antenatal" ->
             IndividualEncounterOrigin AntenatalEncounter |> Just
 
-        "inmmunization" ->
-            IndividualEncounterOrigin InmmunizationEncounter |> Just
-
         "nutrition" ->
             IndividualEncounterOrigin NutritionEncounter |> Just
 

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4496,11 +4496,6 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
 
                                                     WellChildEncounter ->
                                                         WellChildParticipantPage InitiatorParticipantsPage personId
-
-                                                    -- Note yet implemented. Providing 'default'
-                                                    -- page, to satisfy compiler.
-                                                    InmmunizationEncounter ->
-                                                        IndividualEncounterTypesPage
                                         in
                                         ( [ resetFormMsg, navigationMsg nextPage ]
                                         , []
@@ -4773,9 +4768,6 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
 
                                         _ ->
                                             []
-
-                                InmmunizationEncounter ->
-                                    []
                         )
                         data
                         |> RemoteData.withDefault []

--- a/client/src/elm/Pages/IndividualEncounterParticipants/View.elm
+++ b/client/src/elm/Pages/IndividualEncounterParticipants/View.elm
@@ -118,10 +118,6 @@ viewSearchForm language currentDate ( healthCenterId, maybeVillageId ) isChw enc
                         |> Maybe.map not
                         |> Maybe.withDefault False
 
-                InmmunizationEncounter ->
-                    -- Not in use (possibly future development).
-                    False
-
         -- For CHW nurse, we present people only from the village that was selected.
         chwCondition person =
             if isChw then
@@ -237,10 +233,6 @@ viewParticipant language currentDate encounterType id person =
 
                 WellChildEncounter ->
                     [ onClick <| SetActivePage <| UserPage <| WellChildParticipantPage InitiatorParticipantsPage id ]
-
-                InmmunizationEncounter ->
-                    -- Not implemented (possibly future development).
-                    []
 
         viewAction =
             div [ class "action" ]

--- a/client/src/elm/Pages/Person/View.elm
+++ b/client/src/elm/Pages/Person/View.elm
@@ -698,17 +698,6 @@ viewCreateEditForm language currentDate coordinates site features geoInfo revers
                             , title = Translate.People
                             }
 
-                        -- Note yet implemented. Providing 'default'
-                        -- values, to satisfy compiler.
-                        InmmunizationEncounter ->
-                            { goBackPage = PinCodePage
-                            , expectedAge = ExpectAdultOrChild
-                            , expectedGender = ExpectMaleOrFemale
-                            , birthDateSelectorFrom = Date.add Years -120 today
-                            , birthDateSelectorTo = today
-                            , title = Translate.People
-                            }
-
                 GroupEncounterOrigin sessionId ->
                     let
                         expectedAge =

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -6752,9 +6752,6 @@ translationSet trans =
                     , somali = Just "Ma dooneysaa inaad billowdo u kuurgalida Booqashada Guriga ee"
                     }
 
-                InmmunizationEncounter ->
-                    translationSet EmptyString
-
                 Backend.IndividualEncounterParticipant.Model.NutritionEncounter ->
                     translationSet EmptyString
 
@@ -9170,13 +9167,6 @@ translationSet trans =
                     , somali = Just "Ogaanshaha Booqashada Guriga Koowaad"
                     }
 
-                InmmunizationEncounter ->
-                    { english = "First Inmmunization Encounter"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Kuronka urucanco ubwa mbere"
-                    , somali = Just "Ogaanshaha Tallaalka Koowaad"
-                    }
-
                 NCDEncounter ->
                     { english = "First NCD Encounter"
                     , kinyarwanda = Just "Isuzuma rya mbere kuburwayi butandura"
@@ -9240,13 +9230,6 @@ translationSet trans =
                     , kinyarwanda = Just "Gusura abarwayi mu rugo"
                     , kirundi = Just "Umubonano mu gihe co kugendera muhira"
                     , somali = Just "Ognaashaha Booqashada Guriga"
-                    }
-
-                InmmunizationEncounter ->
-                    { english = "Inmmunization Encounter"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Nothing
                     }
 
                 NCDEncounter ->
@@ -9316,13 +9299,6 @@ translationSet trans =
                     , kinyarwanda = Just "Hitamo Gusura Umurwayi"
                     , kirundi = Just "Hitamo Gusura Umugwayi"
                     , somali = Just "Dooro Booqasho Guri"
-                    }
-
-                InmmunizationEncounter ->
-                    { english = "Select Inmmunization Visit"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Just "Dooro Booqasho Tallaal"
                     }
 
                 NCDEncounter ->
@@ -9398,13 +9374,6 @@ translationSet trans =
                     , somali = Just "Booqashada Guriga is Xig xigta"
                     }
 
-                InmmunizationEncounter ->
-                    { english = "Subsequent Inmmunization Encounter"
-                    , kinyarwanda = Nothing
-                    , kirundi = Nothing
-                    , somali = Just "Ogaanshaha Tallaalka is Xig xiga"
-                    }
-
                 NCDEncounter ->
                     { english = "Subsequent NCD Visit"
                     , kinyarwanda = Just "Isuzuma Rikurikiyeho ku Burwayi Butandura"
@@ -9453,13 +9422,6 @@ translationSet trans =
 
                 HomeVisitEncounter ->
                     translationSet HomeVisit
-
-                InmmunizationEncounter ->
-                    { english = "Inmmunization"
-                    , kinyarwanda = Nothing
-                    , kirundi = Just "Incanco"
-                    , somali = Just "Tallaal"
-                    }
 
                 NCDEncounter ->
                     { english = "Noncommunicable Diseases"
@@ -29417,13 +29379,6 @@ translateActivePage page =
                             , kinyarwanda = Nothing
                             , kirundi = Nothing
                             , somali = Just "Ka qeyb galayaasha Booqashada Guriga"
-                            }
-
-                        InmmunizationEncounter ->
-                            { english = "Inmmunization Participants"
-                            , kinyarwanda = Nothing
-                            , kirundi = Nothing
-                            , somali = Just "Ka Qeyb galayaasha Tallaalka"
                             }
 
                         NCDEncounter ->

--- a/server/hedley/modules/custom/hedley_schedule/hedley_schedule.features.field_base.inc
+++ b/server/hedley/modules/custom/hedley_schedule/hedley_schedule.features.field_base.inc
@@ -244,7 +244,6 @@ function hedley_schedule_field_default_field_bases() {
         'nutrition' => 'Nutrition',
         'tuberculosis' => 'Tuberculosis',
         'well-child' => 'Well Child',
-        'inmmunization' => 'Inmmunization',
       ),
       'allowed_values_function' => '',
     ),


### PR DESCRIPTION
#1755

## Summary

- Drops the unused `InmmunizationEncounter` constructor from the `IndividualEncounterType` union and every case branch that referenced it (8 Elm files, 83 lines deleted).
- Removes the `'inmmunization' => 'Inmmunization'` allowed value from the `field_encounter_type` Features export (`hedley_schedule.features.field_base.inc`) — picked up on deploy by the existing `drush fra` step.

## Verification

- `elm make` compiles cleanly (548 modules).
- `elm-format --validate` clean on edited files.
- `ddev phpcs` clean on the edited PHP.
- Live-DB check on `ihangane.live`: zero rows with `field_encounter_type_value='inmmunization'` in both `field_data_field_encounter_type` and `field_revision_field_encounter_type`.

## Test plan

- [x] CircleCI green (lint_phpcs, lint_elm, lint_shellcheck, test_simpletest_linux)
- [ ] On deploy environment: `drush fra` applies cleanly and the `field_encounter_type` field no longer lists `inmmunization`
- [ ] Smoke: navigate the encounter-type picker — the page renders normally and existing encounter types still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
