### PR TITLE
Add HTTP timeout to sync upload requests

### DIFF
--- a/client/src/elm/SyncManager/Model.elm
+++ b/client/src/elm/SyncManager/Model.elm
@@ -1,4 +1,4 @@
-module SyncManager.Model exposing (BackendAuthorityEntity(..), BackendEntity, BackendEntityIdentifier, BackendGeneralEntity(..), BackendWhatsAppEntity, DownloadPhotosAllRec, DownloadPhotosBatchRec, DownloadPhotosMode(..), DownloadPhotosStatus(..), DownloadSyncResponse, Flags, IncidentContnentIdentifier, IndexDbDeferredPhotoRemoteData, IndexDbQueryDeferredPhotoBatchResultRecord, IndexDbQueryDeferredPhotoResultRecord, IndexDbQueryType(..), IndexDbQueryTypeResult(..), IndexDbQueryUploadAuthorityResultRecord, IndexDbQueryUploadFileResultRecord, IndexDbQueryUploadGeneralResultRecord, IndexDbQueryUploadPhotoResultRecord, IndexDbQueryUploadWhatsAppResultRecord, IndexDbSaveResult, IndexDbSaveResultTable(..), IndexDbSaveStatus(..), IndexDbUploadRemoteData, Model, Msg(..), PhotoBatchResult, Site(..), SiteFeature(..), SyncCycle(..), SyncIncidentType(..), SyncInfoAuthority, SyncInfoAuthorityForPort, SyncInfoAuthorityZipper, SyncInfoGeneral, SyncInfoGeneralForPort, SyncInfoStatus(..), SyncSpeed, SyncStatus(..), UploadFileError(..), UploadMethod(..), UploadRec, downloadRequestTimeout, emptyModel, emptySyncInfoAuthority, emptyUploadRec)
+module SyncManager.Model exposing (BackendAuthorityEntity(..), BackendEntity, BackendEntityIdentifier, BackendGeneralEntity(..), BackendWhatsAppEntity, DownloadPhotosAllRec, DownloadPhotosBatchRec, DownloadPhotosMode(..), DownloadPhotosStatus(..), DownloadSyncResponse, Flags, IncidentContnentIdentifier, IndexDbDeferredPhotoRemoteData, IndexDbQueryDeferredPhotoBatchResultRecord, IndexDbQueryDeferredPhotoResultRecord, IndexDbQueryType(..), IndexDbQueryTypeResult(..), IndexDbQueryUploadAuthorityResultRecord, IndexDbQueryUploadFileResultRecord, IndexDbQueryUploadGeneralResultRecord, IndexDbQueryUploadPhotoResultRecord, IndexDbQueryUploadWhatsAppResultRecord, IndexDbSaveResult, IndexDbSaveResultTable(..), IndexDbSaveStatus(..), IndexDbUploadRemoteData, Model, Msg(..), PhotoBatchResult, Site(..), SiteFeature(..), SyncCycle(..), SyncIncidentType(..), SyncInfoAuthority, SyncInfoAuthorityForPort, SyncInfoAuthorityZipper, SyncInfoGeneral, SyncInfoGeneralForPort, SyncInfoStatus(..), SyncSpeed, SyncStatus(..), UploadFileError(..), UploadMethod(..), UploadRec, downloadRequestTimeout, emptyModel, emptySyncInfoAuthority, emptyUploadRec, uploadRequestTimeout)
 
 import AssocList as Dict exposing (Dict)
 import Backend.AcuteIllnessEncounter.Model exposing (AcuteIllnessEncounter)
@@ -750,6 +750,19 @@ less than 3. Timeout is double the sum of the 2.
 downloadRequestTimeout : Int
 downloadRequestTimeout =
     (12000 + 3000) * 2
+
+
+{-| Upload requests (POST to /api/sync) carry a batch of changes and may run
+over slow rural connections, so we allow more headroom than downloads. The
+crucial point is that there is a timeout at all: without one, a stalled
+connection (e.g. a dropped mobile link that never sends a TCP RST) leaves the
+request in `Loading` indefinitely, wedging the entire upload phase until the
+app is manually reloaded. The value is in milliseconds, as expected by
+`HttpBuilder.withTimeout`.
+-}
+uploadRequestTimeout : Float
+uploadRequestTimeout =
+    60 * 1000
 
 
 type SyncIncidentType

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -1246,6 +1246,7 @@ update currentTime activePage dbVersion device msg model =
                                         |> withJsonBody (Json.Encode.object <| SyncManager.Encoder.encodeIndexDbQueryUploadAuthorityResultRecord dbVersion result)
                                         -- We don't need to decode anything, as we just want to have
                                         -- the browser download it.
+                                        |> HttpBuilder.withTimeout uploadRequestTimeout
                                         |> HttpBuilder.send (RemoteData.fromResult >> BackendUploadAuthorityHandle result)
                                     )
 
@@ -1438,6 +1439,7 @@ update currentTime activePage dbVersion device msg model =
                                         |> withJsonBody (Json.Encode.object <| SyncManager.Encoder.encodeIndexDbQueryUploadGeneralResultRecord dbVersion result)
                                         -- We don't need to decode anything, as we just want to have
                                         -- the browser download it.
+                                        |> HttpBuilder.withTimeout uploadRequestTimeout
                                         |> HttpBuilder.send (RemoteData.fromResult >> BackendUploadGeneralHandle result)
                                     )
 
@@ -1589,6 +1591,7 @@ update currentTime activePage dbVersion device msg model =
                                     , HttpBuilder.post (device.backendUrl ++ "/api/sync")
                                         |> withQueryParams [ ( "access_token", device.accessToken ) ]
                                         |> withJsonBody (Json.Encode.object <| SyncManager.Encoder.encodeIndexDbQueryUploadWhatsAppResultRecord dbVersion result)
+                                        |> HttpBuilder.withTimeout uploadRequestTimeout
                                         |> HttpBuilder.send (RemoteData.fromResult >> BackendUploadWhatsAppHandle result)
                                     )
 


### PR DESCRIPTION
Fixes #1769

## Problem

The three sync upload requests (POST to `/api/sync`) in `SyncManager/Update.elm` — authority (`:1244`), general (`:1436`), whatsApp (`:1589`) — were issued with no HTTP timeout, so `elm/http` waited indefinitely. A connection that stalls without a TCP RST (common on flaky rural mobile links) leaves the request in `RemoteData.Loading` forever. Since the only re-issue guard is `RemoteData.isLoading`, the entire upload phase is wedged until the PWA is manually reloaded, and clinical data sits undelivered on the device. Downloads already self-heal via a `downloadRequestTimeout` staleness check; uploads had no equivalent.

## Fix

Add `HttpBuilder.withTimeout uploadRequestTimeout` (60s) to the three upload requests, and define the documented `uploadRequestTimeout` constant in `SyncManager/Model.elm` next to the existing `downloadRequestTimeout`.

On timeout, `elm/http` returns `Http.Timeout`, which flows into the existing `BackendUpload*Handle` `Failure` branch (`Update.elm:1294`) and clears `Loading`, so the next sync cycle retries the batch. The retry is safe because the server wraps each batch in a `db_transaction()` and skips UUIDs that already exist (idempotent upload).

## Testing

- `elm make` → Success, 548 modules
- `elm-format --validate` → clean
- `elm-review` (full project) → no errors
- `elm-test src/elm/SyncManager/Test.elm` → 3/3 passed

The stalled-connection condition itself isn't reproducible in the automated suites, so the behaviour (timeout → `Http.Timeout` → existing `Failure`/retry path) is verified by reading the failure handlers rather than an integration test.