### PR TITLE
Translate hardcoded fallback error strings

### DIFF
--- a/client/src/elm/Pages/Participant/View.elm
+++ b/client/src/elm/Pages/Participant/View.elm
@@ -63,13 +63,12 @@ viewChild language currentDate zscores site features isChw childId ( sessionId, 
             viewFoundChild language currentDate zscores site features isChw ( childId, child ) ( sessionId, session ) pages db model
 
         Nothing ->
-            -- TODO: Make this error a little nicer, and translatable ... it
-            -- could occur for real if an invalid or out-of-date URL is
-            -- entered, for instance. It shouldn't occur through normal
-            -- navigation if the session is consistent (i.e. absent bugs).
+            -- Reachable if an invalid or out-of-date URL is entered. Should
+            -- not occur through normal navigation if the session is
+            -- consistent (i.e. absent bugs).
             div [ class "wrap" ]
-                [ h3 [] [ text "Internal error" ]
-                , p [] [ text "Error in Pages.Participant.View.viewChild -- child could not be found." ]
+                [ h3 [] [ text <| translate language Translate.InternalError ]
+                , p [] [ text <| translate language Translate.ChildNotFoundError ]
                 ]
 
 
@@ -284,13 +283,12 @@ viewMother language currentDate zscores site features isChw motherId ( sessionId
             viewFoundMother language currentDate zscores site features isChw ( motherId, mother ) ( sessionId, session ) pages db model
 
         Nothing ->
-            -- TODO: Make this error a little nicer, and translatable ... it
-            -- could occur for real if an invalid or out-of-date URL is
-            -- entered, for instance. It shouldn't occur through normal
-            -- navigation if the session is consistent (i.e. absent bugs).
+            -- Reachable if an invalid or out-of-date URL is entered. Should
+            -- not occur through normal navigation if the session is
+            -- consistent (i.e. absent bugs).
             div [ class "wrap" ]
-                [ h3 [] [ text "Internal error" ]
-                , p [] [ text "Error in Pages.Participant.View.viewMother -- mother could not be found." ]
+                [ h3 [] [ text <| translate language Translate.InternalError ]
+                , p [] [ text <| translate language Translate.MotherNotFoundError ]
                 ]
 
 

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -525,6 +525,7 @@ type TranslationId
     | ChildIdentification
     | ChildNutritionSignLabel ChildNutritionSign
     | ChildName
+    | ChildNotFoundError
     | ChildNutrition
     | Children
     | ChildrenNames
@@ -905,6 +906,7 @@ type TranslationId
     | InfrastructureEnvironmentWash
     | InitialResultsDisplay InitialResultsDisplay
     | InitiationDate
+    | InternalError
     | IntractableVomiting Bool
     | IntractableVomitingQuestion
     | InstructionsChooseOneMedication
@@ -1151,6 +1153,7 @@ type TranslationId
     | MotherId
     | MotherName String
     | MotherNameLabel
+    | MotherNotFoundError
     | MTDIn
     | MTDOut
     | MUAC
@@ -4745,6 +4748,13 @@ translationSet trans =
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Just "Magaca Canuga"
+            }
+
+        ChildNotFoundError ->
+            { english = "Could not find this child."
+            , kinyarwanda = Just "Uyu mwana ntiyabashije kuboneka."
+            , kirundi = Just "Uyu mwana ntiyaronse."
+            , somali = Just "Canugan lama helin."
             }
 
         ChildNutrition ->
@@ -9537,6 +9547,13 @@ translationSet trans =
             , somali = Nothing
             }
 
+        InternalError ->
+            { english = "Internal error"
+            , kinyarwanda = Just "Ikosa rya sisitemu"
+            , kirundi = Just "Ikosa ryo muri sisitemu"
+            , somali = Just "Khalad gudaha ah"
+            }
+
         IntractableVomiting isIntractable ->
             if isIntractable then
                 { english = "Intractable Vomiting"
@@ -13364,6 +13381,13 @@ translationSet trans =
             , kinyarwanda = Just "Izina ry'umubyeyi"
             , kirundi = Just "Izina rya mama"
             , somali = Just "Magaca Hooyada"
+            }
+
+        MotherNotFoundError ->
+            { english = "Could not find this mother."
+            , kinyarwanda = Just "Uyu mubyeyi ntiyabashije kuboneka."
+            , kirundi = Just "Uyu muvyeyi ntiyaronse."
+            , somali = Just "Hooyadan lama helin."
             }
 
         MTDIn ->

--- a/server/elm/src/App/View.elm
+++ b/server/elm/src/App/View.elm
@@ -11,6 +11,7 @@ import Pages.Reports.View
 import Pages.ReportsMenu.View
 import Pages.Scoreboard.View
 import Pages.ScoreboardMenu.View
+import Translate exposing (translate)
 
 
 view : Model -> Html Msg
@@ -83,4 +84,4 @@ view model =
 
         NotFound ->
             div []
-                [ text "Wrong page?" ]
+                [ text <| translate model.language Translate.WrongPage ]

--- a/server/elm/src/Translate.elm
+++ b/server/elm/src/Translate.elm
@@ -282,6 +282,7 @@ type TranslationId
     | WastingSevere
     | WellChildActivity WellChildActivity
     | WideScopeNote
+    | WrongPage
     | Year Int
     | YearLabel
     | Zone
@@ -3671,6 +3672,13 @@ translationSet transId =
             , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Nothing
+            }
+
+        WrongPage ->
+            { english = "Wrong page?"
+            , kinyarwanda = Just "Urupapuro rutari rwo?"
+            , kirundi = Just "Urupapuro rutari rwo?"
+            , somali = Just "Bogga ma khaldanyahay?"
             }
 
         Year year ->

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -12599,34 +12599,12 @@ var $author$project$App$Update$init = function (flags) {
 };
 var $elm$core$Platform$Sub$batch = _Platform_batch;
 var $elm$core$Platform$Sub$none = $elm$core$Platform$Sub$batch(_List_Nil);
+var $author$project$Translate$WrongPage = {$: 'WrongPage'};
 var $elm$html$Html$div = _VirtualDom_node('div');
 var $elm$virtual_dom$VirtualDom$map = _VirtualDom_map;
 var $elm$html$Html$map = $elm$virtual_dom$VirtualDom$map;
 var $elm$virtual_dom$VirtualDom$text = _VirtualDom_text;
 var $elm$html$Html$text = $elm$virtual_dom$VirtualDom$text;
-var $elm$html$Html$Attributes$stringProperty = F2(
-	function (key, string) {
-		return A2(
-			_VirtualDom_property,
-			key,
-			$elm$json$Json$Encode$string(string));
-	});
-var $elm$html$Html$Attributes$class = $elm$html$Html$Attributes$stringProperty('className');
-var $author$project$Utils$Html$emptyNode = $elm$html$Html$text('');
-var $elm$html$Html$ul = _VirtualDom_node('ul');
-var $elm$html$Html$li = _VirtualDom_node('li');
-var $author$project$Translate$ErrorBadPayload = function (a) {
-	return {$: 'ErrorBadPayload', a: a};
-};
-var $author$project$Translate$ErrorBadStatus = function (a) {
-	return {$: 'ErrorBadStatus', a: a};
-};
-var $author$project$Translate$ErrorBadUrl = {$: 'ErrorBadUrl'};
-var $author$project$Translate$ErrorNetworkError = {$: 'ErrorNetworkError'};
-var $author$project$Translate$ErrorTimeout = {$: 'ErrorTimeout'};
-var $author$project$Translate$HttpError = function (a) {
-	return {$: 'HttpError', a: a};
-};
 var $author$project$Translate$AcuteIllness = {$: 'AcuteIllness'};
 var $author$project$Translate$Antenatal = {$: 'Antenatal'};
 var $author$project$Translate$Caring = {$: 'Caring'};
@@ -14953,6 +14931,13 @@ var $author$project$Translate$translationSet = function (transId) {
 				}
 			case 'WideScopeNote':
 				return {english: 'The selected scope may contain a large number of patients and report generation could take several minutes.', kinyarwanda: $elm$core$Maybe$Nothing, kirundi: $elm$core$Maybe$Nothing, somali: $elm$core$Maybe$Nothing};
+			case 'WrongPage':
+				return {
+					english: 'Wrong page?',
+					kinyarwanda: $elm$core$Maybe$Just('Urupapuro rutari rwo?'),
+					kirundi: $elm$core$Maybe$Just('Urupapuro rutari rwo?'),
+					somali: $elm$core$Maybe$Just('Bogga ma khaldanyahay?')
+				};
 			case 'Year':
 				var year = transId.a;
 				return {
@@ -15010,6 +14995,29 @@ var $author$project$Translate$translate = F2(
 					}(set));
 		}
 	});
+var $elm$html$Html$Attributes$stringProperty = F2(
+	function (key, string) {
+		return A2(
+			_VirtualDom_property,
+			key,
+			$elm$json$Json$Encode$string(string));
+	});
+var $elm$html$Html$Attributes$class = $elm$html$Html$Attributes$stringProperty('className');
+var $author$project$Utils$Html$emptyNode = $elm$html$Html$text('');
+var $elm$html$Html$ul = _VirtualDom_node('ul');
+var $elm$html$Html$li = _VirtualDom_node('li');
+var $author$project$Translate$ErrorBadPayload = function (a) {
+	return {$: 'ErrorBadPayload', a: a};
+};
+var $author$project$Translate$ErrorBadStatus = function (a) {
+	return {$: 'ErrorBadStatus', a: a};
+};
+var $author$project$Translate$ErrorBadUrl = {$: 'ErrorBadUrl'};
+var $author$project$Translate$ErrorNetworkError = {$: 'ErrorNetworkError'};
+var $author$project$Translate$ErrorTimeout = {$: 'ErrorTimeout'};
+var $author$project$Translate$HttpError = function (a) {
+	return {$: 'HttpError', a: a};
+};
 var $author$project$Utils$WebData$errorString = F2(
 	function (language, error) {
 		switch (error.$) {
@@ -45818,7 +45826,8 @@ var $author$project$App$View$view = function (model) {
 				_List_Nil,
 				_List_fromArray(
 					[
-						$elm$html$Html$text('Wrong page?')
+						$elm$html$Html$text(
+						A2($author$project$Translate$translate, model.language, $author$project$Translate$WrongPage))
 					]));
 	}
 };


### PR DESCRIPTION
#1759

## Summary

Replaces 3 hardcoded English fallback strings that previously rendered to real users:

- **`Pages/Participant/View.elm`**: both paired `Nothing ->` branches in `viewChild` and `viewMother` (reachable from stale/invalid URLs when the session no longer contains the referenced participant). The module-path-leaking text ("Error in Pages.Participant.View.viewChild -- child could not be found.") is replaced with friendlier copy ("Could not find this child/mother."). Drops the related TODO comments.
- **`server/elm/src/App/View.elm`**: the NotFound page's `text "Wrong page?"` on the server-side admin Elm app.

Adds 3 new `TranslationId` variants to client `Translate.elm` (`ChildNotFoundError`, `InternalError`, `MotherNotFoundError`) and 1 to server `Translate.elm` (`WrongPage`). Server `elm-main.js` bundle regenerated per the project rule.

## Verification

- `elm make` clean on both client and server.
- `elm-format --validate` clean on all edited files.
- `server/hedley/modules/custom/hedley_general/js/elm-main.js` regenerated.

## Translation review needed

Kinyarwanda/Kirundi/Somali entries were drafted from existing patterns in the same file (`PageNotFoundMsg`, `NoMatchesFound`, `BackendError`, `MotherName`):

| Token | English | Kinyarwanda | Kirundi | Somali |
|---|---|---|---|---|
| `ChildNotFoundError` | Could not find this child. | Uyu mwana ntiyabashije kuboneka. | Uyu mwana ntiyaronse. | Canugan lama helin. |
| `InternalError` | Internal error | Ikosa rya sisitemu | Ikosa ryo muri sisitemu | Khalad gudaha ah |
| `MotherNotFoundError` | Could not find this mother. | Uyu mubyeyi ntiyabashije kuboneka. | Uyu muvyeyi ntiyaronse. | Hooyadan lama helin. |
| `WrongPage` | Wrong page? | Urupapuro rutari rwo? | Urupapuro rutari rwo? | Bogga ma khaldanyahay? |

**Please get a native-speaker pass on these** before merge — they're consistent with existing project vocabulary but I (the author) am not fluent.

## Test plan

- [ ] CircleCI green
- [ ] Smoke: navigate to a stale clinic-session URL with a child/mother that doesn't exist → page renders translated "Could not find this child/mother." in the active language instead of the debug-style English
- [ ] Smoke: hit any bad URL on the reports admin site → renders translated "Wrong page?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
