### PR TITLE
Fix WhatsApp screenshot upload writing fileId to wrong IndexedDB table

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -868,10 +868,10 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
 
               // Update IndexDb to hold the fileId. As there could have been multiple
               // operations on the same entity, we replace all the screenshot occurrences.
-              // For example, lets say a person's screenshot was changed, and later also
-              // their name. So on the two records there were created on the
-              // screenshotUploadChanges table, the same screenshot local URL will appear.
-              await dbSync.authorityPhotoUploadChanges.where('screenshot').equals(row.screenshot).modify(changes);
+              // For example, lets say a report was generated for a person, and later
+              // another report. So on the two records that were created on the
+              // whatsAppUploads table, the same screenshot local URL will appear.
+              await dbSync.whatsAppUploads.where('screenshot').equals(row.screenshot).modify(changes);
             }
 
             return sendIndexedDbFetchResult(queryType, {tag: 'Success', result: row});


### PR DESCRIPTION
Fixes #1767

## Problem

In the `IndexDbQueryUploadScreenshot` handler (`client/src/js/app.js`), the cache-miss fallback wrote its `fileId`/`syncStage` update to `authorityPhotoUploadChanges`, whose schema (`&localId,photo,fileId,isSynced`) has **no `screenshot` column**. The `.where('screenshot')` query therefore matched zero rows, leaving the real `whatsAppUploads` record at `syncStage: 0` — re-fetched on every sync cycle while still reporting `Success`, silently wedging the upload lane (which runs before general/authority uploads).

## Fix

Write the fallback's default-image `fileId`/`syncStage` to `whatsAppUploads`, matching the success path a few lines above, so the record advances to `syncStage: 1` and the lane drains. Also corrected the stale comment that referenced a non-existent "screenshotUploadChanges" table.

```diff
-              await dbSync.authorityPhotoUploadChanges.where('screenshot').equals(row.screenshot).modify(changes);
+              await dbSync.whatsAppUploads.where('screenshot').equals(row.screenshot).modify(changes);
```

## Testing

This path triggers only in the edge case where a screenshot is registered in IndexedDB but evicted from the `screenshots-upload` cache, so it is not covered by the existing automated suites. Verified by code inspection and cross-checking the Dexie table schemas against the query/write paths: both screenshot writes in the block now target `whatsAppUploads`, and a repo-wide grep confirms no other copies of the buggy pattern.