### PR TITLE
ci: build client before starting DDEV to avoid Elm-compile memory stall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,12 +89,11 @@ jobs:
       - run:
           name: Free port 3000 for host-side serving
           command: rm -f .ddev/docker-compose.client-http.yaml
-      - run:
-          name: Install DDEV
-          command: ci-scripts/install_ddev.sh
-      - run:
-          name: Install Drupal
-          command: ci-scripts/install_drupal.sh
+      # Build the client (npm/bower/gulp/Elm) BEFORE starting DDEV. The Elm
+      # compile is memory-intensive; running it alongside the DDEV containers
+      # (MariaDB/PHP, heavy after the Drupal install) exhausted physical RAM,
+      # so the compile thrashed on swap, made no progress, and stalled past the
+      # no-output timeout. Compiling first gives Elm the full machine RAM.
       - run:
           name: Install and build client
           command: ci-scripts/install_client.sh
@@ -103,6 +102,12 @@ jobs:
           name: Verify Elm compiled
           command: |
             test -f client/serve/Main.js || (echo "Main.js not found - Elm compilation failed" && exit 1)
+      - run:
+          name: Install DDEV
+          command: ci-scripts/install_ddev.sh
+      - run:
+          name: Install Drupal
+          command: ci-scripts/install_drupal.sh
       - run:
           name: Install Playwright browsers
           command: cd client && DEBIAN_FRONTEND=noninteractive npx playwright install --with-deps chromium
@@ -138,12 +143,11 @@ jobs:
       - run:
           name: Free port 3000 for host-side serving
           command: rm -f .ddev/docker-compose.client-http.yaml
-      - run:
-          name: Install DDEV
-          command: ci-scripts/install_ddev.sh
-      - run:
-          name: Install Drupal
-          command: ci-scripts/install_drupal.sh
+      # Build the client (npm/bower/gulp/Elm) BEFORE starting DDEV. The Elm
+      # compile is memory-intensive; running it alongside the DDEV containers
+      # (MariaDB/PHP, heavy after the Drupal install) exhausted physical RAM,
+      # so the compile thrashed on swap, made no progress, and stalled past the
+      # no-output timeout. Compiling first gives Elm the full machine RAM.
       - run:
           name: Install and build client
           command: ci-scripts/install_client.sh
@@ -152,6 +156,12 @@ jobs:
           name: Verify Elm compiled
           command: |
             test -f client/serve/Main.js || (echo "Main.js not found - Elm compilation failed" && exit 1)
+      - run:
+          name: Install DDEV
+          command: ci-scripts/install_ddev.sh
+      - run:
+          name: Install Drupal
+          command: ci-scripts/install_drupal.sh
       - run:
           name: Install Playwright browsers
           command: cd client && DEBIAN_FRONTEND=noninteractive npx playwright install --with-deps chromium
@@ -187,12 +197,11 @@ jobs:
       - run:
           name: Free port 3000 for host-side serving
           command: rm -f .ddev/docker-compose.client-http.yaml
-      - run:
-          name: Install DDEV
-          command: ci-scripts/install_ddev.sh
-      - run:
-          name: Install Drupal
-          command: ci-scripts/install_drupal.sh
+      # Build the client (npm/bower/gulp/Elm) BEFORE starting DDEV. The Elm
+      # compile is memory-intensive; running it alongside the DDEV containers
+      # (MariaDB/PHP, heavy after the Drupal install) exhausted physical RAM,
+      # so the compile thrashed on swap, made no progress, and stalled past the
+      # no-output timeout. Compiling first gives Elm the full machine RAM.
       - run:
           name: Install and build client
           command: ci-scripts/install_client.sh
@@ -201,6 +210,12 @@ jobs:
           name: Verify Elm compiled
           command: |
             test -f client/serve/Main.js || (echo "Main.js not found - Elm compilation failed" && exit 1)
+      - run:
+          name: Install DDEV
+          command: ci-scripts/install_ddev.sh
+      - run:
+          name: Install Drupal
+          command: ci-scripts/install_drupal.sh
       - run:
           name: Install Playwright browsers
           command: cd client && DEBIAN_FRONTEND=noninteractive npx playwright install --with-deps chromium


### PR DESCRIPTION
## Problem

The `e2e_playwright_1`, `e2e_playwright_2`, and `e2e_reporting` jobs intermittently fail at the **Install and build client** step with:

```
Too long with no output (exceeded 4m0s): context deadline exceeded
```

The log always ends right after `copy:dev`, with the silent `elmCompile` running and never producing output.

## Root cause

The step ran **after** `Install DDEV` / `Install Drupal`, so the memory-intensive Elm compile (548 modules) ran while the DDEV containers (MariaDB/PHP, heavy after the Drupal install + migrations) were still holding RAM. Together they exceed the machine's physical RAM (15 GB on `large`).

The 4 GB swap added previously (`597ad2cc5`, `9e4611865`) stopped the OOM *kills*, but swap doesn't add capacity — when the compile's working set spills to swap it **thrashes**, making near-zero forward progress. Since `elm make` is silent during compilation, that stall surfaces as ">4 min with no output" and CircleCI kills the step. It's intermittent because it depends on how much RAM DDEV/MariaDB happens to hold when the compile peaks (healthy runs finish in ~2 min; unhealthy ones thrash and stall).

## Fix

Reorder all three E2E jobs so the client is built (and `Main.js` verified) **before** DDEV/Drupal are installed:

```
Free port 3000 → Install and build client → Verify Elm compiled → Install DDEV → Install Drupal → Playwright → Start app → Run E2E
```

The client build is host-side (`npm`/`bower`/`gulp`/Elm) and has no dependency on DDEV, so it can run first — giving the Elm compile the full machine RAM with no contention. Unlike the earlier "stop DDEV during the compile" attempt (`73c4c852e`, reverted in `9e4611865` because it broke DDEV state and hung `drush`), this never disturbs DDEV — it simply starts later.

## Validation

- `.circleci/config.yml` parses as valid YAML; step order confirmed reordered in all three E2E jobs.
- The real test is CI itself. Because the original failure was intermittent (~per-shard coin-flip), a single green run is supporting evidence; I'll re-run the workflow a couple of times to build confidence that the stall is gone.

The 4 GB swap workaround in `install_client.sh` is left in place as harmless belt-and-suspenders; it can be removed in a follow-up if desired.