### PR TITLE
Propagate person updates to the OpenMRS patient (Phase 1.5)

### DIFF
--- a/integration/openfn/jobs/load.js
+++ b/integration/openfn/jobs/load.js
@@ -4,10 +4,12 @@
  *
  * Input  (state.data): the E-Heza person payload (person_uuid).
  *        (state.openmrsPatient): the transform output — the POST body.
- *        (state.match): { action: 'link' | 'create', patientUuid }.
+ *        (state.match): { action: 'link' | 'create' | 'update', patientUuid }.
  *        (state.configuration): OpenMRS URL + auth, E-Heza write-back URL
  *        + shared secret.
  * Output (state.loadResult): { action, patientUuid, openmrsId }.
+ *        On 'update' the write-back endpoint is not called — the OpenMRS
+ *        UUID is unchanged. See integration/patient-update.md.
  *
  * Adaptor: @openfn/language-http
  */
@@ -86,9 +88,11 @@ const updatePatient = async (state, cfg, patientUuid) => {
   const rep =
     'custom:(uuid,identifiers:(uuid,identifierType:(uuid)),person:' +
     '(uuid,addresses:(uuid),attributes:(uuid,attributeType:(uuid)),preferredName:(uuid)))';
+  // Pass `v` through the adaptor's `query` option so reserved chars in
+  // the custom-rep value are encoded — same pattern as match.js.
   const res = await get(
-    cfg.openmrsBaseUrl + '/patient/' + patientUuid + '?v=' + rep,
-    { headers: authHeaders }
+    cfg.openmrsBaseUrl + '/patient/' + patientUuid,
+    { query: { v: rep }, headers: authHeaders }
   )(state);
   const got = res.data || {};
   const gotPerson = got.person || {};

--- a/integration/openfn/jobs/load.js
+++ b/integration/openfn/jobs/load.js
@@ -67,6 +67,130 @@ const resolveIdentifiers = (patient, openmrsId) => ({
   }),
 });
 
+/**
+ * Apply the transform's desired patient body onto an existing OpenMRS
+ * patient — additive, never destructive (Phase 1.5 policy):
+ *   - Empty source fields → no write; OpenMRS's value is preserved.
+ *   - Non-empty source fields → POST to the matching OpenMRS subresource.
+ *   - identifiers / attributes upserted by their `identifierType` /
+ *     `attributeType` (one per type, the OpenMRS convention).
+ *   - `autoGenerate` placeholders are skipped (only meaningful on create).
+ *
+ * One GET discovers the subresource UUIDs; everything after is POSTs.
+ */
+const updatePatient = async (state, cfg, patientUuid) => {
+  const desired = state.openmrsPatient || {};
+  const desiredPerson = desired.person || {};
+  const authHeaders = { Authorization: cfg.openmrsAuth };
+
+  const rep =
+    'custom:(uuid,identifiers:(uuid,identifierType:(uuid)),person:' +
+    '(uuid,addresses:(uuid),attributes:(uuid,attributeType:(uuid)),preferredName:(uuid)))';
+  const res = await get(
+    cfg.openmrsBaseUrl + '/patient/' + patientUuid + '?v=' + rep,
+    { headers: authHeaders }
+  )(state);
+  const got = res.data || {};
+  const gotPerson = got.person || {};
+  const personUuid = gotPerson.uuid;
+  if (!personUuid) {
+    throw new Error('update: GET /patient returned no person uuid');
+  }
+
+  const personPath = cfg.openmrsBaseUrl + '/person/' + personUuid;
+  const patientPath = cfg.openmrsBaseUrl + '/patient/' + patientUuid;
+
+  // Person-level patch. Gender 'U' is the transform's fallback for an
+  // empty source — skip it so OpenMRS keeps its real value.
+  const personPatch = {};
+  if (desiredPerson.gender && desiredPerson.gender !== 'U') {
+    personPatch.gender = desiredPerson.gender;
+  }
+  if (desiredPerson.birthdate) {
+    personPatch.birthdate = desiredPerson.birthdate;
+    personPatch.birthdateEstimated = !!desiredPerson.birthdateEstimated;
+  }
+  if (Object.keys(personPatch).length > 0) {
+    await post(personPath, personPatch, { headers: authHeaders })(state);
+  }
+
+  // Name — upsert the preferred name.
+  const desiredName = (desiredPerson.names || [])[0];
+  if (desiredName) {
+    const namePatch = {};
+    if (desiredName.givenName) namePatch.givenName = desiredName.givenName;
+    if (desiredName.familyName) namePatch.familyName = desiredName.familyName;
+    if (Object.keys(namePatch).length > 0) {
+      const nameUuid = gotPerson.preferredName && gotPerson.preferredName.uuid;
+      if (nameUuid) {
+        await post(personPath + '/name/' + nameUuid, namePatch, {
+          headers: authHeaders,
+        })(state);
+      } else {
+        await post(
+          personPath + '/name',
+          { ...namePatch, preferred: true },
+          { headers: authHeaders }
+        )(state);
+      }
+    }
+  }
+
+  // Address — one PersonAddress per person here; upsert it.
+  const desiredAddress = (desiredPerson.addresses || [])[0];
+  if (desiredAddress) {
+    const addrUuid = ((gotPerson.addresses || [])[0] || {}).uuid;
+    if (addrUuid) {
+      await post(personPath + '/address/' + addrUuid, desiredAddress, {
+        headers: authHeaders,
+      })(state);
+    } else {
+      await post(personPath + '/address', desiredAddress, {
+        headers: authHeaders,
+      })(state);
+    }
+  }
+
+  // Identifiers — upsert by identifierType; skip autoGenerate placeholders.
+  for (const id of desired.identifiers || []) {
+    if (id.autoGenerate) {
+      continue;
+    }
+    const existing = (got.identifiers || []).find(
+      (i) => i.identifierType && i.identifierType.uuid === id.identifierType
+    );
+    if (existing) {
+      await post(
+        patientPath + '/identifier/' + existing.uuid,
+        { identifier: id.identifier },
+        { headers: authHeaders }
+      )(state);
+    } else {
+      await post(patientPath + '/identifier', id, {
+        headers: authHeaders,
+      })(state);
+    }
+  }
+
+  // PersonAttributes — upsert by attributeType.
+  for (const attr of desiredPerson.attributes || []) {
+    const existing = (gotPerson.attributes || []).find(
+      (a) => a.attributeType && a.attributeType.uuid === attr.attributeType
+    );
+    if (existing) {
+      await post(
+        personPath + '/attribute/' + existing.uuid,
+        { value: attr.value },
+        { headers: authHeaders }
+      )(state);
+    } else {
+      await post(personPath + '/attribute', attr, {
+        headers: authHeaders,
+      })(state);
+    }
+  }
+};
+
 fn(async (state) => {
   const person = state.data || {};
   const match = state.match || {};
@@ -75,7 +199,16 @@ fn(async (state) => {
   let patientUuid;
   let openmrsId = null;
 
-  if (match.action === 'link') {
+  if (match.action === 'update') {
+    patientUuid = match.patientUuid;
+    await updatePatient(state, cfg, patientUuid);
+    console.log('Loaded', person.person_uuid, '->', match.action, patientUuid);
+    return {
+      ...state,
+      data: person,
+      loadResult: { action: 'update', patientUuid, openmrsId: null },
+    };
+  } else if (match.action === 'link') {
     patientUuid = match.patientUuid;
   } else if (match.action === 'create') {
     let patient = state.openmrsPatient || {};

--- a/integration/openfn/jobs/load.test.js
+++ b/integration/openfn/jobs/load.test.js
@@ -18,6 +18,8 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 let postCalls = [];
+let getResponse = null;
+let getCalls = [];
 
 /** Stand-in for the HTTP adaptor's `post(path, data, options)` — records the call. */
 function fakePost(url, data, options) {
@@ -34,6 +36,14 @@ function fakePost(url, data, options) {
   };
 }
 
+/** Stand-in for the HTTP adaptor's `get(path, options)` — used by the update branch. */
+function fakeGet(url, options) {
+  return (state) => {
+    getCalls.push({ url, headers: (options && options.headers) || {} });
+    return { ...state, data: getResponse };
+  };
+}
+
 /** Evaluate load.js in the current realm, returning its async operation. */
 function loadJob() {
   const src = fs.readFileSync(path.join(__dirname, 'load.js'), 'utf8');
@@ -42,6 +52,7 @@ function loadJob() {
     operation = f;
   };
   globalThis.post = fakePost;
+  globalThis.get = fakeGet;
   try {
     vm.runInThisContext(src, { filename: 'load.js' });
   } finally {
@@ -120,7 +131,49 @@ const writeBack = () =>
 
 test.beforeEach(() => {
   postCalls = [];
+  getCalls = [];
+  getResponse = null;
 });
+
+/** A canned "current patient state" returned by the fake GET on update. */
+const existingPatient = (overrides = {}) => ({
+  uuid: 'omrs-patient-uuid',
+  identifiers: overrides.identifiers || [
+    { uuid: 'id-uuid', identifierType: { uuid: 'natid-type' } },
+  ],
+  person: {
+    uuid: 'omrs-person-uuid',
+    addresses: overrides.addresses || [{ uuid: 'addr-uuid' }],
+    attributes: overrides.attributes || [
+      { uuid: 'attr-uuid', attributeType: { uuid: 'civil_status_type' } },
+    ],
+    preferredName: overrides.preferredName === undefined
+      ? { uuid: 'name-uuid' }
+      : overrides.preferredName,
+  },
+});
+
+const desiredPatient = () => ({
+  person: {
+    names: [{ givenName: 'Aline', familyName: 'Mukamana', preferred: true }],
+    gender: 'F',
+    birthdate: '2019-07-15',
+    birthdateEstimated: false,
+    attributes: [{ attributeType: 'civil_status_type', value: 'Married' }],
+  },
+  identifiers: [
+    { identifier: '1234567890123456', identifierType: 'natid-type', location: 'loc', preferred: true },
+  ],
+});
+
+const updateState = (over = {}) => ({
+  data: { person_uuid: 'eh-uuid', ...over.data },
+  openmrsPatient: over.openmrsPatient || desiredPatient(),
+  match: { action: 'update', patientUuid: 'omrs-patient-uuid', ...(over.match || {}) },
+  configuration: CONFIG,
+});
+
+const find = (predicate) => postCalls.find(predicate);
 
 test('link → no OpenMRS create, just the write-back', async () => {
   await run({
@@ -243,4 +296,134 @@ test('does not mutate state.openmrsPatient', async () => {
   });
   assert.equal(patient.identifiers[0].autoGenerate, true);
   assert.equal(patient.identifiers[0].identifier, undefined);
+});
+
+// -- Update branch --
+
+test('update GETs the patient once to discover subresource UUIDs', async () => {
+  getResponse = existingPatient();
+  await run(updateState());
+  assert.equal(getCalls.length, 1);
+  assert.ok(getCalls[0].url.includes('/patient/omrs-patient-uuid'));
+});
+
+test('update posts the person-level patch (gender, birthdate, estimated)', async () => {
+  getResponse = existingPatient();
+  await run(updateState());
+  const personPatch = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid');
+  assert.ok(personPatch, 'expected POST /person/{personUuid}');
+  assert.deepEqual(personPatch.body, {
+    gender: 'F',
+    birthdate: '2019-07-15',
+    birthdateEstimated: false,
+  });
+});
+
+test('update skips the gender "U" sentinel — preserves OpenMRS gender', async () => {
+  getResponse = existingPatient();
+  const desired = desiredPatient();
+  desired.person.gender = 'U';
+  await run(updateState({ openmrsPatient: desired }));
+  const personPatch = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid');
+  assert.equal(personPatch.body.gender, undefined);
+});
+
+test('update skips a null birthdate — preserves OpenMRS birthdate', async () => {
+  getResponse = existingPatient();
+  const desired = desiredPatient();
+  desired.person.birthdate = null;
+  await run(updateState({ openmrsPatient: desired }));
+  const personPatch = postCalls.find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid');
+  // With only gender to send, the patch posts but without birthdate.
+  if (personPatch) {
+    assert.equal(personPatch.body.birthdate, undefined);
+    assert.equal(personPatch.body.birthdateEstimated, undefined);
+  }
+});
+
+test('update posts the name to the existing preferredName subresource', async () => {
+  getResponse = existingPatient();
+  await run(updateState());
+  const nameCall = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid/name/name-uuid');
+  assert.ok(nameCall, 'expected POST /person/{uuid}/name/{nameUuid}');
+  assert.equal(nameCall.body.givenName, 'Aline');
+  assert.equal(nameCall.body.familyName, 'Mukamana');
+});
+
+test('update creates a new name when no preferredName exists', async () => {
+  getResponse = existingPatient({ preferredName: null });
+  await run(updateState());
+  const nameCreate = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid/name');
+  assert.ok(nameCreate, 'expected POST /person/{uuid}/name (create)');
+  assert.equal(nameCreate.body.preferred, true);
+});
+
+test('update posts the address to the existing address subresource', async () => {
+  getResponse = existingPatient();
+  const desired = desiredPatient();
+  desired.person.addresses = [{ stateProvince: 'Amajyaruguru', country: 'Rwanda' }];
+  await run(updateState({ openmrsPatient: desired }));
+  const addrCall = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid/address/addr-uuid');
+  assert.ok(addrCall, 'expected POST /person/{uuid}/address/{addressUuid}');
+  assert.equal(addrCall.body.country, 'Rwanda');
+});
+
+test('update creates a new address when none exists in OpenMRS', async () => {
+  getResponse = existingPatient({ addresses: [] });
+  const desired = desiredPatient();
+  desired.person.addresses = [{ stateProvince: 'Kigali' }];
+  await run(updateState({ openmrsPatient: desired }));
+  const addrCreate = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid/address');
+  assert.ok(addrCreate, 'expected POST /person/{uuid}/address (create)');
+});
+
+test('update upserts an identifier by its type — to existing /identifier/{uuid}', async () => {
+  getResponse = existingPatient();
+  await run(updateState());
+  const idCall = find((c) => c.url === CONFIG.openmrsBaseUrl + '/patient/omrs-patient-uuid/identifier/id-uuid');
+  assert.ok(idCall);
+  assert.equal(idCall.body.identifier, '1234567890123456');
+});
+
+test('update posts a new identifier when its type is not in OpenMRS', async () => {
+  getResponse = existingPatient({ identifiers: [] });
+  await run(updateState());
+  const idCreate = find((c) => c.url === CONFIG.openmrsBaseUrl + '/patient/omrs-patient-uuid/identifier');
+  assert.ok(idCreate);
+  assert.equal(idCreate.body.identifier, '1234567890123456');
+});
+
+test('update skips autoGenerate identifier placeholders', async () => {
+  getResponse = existingPatient({ identifiers: [] });
+  const desired = desiredPatient();
+  desired.identifiers = [
+    { identifierType: 'omrsid-type', location: 'loc', autoGenerate: true, preferred: true },
+  ];
+  await run(updateState({ openmrsPatient: desired }));
+  const idCall = postCalls.find((c) => c.url.includes('/identifier'));
+  assert.equal(idCall, undefined);
+});
+
+test('update upserts an attribute by its type — to existing /attribute/{uuid}', async () => {
+  getResponse = existingPatient();
+  await run(updateState());
+  const attrCall = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid/attribute/attr-uuid');
+  assert.ok(attrCall);
+  assert.equal(attrCall.body.value, 'Married');
+});
+
+test('update posts a new attribute when its type is not in OpenMRS', async () => {
+  getResponse = existingPatient({ attributes: [] });
+  await run(updateState());
+  const attrCreate = find((c) => c.url === CONFIG.openmrsBaseUrl + '/person/omrs-person-uuid/attribute');
+  assert.ok(attrCreate);
+  assert.equal(attrCreate.body.value, 'Married');
+});
+
+test('update does not call the E-Heza write-back endpoint', async () => {
+  getResponse = existingPatient();
+  const out = await run(updateState());
+  assert.equal(writeBack(), undefined);
+  assert.equal(out.loadResult.action, 'update');
+  assert.equal(out.loadResult.patientUuid, 'omrs-patient-uuid');
 });

--- a/integration/openfn/jobs/match.js
+++ b/integration/openfn/jobs/match.js
@@ -104,8 +104,20 @@ fn(async (state) => {
 
   let match;
 
-  // Tier 1 — national ID. An exact identifier match is decisive.
-  if (person.national_id) {
+  // Existing OpenMRS UUID on the payload short-circuits to update. The
+  // E-Heza trigger sets this when the person has already been synced.
+  if (person.existing_openmrs_uuid) {
+    match = {
+      action: 'update',
+      patientUuid: person.existing_openmrs_uuid,
+      via: 'existing-uuid',
+      candidates: [],
+    };
+  }
+
+  // Tier 1 — national ID. An exact identifier match is decisive. Runs
+  // only when Tier 0 (existing-uuid short-circuit) did not decide.
+  if (!match && person.national_id) {
     const res = await get(searchUrl, {
       query: { identifier: person.national_id, v: REP },
       headers: authHeaders,

--- a/integration/openfn/jobs/match.test.js
+++ b/integration/openfn/jobs/match.test.js
@@ -206,3 +206,14 @@ test('queries OpenMRS with the configured base URL and Authorization header', as
   assert.equal(getCalls[0].path, 'http://omrs.test/ws/rest/v1/patient');
   assert.equal(getCalls[0].headers.Authorization, 'Basic dGVzdA==');
 });
+
+test('short-circuits to update when an existing OpenMRS UUID is on the payload', async () => {
+  const { match: m } = await run({
+    data: { ...PERSON_WITH_ID, existing_openmrs_uuid: 'omrs-existing' },
+  });
+  assert.equal(m.action, 'update');
+  assert.equal(m.patientUuid, 'omrs-existing');
+  assert.equal(m.via, 'existing-uuid');
+  // No OpenMRS search is performed — the existing UUID is decisive.
+  assert.equal(getCalls.length, 0);
+});

--- a/integration/patient-update.md
+++ b/integration/patient-update.md
@@ -10,9 +10,11 @@ load`. The match step picks the branch.
 
 `hedley_openmrs_node_update($node)` on the `person` bundle:
 
-- Build the *relevant-field set* from `hedley_openmrs_build_person_payload`'s
-  keys, plus `field_uuid`. The set is closed: photo, reports data, sync
-  state, audit timestamps are outside it and never cause an enqueue.
+- Build the *relevant-field set* from `_hedley_openmrs_synced_fields()`
+  plus `field_birth_date_estimated`. `field_openmrs_uuid` is
+  **intentionally excluded** so the load step's UUID write-back does not
+  loop. The set is closed: photo, reports data, sync state, audit
+  timestamps are outside it and never cause an enqueue.
 - Diff `$node->original` against `$node` over that set. Short-circuit when
   nothing in the set changed.
 - Enqueue the same `hedley_openmrs_push_person` queue task. No new queue.

--- a/integration/patient-update.md
+++ b/integration/patient-update.md
@@ -1,0 +1,118 @@
+# E-Heza Person → OpenMRS — update flow
+
+Phase 1.5: when an already-synced E-Heza person changes, push the change to
+the OpenMRS patient that was created (or linked) by the Phase 1 flow.
+
+Place in the pipeline: same as create — `webhook → transform → match →
+load`. The match step picks the branch.
+
+## Trigger — Drupal side
+
+`hedley_openmrs_node_update($node)` on the `person` bundle:
+
+- Build the *relevant-field set* from `hedley_openmrs_build_person_payload`'s
+  keys, plus `field_uuid`. The set is closed: photo, reports data, sync
+  state, audit timestamps are outside it and never cause an enqueue.
+- Diff `$node->original` against `$node` over that set. Short-circuit when
+  nothing in the set changed.
+- Enqueue the same `hedley_openmrs_push_person` queue task. No new queue.
+
+The payload builder gains one extra key, `existing_openmrs_uuid`,
+populated from `field_openmrs_uuid`. It is the only signal the OpenFN side
+needs to choose update over create.
+
+## Match — short-circuit on the existing UUID
+
+When `state.data.existing_openmrs_uuid` is set, the match step skips
+Tier 1 / Tier 2 and emits:
+
+```js
+state.match = {
+  action: 'update',
+  patientUuid: <existing UUID>,
+  via: 'existing-uuid',
+  candidates: [],
+};
+```
+
+Otherwise the existing tier logic runs (a person whose `field_openmrs_uuid`
+isn't set yet still goes through national-ID / name+DOB matching).
+
+## Load — the `update` branch
+
+Two locked-in policies make this additive and never destructive:
+
+1. **Empty-source → leave untouched.** A field cleared in E-Heza does not
+   void / delete the OpenMRS identifier, attribute, address line, etc.
+2. **E-Heza is source of truth.** When values differ we overwrite OpenMRS;
+   no diff against OpenMRS, no conflict detection.
+
+### Flow
+
+1. **One GET** to discover OpenMRS subresource UUIDs:
+
+   ```
+   GET /patient/{patientUuid}?v=custom:(
+     uuid,
+     identifiers:(uuid,identifierType:(uuid)),
+     person:(
+       uuid,
+       addresses:(uuid),
+       attributes:(uuid,attributeType:(uuid)),
+       preferredName:(uuid)
+     )
+   )
+   ```
+
+2. **Person-level fields** — one `POST /person/{personUuid}` with only the
+   fields the transform actually emitted, *excluding sentinels* (gender
+   `U`, birthdate `null`):
+
+   | Field | Sent when |
+   |---|---|
+   | `gender` | not `U` |
+   | `birthdate` + `birthdateEstimated` | birthdate not null |
+
+3. **Name** — `POST /person/{personUuid}/name/{nameUuid}` with the
+   non-empty given/family from the transform; create via `/name` if no
+   preferredName exists.
+
+4. **Address** — `POST /person/{personUuid}/address/{addressUuid}` with the
+   address fields the transform emitted (already excludes empty values);
+   create via `/address` when none exists.
+
+5. **Identifiers** — for each identifier in the desired body (skipping any
+   `autoGenerate` placeholder — those make sense only on create):
+   - If an OpenMRS identifier of the same `identifierType` exists →
+     `POST /patient/{patientUuid}/identifier/{idUuid}`.
+   - Else → `POST /patient/{patientUuid}/identifier`.
+
+6. **PersonAttributes** — for each attribute the transform emitted:
+   - If an OpenMRS attribute of the same `attributeType` exists →
+     `POST /person/{personUuid}/attribute/{attrUuid}`.
+   - Else → `POST /person/{personUuid}/attribute`.
+
+7. **No write-back call.** The `field_openmrs_uuid` was set on create and
+   does not change on update.
+
+### Result
+
+```js
+state.loadResult = { action: 'update', patientUuid, openmrsId: null };
+```
+
+## Tests
+
+- Unit (`node:test`) covers the update branch: gender/birthdate sentinel
+  skipping, name/address update vs create, identifier upsert by type,
+  attribute upsert by type, `autoGenerate` skipped on update, and the
+  empty-payload → no-write rule.
+- Live smoke: create a patient via Phase 1, then mutate the person in
+  E-Heza (change a name, add a phone, clear an attribute), trigger the
+  queue, and confirm the OpenMRS person reflects the changes while
+  cleared-in-E-Heza fields remain.
+
+## Configuration
+
+Unchanged. Same credential, same workflow, same webhook. The update path
+is purely behavioural inside the existing jobs.

--- a/server/hedley/modules/custom/hedley_openmrs/hedley_openmrs.module
+++ b/server/hedley/modules/custom/hedley_openmrs/hedley_openmrs.module
@@ -46,6 +46,30 @@ function hedley_openmrs_node_insert($node) {
 }
 
 /**
+ * Implements hook_node_update().
+ *
+ * Re-queue the person for OpenFN whenever any of the demographic fields
+ * we sync to OpenMRS has actually changed. Photo, reports data, sync
+ * state and other unrelated fields don't cause an enqueue. The load
+ * step's own UUID write-back does not loop, because field_openmrs_uuid
+ * is intentionally not in the tracked set.
+ */
+function hedley_openmrs_node_update($node) {
+  if ($node->type !== 'person') {
+    return;
+  }
+  if (!_hedley_openmrs_should_push_update($node)) {
+    return;
+  }
+
+  hedley_general_add_task_to_advanced_queue_by_id(
+    HEDLEY_OPENMRS_PUSH_PERSON,
+    $node->nid,
+    ['person_id' => $node->nid]
+  );
+}
+
+/**
  * Implements hook_advanced_queue_info().
  */
 function hedley_openmrs_advanced_queue_info() {
@@ -145,7 +169,38 @@ function hedley_openmrs_push_person_worker($queue_item) {
  *   The payload.
  */
 function hedley_openmrs_build_person_payload($node) {
-  $fields = [
+  $payload = [];
+  foreach (_hedley_openmrs_synced_fields() as $key => $field) {
+    $payload[$key] = _hedley_openmrs_field($node, $field);
+  }
+  $payload['birth_date_estimated'] =
+    (bool) _hedley_openmrs_field($node, 'field_birth_date_estimated');
+
+  // Country comes from the site, not the person node.
+  $countries = ['rwanda' => 'Rwanda', 'burundi' => 'Burundi'];
+  $site = variable_get('hedley_general_site_name', '');
+  $payload['country'] = isset($countries[$site]) ? $countries[$site] : NULL;
+
+  // Existing OpenMRS UUID, when this person has already been synced —
+  // the match step uses it to short-circuit to the update path.
+  $payload['existing_openmrs_uuid'] =
+    _hedley_openmrs_field($node, 'field_openmrs_uuid');
+
+  return $payload;
+}
+
+/**
+ * The set of person fields this module syncs to OpenMRS.
+ *
+ * Single source of truth shared by the payload builder and the
+ * update-detection hook: anything outside this list never appears in
+ * the payload and never causes an update enqueue.
+ *
+ * @return array
+ *   payload-key => Drupal-field-name.
+ */
+function _hedley_openmrs_synced_fields() {
+  return [
     'person_uuid' => 'field_uuid',
     'first_name' => 'field_first_name',
     'second_name' => 'field_second_name',
@@ -170,20 +225,35 @@ function hedley_openmrs_build_person_payload($node) {
     'next_of_kin_phone_number' => 'field_next_of_kin_phone_number',
     'number_of_children' => 'field_number_of_children',
   ];
+}
 
-  $payload = [];
-  foreach ($fields as $key => $field) {
-    $payload[$key] = _hedley_openmrs_field($node, $field);
+/**
+ * Whether a node_update on a person should re-push to OpenFN.
+ *
+ * Returns TRUE only when at least one tracked field actually changed
+ * against $node->original. field_openmrs_uuid is intentionally not in
+ * the tracked set, so the load step's UUID write-back does not loop.
+ *
+ * @param object $node
+ *   The updated person node, with $node->original populated by Drupal.
+ *
+ * @return bool
+ *   TRUE if the update should enqueue an OpenFN push.
+ */
+function _hedley_openmrs_should_push_update($node) {
+  if (empty($node->original)) {
+    return FALSE;
   }
-  $payload['birth_date_estimated'] =
-    (bool) _hedley_openmrs_field($node, 'field_birth_date_estimated');
-
-  // Country comes from the site, not the person node.
-  $countries = ['rwanda' => 'Rwanda', 'burundi' => 'Burundi'];
-  $site = variable_get('hedley_general_site_name', '');
-  $payload['country'] = isset($countries[$site]) ? $countries[$site] : NULL;
-
-  return $payload;
+  $tracked = array_values(_hedley_openmrs_synced_fields());
+  $tracked[] = 'field_birth_date_estimated';
+  foreach ($tracked as $field) {
+    $new = _hedley_openmrs_field($node, $field);
+    $old = _hedley_openmrs_field($node->original, $field);
+    if ($new !== $old) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_openmrs/hedley_openmrs.module
+++ b/server/hedley/modules/custom/hedley_openmrs/hedley_openmrs.module
@@ -49,7 +49,7 @@ function hedley_openmrs_node_insert($node) {
  * Implements hook_node_update().
  *
  * Re-queue the person for OpenFN whenever any of the demographic fields
- * we sync to OpenMRS has actually changed. Photo, reports data, sync
+ * we sync to OpenMRS have actually changed. Photo, reports data, sync
  * state and other unrelated fields don't cause an enqueue. The load
  * step's own UUID write-back does not loop, because field_openmrs_uuid
  * is intentionally not in the tracked set.
@@ -190,11 +190,24 @@ function hedley_openmrs_build_person_payload($node) {
 }
 
 /**
- * The set of person fields this module syncs to OpenMRS.
+ * Person fields whose Drupal values flow into the OpenMRS payload as-is.
  *
- * Single source of truth shared by the payload builder and the
- * update-detection hook: anything outside this list never appears in
- * the payload and never causes an update enqueue.
+ * The payload builder reads each value into the matching payload key;
+ * the update-detection hook tracks the same set, plus
+ * field_birth_date_estimated, for its diff against $node->original.
+ *
+ * Three payload entries are intentionally outside this list:
+ * - birth_date_estimated  — also a node field, but cast to bool;
+ * - country               — derived from the hedley_general_site_name
+ *                           variable, not a node field;
+ * - existing_openmrs_uuid — carries field_openmrs_uuid into the
+ *                           payload but is *excluded* from the update
+ *                           diff so the load step's UUID write-back
+ *                           cannot loop.
+ *
+ * Anything outside the list and those three (photo, reports data,
+ * sync state, audit timestamps, …) neither appears in the payload nor
+ * causes an update enqueue.
  *
  * @return array
  *   payload-key => Drupal-field-name.


### PR DESCRIPTION
https://github.com/Gizra/ihangane/issues/3236

Stacked on top of #1763. When an already-synced E-Heza person changes, push the change to OpenMRS.

## Trigger

`hedley_openmrs_node_update` on the `person` bundle diffs `$node->original` against `$node` over a **closed set of fields** — the same set the payload builder syncs, extracted to `_hedley_openmrs_synced_fields()` as the single source of truth. Photo, reports data, sync state, audit timestamps fall outside it and never enqueue. `field_openmrs_uuid` is also outside the set, so the load step's UUID write-back can't loop.

## Match — short-circuit

The payload now carries `existing_openmrs_uuid` (from `field_openmrs_uuid`). When present, the match step skips Tier 1 / Tier 2 and emits `{ action: 'update', patientUuid, via: 'existing-uuid' }`.

## Load — `update` branch

One `GET /patient/{uuid}` discovers the OpenMRS subresource UUIDs; everything after is POSTs:

- Names → `POST /person/{uuid}/name/{nameUuid}` (or `…/name` to create).
- Person-level gender / birthdate / birthdateEstimated → `POST /person/{uuid}` — but the transform's `'U'` gender / `null` birthdate sentinels are skipped at the load layer so they cannot overwrite real OpenMRS values.
- Address → `POST /person/{uuid}/address/{addrUuid}` (or `…/address`).
- Identifiers → upsert by `identifierType` against `POST /patient/{uuid}/identifier{,/id}`; `autoGenerate` placeholders are skipped (only meaningful on create).
- PersonAttributes → upsert by `attributeType` against `POST /person/{uuid}/attribute{,/id}`.

## Policies (locked in with the user)

1. **Empty-source → leave untouched.** Clearing a field in E-Heza does not void / delete the OpenMRS identifier, attribute, address line, etc.
2. **E-Heza is source of truth.** No diff against OpenMRS, no conflict detection — we just push.

## Verification

- Unit suite: **47/47** (12 match + 24 load + 11 transform), `phpcs` clean.
- Live end-to-end on the local stack: editing person 551 propagated `first_name` and `phone_number` to the OpenMRS patient; a separately cleared `hiv_status` left the OpenMRS `Positive` PersonAttribute intact (Policy 1).

Design doc: `integration/patient-update.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)