### PR TITLE
Drop unused Dropzone dictDefaultMessage option

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1838,11 +1838,12 @@ function attachDropzone() {
     return;
   }
 
-  // TODO: Feed the dictDefaultMessage in as a param, so we can use the
-  // translated version.
+  // The default message is rendered by Elm inside `.dz-message`. Dropzone
+  // detects the pre-existing element (see Dropzone.js init guard against
+  // `.dz-message`) and leaves the translated content in place, so we do
+  // not need to pass `dictDefaultMessage` here.
   dropZone = new Dropzone(selector, {
     url: "cache-upload/images",
-    dictDefaultMessage: "Touch here to take a photo, or drop a photo file here.",
     acceptedFiles: "jpg,jpeg,png,gif,image/*",
     capture: 'camera',
     resizeWidth: 600,


### PR DESCRIPTION
#1761

## Summary

Drops the unused `dictDefaultMessage` Dropzone option and the stale TODO above it. Elm already renders the translated message inside `.dz-message`, and Dropzone 5.7.0's init guard (`dropzone.js:1218`) preserves the pre-existing element instead of overwriting it — so the JS English string was never displayed.

## Verification

- **Static analysis:** `grep dictDefaultMessage dropzone.js` → 2 hits, only one of which is a use site, gated by `!this.element.querySelector(".dz-message")`. Since Elm always renders `.dz-message` first, this branch never fires.
- **Runtime test:** built a minimal HTML harness mirroring the exact DOM Elm produces and called `new Dropzone(...)` with the existing options. After init: message count stays at 1, pre-existing translated content preserved verbatim, the `dictDefaultMessage` string never appears anywhere in the DOM.

## Test plan

- [ ] CircleCI green
- [ ] Smoke (Kinyarwanda/Kirundi/Somali): open any photo-capture page and verify the dropzone's prompt is in the active language, not English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
