### PR TITLE
Extract saveMeasurementMsgs helper to dedupe per-program save handlers

### DIFF
--- a/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
@@ -40,7 +40,7 @@ import Measurement.Utils
 import Pages.AcuteIllness.Activity.Model exposing (ContactsTracingFormState(..), Model, Msg(..))
 import Pages.AcuteIllness.Activity.Utils exposing (acuteFindingsFormWithDefault, coreExamFormWithDefault, coughLessThan2WeeksConstant, reviewDangerSignsFormWithDefault, symptomMaxDuration, symptomsGIFormWithDefault, symptomsGeneralFormWithDefault, symptomsRespiratoryFormWithDefault, toAcuteFindingsValueWithDefault, toContactsTracingValueWithDefault, toCoreExamValueWithDefault, toCovidTestingValueWithDefault, toFollowUpValueWithDefault, toMalariaTestingValueWithDefault, toMedicationDistributionValueWithDefault, toReviewDangerSignsValueWithDefault, toSymptomsGIValueWithDefault, toSymptomsGeneralValueWithDefault, toSymptomsRespiratoryValueWithDefault, toTreatmentReviewValueWithDefault, toggleSymptomsSign)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (nonAdministrationReasonToSign, setMuacValueForSite, setMultiSelectInputValue)
+import Pages.Utils exposing (nonAdministrationReasonToSign, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue)
 import RemoteData exposing (RemoteData(..))
 import SyncManager.Model exposing (Site)
 
@@ -98,6 +98,9 @@ update site selectedHealthCenter id db msg model =
         generateNextStepsMsgs nextTask =
             Maybe.map (\task -> [ SetActiveNextStepsTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| AcuteIllnessEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgAcuteIllnessEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -442,58 +445,26 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveVitals personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generatePhysicalExamMsgs nextTask
-
-                appMsgs =
-                    toVitalsValueWithDefault measurement model.physicalExamData.vitalsForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveVitals personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVitalsValueWithDefault
+                model.physicalExamData.vitalsForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveVitals personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generatePhysicalExamMsgs nextTask)
 
         SaveAcuteFindings personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generatePhysicalExamMsgs nextTask
-
-                appMsgs =
-                    toAcuteFindingsValueWithDefault measurement model.physicalExamData.acuteFindingsForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveAcuteFindings personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAcuteFindingsValueWithDefault
+                model.physicalExamData.acuteFindingsForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveAcuteFindings personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generatePhysicalExamMsgs nextTask)
 
         SetMuac string ->
             let
@@ -513,31 +484,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveMuac personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generatePhysicalExamMsgs nextTask
-
-                appMsgs =
-                    toMuacValueWithDefault measurement model.physicalExamData.muacForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveMuac personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMuacValueWithDefault
+                model.physicalExamData.muacForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveMuac personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generatePhysicalExamMsgs nextTask)
 
         SetNutritionSign sign ->
             let
@@ -561,31 +516,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveNutrition personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generatePhysicalExamMsgs nextTask
-
-                appMsgs =
-                    Pages.AcuteIllness.Activity.Utils.toNutritionValueWithDefault measurement model.physicalExamData.nutritionForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveNutrition personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs Pages.AcuteIllness.Activity.Utils.toNutritionValueWithDefault
+                model.physicalExamData.nutritionForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveNutrition personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generatePhysicalExamMsgs nextTask)
 
         SetCoreExamHeart value ->
             let
@@ -623,31 +562,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveCoreExam personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generatePhysicalExamMsgs nextTask
-
-                appMsgs =
-                    toCoreExamValueWithDefault measurement model.physicalExamData.coreExamForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveCoreExam personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toCoreExamValueWithDefault
+                model.physicalExamData.coreExamForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveCoreExam personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generatePhysicalExamMsgs nextTask)
 
         SetActiveLaboratoryTask task ->
             let
@@ -695,31 +618,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveMalariaTesting personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    toMalariaTestingValueWithDefault measurement model.laboratoryData.malariaTestingForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveMalariaTesting personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMalariaTestingValueWithDefault
+                model.laboratoryData.malariaTestingForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveMalariaTesting personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateLaboratoryMsgs nextTask)
 
         SetCovidTestingBoolInput formUpdateFunc value ->
             let
@@ -756,31 +663,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveCovidTesting personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    toCovidTestingValueWithDefault measurement model.laboratoryData.covidTestingForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveCovidTesting personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toCovidTestingValueWithDefault
+                model.laboratoryData.covidTestingForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveCovidTesting personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateLaboratoryMsgs nextTask)
 
         SetActivePriorTreatmentTask task ->
             let
@@ -896,31 +787,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveSendToHC personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toSendToHCValueWithDefault measurement model.nextStepsData.sendToHCForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveSendToHC personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSendToHCValueWithDefault
+                model.nextStepsData.sendToHCForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveSendToHC personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateNextStepsMsgs nextTask)
 
         SetMedicationDistributionBoolInput formUpdateFunc value ->
             let
@@ -973,31 +848,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveMedicationDistribution personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toMedicationDistributionValueWithDefault measurement model.nextStepsData.medicationDistributionForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveMedicationDistribution personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationDistributionValueWithDefault
+                model.nextStepsData.medicationDistributionForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveMedicationDistribution personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateNextStepsMsgs nextTask)
 
         SetActiveOngoingTreatmentTask task ->
             let
@@ -1231,31 +1090,15 @@ update site selectedHealthCenter id db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toHealthEducationValueWithDefault measurement model.nextStepsData.healthEducationForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateNextStepsMsgs nextTask)
 
         SetFollowUpOption option ->
             let
@@ -1276,33 +1119,18 @@ update site selectedHealthCenter id db msg model =
 
         SaveFollowUp personId diagnosis saved nextTask ->
             let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
                 followUpForm =
                     model.nextStepsData.followUpForm
-
-                appMsgs =
-                    toFollowUpValueWithDefault measurement { followUpForm | diagnosis = diagnosis }
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveFollowUp personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
             in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toFollowUpValueWithDefault
+                { followUpForm | diagnosis = diagnosis }
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveFollowUp personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateNextStepsMsgs nextTask)
 
         SetContactsTracingFormState newState ->
             let
@@ -1572,28 +1400,12 @@ update site selectedHealthCenter id db msg model =
                     noChange
 
         SaveContactsTracing personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toContactsTracingValueWithDefault measurement model.nextStepsData.contactsTracingForm
-                        |> Maybe.map
-                            (Backend.AcuteIllnessEncounter.Model.SaveContactsTracing personId measurementId
-                                >> Backend.Model.MsgAcuteIllnessEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toContactsTracingValueWithDefault
+                model.nextStepsData.contactsTracingForm
+                saved
+                (Backend.AcuteIllnessEncounter.Model.SaveContactsTracing personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
+                |> sequenceExtra (update site selectedHealthCenter id db) (generateNextStepsMsgs nextTask)

--- a/client/src/elm/Pages/ChildScoreboard/Activity/Update.elm
+++ b/client/src/elm/Pages/ChildScoreboard/Activity/Update.elm
@@ -30,7 +30,7 @@ import Measurement.Utils
 import Pages.ChildScoreboard.Activity.Model exposing (Model, Msg(..))
 import Pages.ChildScoreboard.Activity.Utils exposing (getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, updateVaccinationFormByVaccineType)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (insertIntoSet, setMuacValueForSite)
+import Pages.Utils exposing (insertIntoSet, saveMeasurementMsgs, setMuacValueForSite)
 import RemoteData
 import SyncManager.Model exposing (Site)
 
@@ -60,6 +60,9 @@ update currentDate site id db msg model =
         generateImmunisationMsgs nextTask =
             Maybe.map (\task -> [ SetActiveImmunisationTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| ChildScoreboardEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgChildScoreboardEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -490,225 +493,89 @@ update currentDate site id db msg model =
             )
 
         SaveBCGImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.bcgForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveBCGImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.bcgForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveBCGImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveDTPImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.dtpForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveDTPImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.dtpForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveDTPImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveDTPStandaloneImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.dtpForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveDTPStandaloneImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.dtpForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveDTPStandaloneImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveIPVImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.ipvForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveIPVImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.ipvForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveIPVImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveMRImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.mrForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveMRImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.mrForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveMRImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveOPVImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.opvForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveOPVImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.opvForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveOPVImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SavePCV13Immunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.pcv13Form
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SavePCV13Immunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.pcv13Form
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SavePCV13Immunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveRotarixImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.rotarixForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.ChildScoreboardEncounter.Model.SaveRotarixImmunisation personId measurementId
-                                >> Backend.Model.MsgChildScoreboardEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.rotarixForm
+                saved
+                (Backend.ChildScoreboardEncounter.Model.SaveRotarixImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)

--- a/client/src/elm/Pages/HIV/Activity/Update.elm
+++ b/client/src/elm/Pages/HIV/Activity/Update.elm
@@ -22,7 +22,7 @@ import Measurement.Utils
 import Pages.HIV.Activity.Model exposing (Model, Msg(..))
 import Pages.HIV.Activity.Utils exposing (diagnosticsFormWithDefault, prescribedMedicationFormWithDefault, symptomReviewFormWithDefault, toDiagnosticsValueWithDefault, toHealthEducationValueWithDefault, toPrescribedMedicationValueWithDefault, toSymptomReviewValueWithDefault)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (setMultiSelectInputValue)
+import Pages.Utils exposing (saveMeasurementMsgs, setMultiSelectInputValue)
 import RemoteData
 
 
@@ -55,6 +55,9 @@ update currentDate id db msg model =
         generateNextStepsMsgs nextTask =
             Maybe.map (\task -> [ SetActiveNextStepsTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| HIVEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgHIVEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         SetActivePage page ->
@@ -279,31 +282,15 @@ update currentDate id db msg model =
             )
 
         SavePrescribedMedication personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    toPrescribedMedicationValueWithDefault measurement model.medicationData.prescribedMedicationForm
-                        |> Maybe.map
-                            (Backend.HIVEncounter.Model.SavePrescribedMedication personId measurementId
-                                >> Backend.Model.MsgHIVEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toPrescribedMedicationValueWithDefault
+                model.medicationData.prescribedMedicationForm
+                saved
+                (Backend.HIVEncounter.Model.SavePrescribedMedication personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetTreatmentReviewBoolInput formUpdateFunc value ->
             let
@@ -376,31 +363,15 @@ update currentDate id db msg model =
             )
 
         SaveTreatmentReview personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    toOngoingTreatmentReviewValueWithDefault measurement model.medicationData.treatmentReviewForm
-                        |> Maybe.map
-                            (Backend.HIVEncounter.Model.SaveTreatmentReview personId measurementId
-                                >> Backend.Model.MsgHIVEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toOngoingTreatmentReviewValueWithDefault
+                model.medicationData.treatmentReviewForm
+                saved
+                (Backend.HIVEncounter.Model.SaveTreatmentReview personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetSymptom symptom ->
             let
@@ -478,31 +449,15 @@ update currentDate id db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toHealthEducationValueWithDefault measurement model.nextStepsData.healthEducationForm
-                        |> Maybe.map
-                            (Backend.HIVEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgHIVEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.HIVEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)
 
         SetFollowUpOption option ->
             let
@@ -522,31 +477,15 @@ update currentDate id db msg model =
             )
 
         SaveFollowUp personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toFollowUpValueWithDefault measurement model.nextStepsData.followUpForm
-                        |> Maybe.map
-                            (Backend.HIVEncounter.Model.SaveFollowUp personId measurementId
-                                >> Backend.Model.MsgHIVEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toFollowUpValueWithDefault
+                model.nextStepsData.followUpForm
+                saved
+                (Backend.HIVEncounter.Model.SaveFollowUp personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)
 
         SetReferToHealthCenter value ->
             let
@@ -600,28 +539,12 @@ update currentDate id db msg model =
             )
 
         SaveReferral personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toSendToHCValueWithDefault measurement model.nextStepsData.sendToHCForm
-                        |> Maybe.map
-                            (Backend.HIVEncounter.Model.SaveReferral personId measurementId
-                                >> Backend.Model.MsgHIVEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSendToHCValueWithDefault
+                model.nextStepsData.sendToHCForm
+                saved
+                (Backend.HIVEncounter.Model.SaveReferral personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)

--- a/client/src/elm/Pages/NCD/Activity/Update.elm
+++ b/client/src/elm/Pages/NCD/Activity/Update.elm
@@ -54,7 +54,7 @@ import Pages.NCD.Activity.Model exposing (Model, Msg(..))
 import Pages.NCD.Activity.Utils exposing (coMorbiditiesFormWithDefault, dangerSignsFormWithDefault, familyHistoryFormWithDefault, medicationHistoryFormWithDefault, symptomReviewFormWithDefault, toCoMorbiditiesValueWithDefault, toDangerSignsValueWithDefault, toFamilyHistoryValueWithDefault, toHealthEducationValueWithDefault, toMedicationHistoryValueWithDefault, toSocialHistoryValueWithDefault, toSymptomReviewValueWithDefault)
 import Pages.NCD.Utils exposing (medicationDistributionFormWithDefault, referralFormWithDefault, toMedicationDistributionValueWithDefault, toReferralValueWithDefault)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (setMultiSelectInputValue)
+import Pages.Utils exposing (saveMeasurementMsgs, setMultiSelectInputValue)
 import RemoteData exposing (RemoteData(..))
 
 
@@ -137,6 +137,9 @@ update currentDate id db msg model =
         generateNextStepsMsgs nextTask =
             Maybe.map (\task -> [ SetActiveNextStepsTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| NCDEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgNCDEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -380,31 +383,15 @@ update currentDate id db msg model =
             )
 
         SaveVitals personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toVitalsValueWithDefault measurement model.examinationData.vitalsForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveVitals personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVitalsValueWithDefault
+                model.examinationData.vitalsForm
+                saved
+                (Backend.NCDEncounter.Model.SaveVitals personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetCoreExamBoolInput formUpdateFunc value ->
             let
@@ -540,31 +527,15 @@ update currentDate id db msg model =
             )
 
         SaveCoreExam personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toCorePhysicalExamValueWithDefault measurement model.examinationData.coreExamForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveCoreExam personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toCorePhysicalExamValueWithDefault
+                model.examinationData.coreExamForm
+                saved
+                (Backend.NCDEncounter.Model.SaveCoreExam personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetActiveMedicalHistoryTask task ->
             let
@@ -606,31 +577,15 @@ update currentDate id db msg model =
             )
 
         SaveCoMorbidities personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicalHistoryMsgs nextTask
-
-                appMsgs =
-                    toCoMorbiditiesValueWithDefault measurement model.medicalHistoryData.coMorbiditiesForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveCoMorbidities personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toCoMorbiditiesValueWithDefault
+                model.medicalHistoryData.coMorbiditiesForm
+                saved
+                (Backend.NCDEncounter.Model.SaveCoMorbidities personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicalHistoryMsgs nextTask)
 
         SetMedicationCausingHypertension medication ->
             let
@@ -687,31 +642,15 @@ update currentDate id db msg model =
             )
 
         SaveMedicationHistory personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicalHistoryMsgs nextTask
-
-                appMsgs =
-                    toMedicationHistoryValueWithDefault measurement model.medicalHistoryData.medicationHistoryForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveMedicationHistory personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationHistoryValueWithDefault
+                model.medicalHistoryData.medicationHistoryForm
+                saved
+                (Backend.NCDEncounter.Model.SaveMedicationHistory personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicalHistoryMsgs nextTask)
 
         SetSocialHistoryBoolInput formUpdateFunc value ->
             let
@@ -757,31 +696,15 @@ update currentDate id db msg model =
             )
 
         SaveSocialHistory personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicalHistoryMsgs nextTask
-
-                appMsgs =
-                    toSocialHistoryValueWithDefault measurement model.medicalHistoryData.socialHistoryForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveSocialHistory personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSocialHistoryValueWithDefault
+                model.medicalHistoryData.socialHistoryForm
+                saved
+                (Backend.NCDEncounter.Model.SaveSocialHistory personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicalHistoryMsgs nextTask)
 
         SetFamilyHistoryBoolInput formUpdateFunc value ->
             let
@@ -867,31 +790,15 @@ update currentDate id db msg model =
             )
 
         SaveFamilyHistory personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicalHistoryMsgs nextTask
-
-                appMsgs =
-                    toFamilyHistoryValueWithDefault measurement model.medicalHistoryData.familyHistoryForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveFamilyHistory personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toFamilyHistoryValueWithDefault
+                model.medicalHistoryData.familyHistoryForm
+                saved
+                (Backend.NCDEncounter.Model.SaveFamilyHistory personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicalHistoryMsgs nextTask)
 
         SetOutsideCareStep step ->
             let
@@ -1031,31 +938,15 @@ update currentDate id db msg model =
             )
 
         SaveOutsideCare personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicalHistoryMsgs nextTask
-
-                appMsgs =
-                    toOutsideCareValueWithDefault NoMedicalConditions measurement model.medicalHistoryData.outsideCareForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveOutsideCare personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs (toOutsideCareValueWithDefault NoMedicalConditions)
+                model.medicalHistoryData.outsideCareForm
+                saved
+                (Backend.NCDEncounter.Model.SaveOutsideCare personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicalHistoryMsgs nextTask)
 
         SetActiveLaboratoryTask task ->
             let
@@ -1167,32 +1058,15 @@ update currentDate id db msg model =
             )
 
         SaveHIVTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.hivTestForm
-                        |> toHIVTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveHIVTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHIVTestValueWithDefault
+                model.laboratoryData.hivTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveHIVTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetUrineDipstickTestFormBoolInput formUpdateFunc value ->
             let
@@ -1283,32 +1157,15 @@ update currentDate id db msg model =
             )
 
         SaveUrineDipstickTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.urineDipstickTestForm
-                        |> toUrineDipstickTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveUrineDipstickTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toUrineDipstickTestValueWithDefault
+                model.laboratoryData.urineDipstickTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveUrineDipstickTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetRandomBloodSugarTestFormBoolInput formUpdateFunc value ->
             let
@@ -1399,32 +1256,15 @@ update currentDate id db msg model =
             )
 
         SaveRandomBloodSugarTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.randomBloodSugarTestForm
-                        |> toRandomBloodSugarTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveRandomBloodSugarTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toRandomBloodSugarTestValueWithDefault
+                model.laboratoryData.randomBloodSugarTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveRandomBloodSugarTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetPregnancyTestFormBoolInput formUpdateFunc value ->
             let
@@ -1515,32 +1355,15 @@ update currentDate id db msg model =
             )
 
         SavePregnancyTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.pregnancyTestForm
-                        |> toPregnancyTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SavePregnancyTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toPregnancyTestValueWithDefault
+                model.laboratoryData.pregnancyTestForm
+                saved
+                (Backend.NCDEncounter.Model.SavePregnancyTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetCreatinineTestFormBoolInput formUpdateFunc value ->
             let
@@ -1930,32 +1753,15 @@ update currentDate id db msg model =
             )
 
         SaveHbA1cTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.hba1cTestForm
-                        |> toHbA1cTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveHbA1cTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHbA1cTestValueWithDefault
+                model.laboratoryData.hba1cTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveHbA1cTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetActiveNextStepsTask task ->
             let
@@ -1983,31 +1789,15 @@ update currentDate id db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toHealthEducationValueWithDefault measurement model.nextStepsData.healthEducationForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.NCDEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)
 
         SetRecommendedTreatmentSignSingle allowedSigns sign ->
             let
@@ -2085,31 +1875,15 @@ update currentDate id db msg model =
             )
 
         SaveMedicationDistribution personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toMedicationDistributionValueWithDefault measurement model.nextStepsData.medicationDistributionForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveMedicationDistribution personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationDistributionValueWithDefault
+                model.nextStepsData.medicationDistributionForm
+                saved
+                (Backend.NCDEncounter.Model.SaveMedicationDistribution personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)
 
         SetReferralBoolInput updateFunc value ->
             let
@@ -2167,28 +1941,12 @@ update currentDate id db msg model =
             )
 
         SaveReferral personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toReferralValueWithDefault measurement model.nextStepsData.referralForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveReferral personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toReferralValueWithDefault
+                model.nextStepsData.referralForm
+                saved
+                (Backend.NCDEncounter.Model.SaveReferral personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)

--- a/client/src/elm/Pages/NCD/RecurrentActivity/Update.elm
+++ b/client/src/elm/Pages/NCD/RecurrentActivity/Update.elm
@@ -21,7 +21,7 @@ import Pages.GlobalCaseManagement.Utils exposing (labsResultsTestData)
 import Pages.NCD.RecurrentActivity.Model exposing (Model, Msg(..))
 import Pages.NCD.Utils exposing (medicationDistributionFormWithDefault, referralFormWithDefault, toMedicationDistributionValueWithDefault, toReferralValueWithDefault)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (setMultiSelectInputValue)
+import Pages.Utils exposing (saveMeasurementMsgs, setMultiSelectInputValue)
 import RemoteData
 
 
@@ -75,6 +75,9 @@ update currentDate id db msg model =
                      in
                      (SetActivePage <| UserPage <| NCDRecurrentEncounterPage id) :: closeLabsResultsMsg
                     )
+
+        toIndexedDbMsg =
+            Backend.Model.MsgNCDEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -254,31 +257,15 @@ update currentDate id db msg model =
             )
 
         SaveUrineDipstickResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toUrineDipstickResultValueWithDefault measurement model.labResultsData.urineDipstickTestForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveUrineDipstickTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toUrineDipstickResultValueWithDefault
+                model.labResultsData.urineDipstickTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveUrineDipstickTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLabResultsMsgs nextTask)
 
         SetRandomBloodSugar value ->
             let
@@ -298,31 +285,15 @@ update currentDate id db msg model =
             )
 
         SaveRandomBloodSugarResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toRandomBloodSugarResultValueWithDefault measurement model.labResultsData.randomBloodSugarTestForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveRandomBloodSugarTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toRandomBloodSugarResultValueWithDefault
+                model.labResultsData.randomBloodSugarTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveRandomBloodSugarTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLabResultsMsgs nextTask)
 
         SetCreatinineResult value ->
             let
@@ -359,31 +330,15 @@ update currentDate id db msg model =
             )
 
         SaveCreatinineResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toCreatinineResultValueWithDefault measurement model.labResultsData.creatinineTestForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveCreatinineTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toCreatinineResultValueWithDefault
+                model.labResultsData.creatinineTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveCreatinineTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLabResultsMsgs nextTask)
 
         SetAltResult value ->
             let
@@ -420,31 +375,15 @@ update currentDate id db msg model =
             )
 
         SaveLiverFunctionResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toLiverFunctionResultValueWithDefault measurement model.labResultsData.liverFunctionTestForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveLiverFunctionTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toLiverFunctionResultValueWithDefault
+                model.labResultsData.liverFunctionTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveLiverFunctionTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLabResultsMsgs nextTask)
 
         SetUnitOfMeasurement value ->
             let
@@ -542,31 +481,15 @@ update currentDate id db msg model =
             )
 
         SaveLipidPanelResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toLipidPanelResultValueWithDefault measurement model.labResultsData.lipidPanelTestForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveLipidPanelTest personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toLipidPanelResultValueWithDefault
+                model.labResultsData.lipidPanelTestForm
+                saved
+                (Backend.NCDEncounter.Model.SaveLipidPanelTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLabResultsMsgs nextTask)
 
         SetActiveNextStepsTask task ->
             let
@@ -655,31 +578,15 @@ update currentDate id db msg model =
             )
 
         SaveMedicationDistribution personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs personId nextTask
-
-                appMsgs =
-                    toMedicationDistributionValueWithDefault measurement model.nextStepsData.medicationDistributionForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveMedicationDistribution personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationDistributionValueWithDefault
+                model.nextStepsData.medicationDistributionForm
+                saved
+                (Backend.NCDEncounter.Model.SaveMedicationDistribution personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs personId nextTask)
 
         SetReferralBoolInput updateFunc value ->
             let
@@ -737,31 +644,15 @@ update currentDate id db msg model =
             )
 
         SaveReferral personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs personId nextTask
-
-                appMsgs =
-                    toReferralValueWithDefault measurement model.nextStepsData.referralForm
-                        |> Maybe.map
-                            (Backend.NCDEncounter.Model.SaveReferral personId measurementId
-                                >> Backend.Model.MsgNCDEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toReferralValueWithDefault
+                model.nextStepsData.referralForm
+                saved
+                (Backend.NCDEncounter.Model.SaveReferral personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs personId nextTask)
 
         CloseLabsResultsEntry personId labsResultsId value ->
             ( model

--- a/client/src/elm/Pages/Nutrition/Activity/Update.elm
+++ b/client/src/elm/Pages/Nutrition/Activity/Update.elm
@@ -13,7 +13,7 @@ import Maybe.Extra exposing (unwrap)
 import Measurement.Utils exposing (contributingFactorsFormWithDefault, ncdaFormWithDefault, nutritionFormWithDefault, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionValueWithDefault, toSendToHCValueWithDefault, toWeightValueWithDefault)
 import Pages.Nutrition.Activity.Model exposing (Model, Msg(..), emptyPhotoData)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (setMuacValueForSite, setMultiSelectInputValue)
+import Pages.Utils exposing (saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue)
 import RemoteData exposing (RemoteData(..))
 import SyncManager.Model exposing (Site)
 
@@ -34,6 +34,9 @@ update site id db msg model =
         generateNextStepsMsgs nextTask =
             Maybe.map (\task -> [ SetActiveNextStepsTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| NutritionEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgNutritionEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -605,31 +608,15 @@ update site id db msg model =
             )
 
         SaveSendToHC personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toSendToHCValueWithDefault measurement model.nextStepsData.sendToHCForm
-                        |> Maybe.map
-                            (Backend.NutritionEncounter.Model.SaveSendToHC personId measurementId
-                                >> Backend.Model.MsgNutritionEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSendToHCValueWithDefault
+                model.nextStepsData.sendToHCForm
+                saved
+                (Backend.NutritionEncounter.Model.SaveSendToHC personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site id db) extraMsgs
+                |> sequenceExtra (update site id db) (generateNextStepsMsgs nextTask)
 
         SetProvidedEducationForDiagnosis value ->
             let
@@ -666,31 +653,15 @@ update site id db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toHealthEducationValueWithDefault measurement model.nextStepsData.healthEducationForm
-                        |> Maybe.map
-                            (Backend.NutritionEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgNutritionEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.NutritionEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site id db) extraMsgs
+                |> sequenceExtra (update site id db) (generateNextStepsMsgs nextTask)
 
         SetContributingFactorsSign sign ->
             let
@@ -722,31 +693,15 @@ update site id db msg model =
             )
 
         SaveContributingFactors personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toContributingFactorsValueWithDefault measurement model.nextStepsData.contributingFactorsForm
-                        |> Maybe.map
-                            (Backend.NutritionEncounter.Model.SaveContributingFactors personId measurementId
-                                >> Backend.Model.MsgNutritionEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toContributingFactorsValueWithDefault
+                model.nextStepsData.contributingFactorsForm
+                saved
+                (Backend.NutritionEncounter.Model.SaveContributingFactors personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site id db) extraMsgs
+                |> sequenceExtra (update site id db) (generateNextStepsMsgs nextTask)
 
         SetFollowUpOption option ->
             let
@@ -767,30 +722,15 @@ update site id db msg model =
 
         SaveFollowUp personId saved assesment nextTask ->
             let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
                 form =
                     model.nextStepsData.followUpForm
-
-                appMsgs =
-                    toNutritionFollowUpValueWithDefault measurement { form | assesment = Just assesment }
-                        |> Maybe.map
-                            (Backend.NutritionEncounter.Model.SaveFollowUp personId measurementId
-                                >> Backend.Model.MsgNutritionEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
             in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionFollowUpValueWithDefault
+                { form | assesment = Just assesment }
+                saved
+                (Backend.NutritionEncounter.Model.SaveFollowUp personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update site id db) extraMsgs
+                |> sequenceExtra (update site id db) (generateNextStepsMsgs nextTask)

--- a/client/src/elm/Pages/Prenatal/Activity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Update.elm
@@ -72,7 +72,7 @@ import Pages.Prenatal.Activity.Model exposing (Model, Msg(..), emptyPregnancyDat
 import Pages.Prenatal.Activity.Types exposing (ImmunisationTask(..), ObstetricHistoryStep(..), SymptomReviewStep(..), WarningPopupType(..))
 import Pages.Prenatal.Activity.Utils exposing (birthPlanFormWithDefault, breastExamFormWithDefault, dangerSignsFormWithDefault, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, guExamFormWithDefault, medicalHistoryFormWithDefault, mentalHealthFormWithDefault, obstetricHistoryStep2FormWithDefault, obstetricalExamFormWithDefault, symptomReviewFormWithDefault, toAppointmentConfirmationValueWithDefault, toBirthPlanValueWithDefault, toBreastExamValueWithDefault, toBreastfeedingValueWithDefault, toDangerSignsValueWithDefault, toFollowUpValueWithDefault, toGUExamValueWithDefault, toHealthEducationValueWithDefault, toLastMenstrualPeriodValueWithDefault, toMedicalHistoryValueWithDefault, toMedicationValueWithDefault, toObstetricHistoryStep2ValueWithDefault, toObstetricHistoryValueWithDefault, toObstetricalExamValueWithDefault, toPregnancyTestValueWithDefault, toPrenatalMentalHealthValueWithDefault, toPrenatalNutritionValueWithDefault, toSocialHistoryValueWithDefault, toSpecialityCareValueWithDefault, toSymptomReviewValueWithDefault, toUltrasoundValueWithDefault, updateSymptomReviewFormWithSymptoms, updateVaccinationFormByVaccineType)
 import Pages.Prenatal.Utils exposing (medicationDistributionFormWithDefaultInitialPhase, referralFormWithDefault, toMalariaPreventionValueWithDefault, toMedicationDistributionValueWithDefaultInitialPhase, toPrenatalReferralValueWithDefault)
-import Pages.Utils exposing (insertIntoSet, nonAdministrationReasonToSign, setMultiSelectInputValue, tasksBarId)
+import Pages.Utils exposing (insertIntoSet, nonAdministrationReasonToSign, saveMeasurementMsgs, setMultiSelectInputValue, tasksBarId)
 import RemoteData exposing (RemoteData(..))
 
 
@@ -171,6 +171,9 @@ update currentDate id db msg model =
         generateMedicationMsgs nextTask =
             Maybe.map (\task -> [ SetActiveMedicationTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| PrenatalEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgPrenatalEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -817,32 +820,15 @@ update currentDate id db msg model =
             )
 
         SaveMedicalHistory personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHistoryMsgs nextTask
-
-                appMsgs =
-                    model.historyData.medicalForm
-                        |> toMedicalHistoryValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMedicalHistory personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicalHistoryValueWithDefault
+                model.historyData.medicalForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMedicalHistory personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateHistoryMsgs nextTask)
 
         SetSocialBoolInput formUpdateFunc value ->
             let
@@ -860,31 +846,15 @@ update currentDate id db msg model =
             )
 
         SaveSocialHistory personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHistoryMsgs nextTask
-
-                appMsgs =
-                    toSocialHistoryValueWithDefault measurement model.historyData.socialForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveSocialHistory personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSocialHistoryValueWithDefault
+                model.historyData.socialForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveSocialHistory personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateHistoryMsgs nextTask)
 
         SetOutsideCareStep step ->
             let
@@ -1024,31 +994,15 @@ update currentDate id db msg model =
             )
 
         SaveOutsideCare personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHistoryMsgs nextTask
-
-                appMsgs =
-                    toOutsideCareValueWithDefault NoPrenatalDiagnosis measurement model.historyData.outsideCareForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveOutsideCare personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs (toOutsideCareValueWithDefault NoPrenatalDiagnosis)
+                model.historyData.outsideCareForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveOutsideCare personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateHistoryMsgs nextTask)
 
         SetActiveExaminationTask task ->
             let
@@ -1092,31 +1046,15 @@ update currentDate id db msg model =
             )
 
         SaveVitals personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toVitalsValueWithDefault measurement model.examinationData.vitalsForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveVitals personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVitalsValueWithDefault
+                model.examinationData.vitalsForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveVitals personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetNutritionAssessmentMeasurement formUpdateFunc value ->
             let
@@ -1313,31 +1251,15 @@ update currentDate id db msg model =
             )
 
         SaveCorePhysicalExam personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toCorePhysicalExamValueWithDefault measurement model.examinationData.corePhysicalExamForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveCorePhysicalExam personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toCorePhysicalExamValueWithDefault
+                model.examinationData.corePhysicalExamForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveCorePhysicalExam personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetObstetricalExamBoolInput formUpdateFunc value ->
             let
@@ -1482,31 +1404,15 @@ update currentDate id db msg model =
             )
 
         SaveObstetricalExam personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toObstetricalExamValueWithDefault measurement model.examinationData.obstetricalExamForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveObstetricalExam personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toObstetricalExamValueWithDefault
+                model.examinationData.obstetricalExamForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveObstetricalExam personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetBreastExamBoolInput formUpdateFunc value ->
             let
@@ -1573,31 +1479,15 @@ update currentDate id db msg model =
             )
 
         SaveBreastExam personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toBreastExamValueWithDefault measurement model.examinationData.breastExamForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveBreastExam personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toBreastExamValueWithDefault
+                model.examinationData.breastExamForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveBreastExam personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetGUExamBoolInput formUpdateFunc value ->
             let
@@ -1650,31 +1540,15 @@ update currentDate id db msg model =
             )
 
         SaveGUExam personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateExaminationMsgs nextTask
-
-                appMsgs =
-                    toGUExamValueWithDefault measurement model.examinationData.guExamForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveGUExam personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toGUExamValueWithDefault
+                model.examinationData.guExamForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveGUExam personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
 
         SetFamilyPlanningSign sign ->
             let
@@ -1773,32 +1647,15 @@ update currentDate id db msg model =
             )
 
         SaveAspirin personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.aspirinForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveAspirin personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.aspirinForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveAspirin personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetCalciumAdministered value ->
             let
@@ -1831,32 +1688,15 @@ update currentDate id db msg model =
             )
 
         SaveCalcium personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.calciumForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveCalcium personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.calciumForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveCalcium personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetFefolAdministered value ->
             let
@@ -1889,32 +1729,15 @@ update currentDate id db msg model =
             )
 
         SaveFefol personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.fefolForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveFefol personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.fefolForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveFefol personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetFolateAdministered value ->
             let
@@ -1947,32 +1770,15 @@ update currentDate id db msg model =
             )
 
         SaveFolate personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.folateForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveFolate personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.folateForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveFolate personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetIronAdministered value ->
             let
@@ -2005,32 +1811,15 @@ update currentDate id db msg model =
             )
 
         SaveIron personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.ironForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveIron personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.ironForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveIron personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetMMSAdministered value ->
             let
@@ -2063,32 +1852,15 @@ update currentDate id db msg model =
             )
 
         SaveMMS personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.mmsForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMMS personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.mmsForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMMS personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetMebendazoleAdministered value ->
             let
@@ -2121,32 +1893,15 @@ update currentDate id db msg model =
             )
 
         SaveMebendazole personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.mebendazoleForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMebendazole personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.mebendazoleForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMebendazole personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
 
         SetMalariaPreventionBoolInput formUpdateFunc value ->
             let
@@ -2504,32 +2259,15 @@ update currentDate id db msg model =
             )
 
         SaveHIVTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.hivTestForm
-                        |> toHIVTestValueUniversalWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHIVTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHIVTestValueUniversalWithDefault
+                model.laboratoryData.hivTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHIVTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetSyphilisTestFormBoolInput formUpdateFunc value ->
             let
@@ -2611,32 +2349,15 @@ update currentDate id db msg model =
             )
 
         SaveSyphilisTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.syphilisTestForm
-                        |> toSyphilisTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveSyphilisTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSyphilisTestValueWithDefault
+                model.laboratoryData.syphilisTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveSyphilisTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetHepatitisBTestFormBoolInput formUpdateFunc value ->
             let
@@ -2690,32 +2411,15 @@ update currentDate id db msg model =
             )
 
         SaveHepatitisBTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.hepatitisBTestForm
-                        |> toHepatitisBTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHepatitisBTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHepatitisBTestValueWithDefault
+                model.laboratoryData.hepatitisBTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHepatitisBTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetMalariaTestFormBoolInput formUpdateFunc value ->
             let
@@ -2791,32 +2495,15 @@ update currentDate id db msg model =
             )
 
         SaveMalariaTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.malariaTestForm
-                        |> toMalariaTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMalariaTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMalariaTestValueWithDefault
+                model.laboratoryData.malariaTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMalariaTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetBloodGpRsTestFormBoolInput formUpdateFunc value ->
             let
@@ -2887,32 +2574,15 @@ update currentDate id db msg model =
             )
 
         SaveBloodGpRsTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.bloodGpRsTestForm
-                        |> toBloodGpRsTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveBloodGpRsTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toBloodGpRsTestValueWithDefault
+                model.laboratoryData.bloodGpRsTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveBloodGpRsTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetUrineDipstickTestFormBoolInput formUpdateFunc value ->
             let
@@ -3140,32 +2810,15 @@ update currentDate id db msg model =
             )
 
         SaveUrineDipstickTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.urineDipstickTestForm
-                        |> toUrineDipstickTestValueUniversalWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveUrineDipstickTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toUrineDipstickTestValueUniversalWithDefault
+                model.laboratoryData.urineDipstickTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveUrineDipstickTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetHemoglobinTestFormBoolInput formUpdateFunc value ->
             let
@@ -3219,32 +2872,15 @@ update currentDate id db msg model =
             )
 
         SaveHemoglobinTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.hemoglobinTestForm
-                        |> toHemoglobinTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHemoglobinTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHemoglobinTestValueWithDefault
+                model.laboratoryData.hemoglobinTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHemoglobinTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetRandomBloodSugarTestFormBoolInput formUpdateFunc value ->
             let
@@ -3298,32 +2934,15 @@ update currentDate id db msg model =
             )
 
         SaveRandomBloodSugarTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.randomBloodSugarTestForm
-                        |> toRandomBloodSugarTestValueUniversalWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveRandomBloodSugarTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toRandomBloodSugarTestValueUniversalWithDefault
+                model.laboratoryData.randomBloodSugarTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveRandomBloodSugarTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetHIVPCRTestFormBoolInput formUpdateFunc value ->
             let
@@ -3401,32 +3020,15 @@ update currentDate id db msg model =
             )
 
         SaveHIVPCRTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.hivPCRTestForm
-                        |> toHIVPCRTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHIVPCRTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHIVPCRTestValueWithDefault
+                model.laboratoryData.hivPCRTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHIVPCRTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetPartnerHIVTestFormBoolInput formUpdateFunc value ->
             let
@@ -3486,32 +3088,15 @@ update currentDate id db msg model =
             )
 
         SavePartnerHIVTest personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLaboratoryMsgs nextTask
-
-                appMsgs =
-                    model.laboratoryData.partnerHIVTestForm
-                        |> toPartnerHIVTestValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SavePartnerHIVTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toPartnerHIVTestValueWithDefault
+                model.laboratoryData.partnerHIVTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SavePartnerHIVTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
 
         SetLabsHistoryCompleted value ->
             let
@@ -3610,32 +3195,15 @@ update currentDate id db msg model =
             )
 
         SaveHealthEducationSubActivity personId saved secondPhaseRequired nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs secondPhaseRequired nextTask
-
-                appMsgs =
-                    model.nextStepsData.healthEducationForm
-                        |> toHealthEducationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SetFollowUpOption option ->
             let
@@ -3768,32 +3336,15 @@ update currentDate id db msg model =
             )
 
         SaveSendToHC personId saved secondPhaseRequired nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs secondPhaseRequired nextTask
-
-                appMsgs =
-                    model.nextStepsData.referralForm
-                        |> toPrenatalReferralValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveSendToHC personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toPrenatalReferralValueWithDefault
+                model.nextStepsData.referralForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveSendToHC personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SetAppointmentDateSelectorState state ->
             let
@@ -3826,32 +3377,15 @@ update currentDate id db msg model =
             )
 
         SaveAppointmentConfirmation personId saved secondPhaseRequired nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs secondPhaseRequired nextTask
-
-                appMsgs =
-                    model.nextStepsData.appointmentConfirmationForm
-                        |> toAppointmentConfirmationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveAppointmentConfirmation personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAppointmentConfirmationValueWithDefault
+                model.nextStepsData.appointmentConfirmationForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveAppointmentConfirmation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SetMedicationDistributionBoolInput formUpdateFunc value ->
             let
@@ -3945,32 +3479,15 @@ update currentDate id db msg model =
             )
 
         SaveMedicationDistribution personId saved secondPhaseRequired nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs secondPhaseRequired nextTask
-
-                appMsgs =
-                    model.nextStepsData.medicationDistributionForm
-                        |> toMedicationDistributionValueWithDefaultInitialPhase measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMedicationDistribution personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationDistributionValueWithDefaultInitialPhase
+                model.nextStepsData.medicationDistributionForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMedicationDistribution personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SaveWait personId measurementId updatedValue ->
             let
@@ -4183,32 +3700,15 @@ update currentDate id db msg model =
             )
 
         SaveMedicationSubActivity personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationSubActivityMsgs nextTask
-
-                appMsgs =
-                    model.treatmentReviewData.medicationForm
-                        |> toMedicationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMedication personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationValueWithDefault
+                model.treatmentReviewData.medicationForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMedication personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate id db) (generateMedicationSubActivityMsgs nextTask)
 
         SetMentalHealthStep step ->
             let

--- a/client/src/elm/Pages/Prenatal/RecurrentActivity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/RecurrentActivity/Update.elm
@@ -29,7 +29,7 @@ import Pages.Page exposing (Page(..), UserPage(..))
 import Pages.Prenatal.RecurrentActivity.Model exposing (LabResultsData, Model, Msg(..))
 import Pages.Prenatal.RecurrentActivity.Utils exposing (toHealthEducationValueWithDefault)
 import Pages.Prenatal.Utils exposing (medicationDistributionFormWithDefaultRecurrentPhase, referralFormWithDefault, toMalariaPreventionValueWithDefault, toMedicationDistributionValueWithDefaultRecurrentPhase, toPrenatalReferralValueWithDefault)
-import Pages.Utils exposing (nonAdministrationReasonToSign, setMultiSelectInputValue)
+import Pages.Utils exposing (nonAdministrationReasonToSign, saveMeasurementMsgs, setMultiSelectInputValue)
 import RemoteData
 
 
@@ -63,6 +63,9 @@ update id isLabTech db msg model =
         generateNextStepsMsgs nextTask =
             Maybe.map (\task -> [ SetActiveNextStepsTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| PrenatalRecurrentEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgPrenatalEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -212,31 +215,15 @@ update id isLabTech db msg model =
             )
 
         SaveSyphilisResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toSyphilisResultValueWithDefault isLabTech measurement model.labResultsData.syphilisTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveSyphilisTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs (toSyphilisResultValueWithDefault isLabTech)
+                model.labResultsData.syphilisTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveSyphilisTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetHepatitisBTestFormBoolInput formUpdateFunc value ->
             let
@@ -290,31 +277,15 @@ update id isLabTech db msg model =
             )
 
         SaveHepatitisBResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toHepatitisBResultValueWithDefault measurement model.labResultsData.hepatitisBTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHepatitisBTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHepatitisBResultValueWithDefault
+                model.labResultsData.hepatitisBTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHepatitisBTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetBloodGpRsTestFormBoolInput formUpdateFunc value ->
             let
@@ -385,31 +356,15 @@ update id isLabTech db msg model =
             )
 
         SaveBloodGpRsResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toBloodGpRsResultValueWithDefault measurement model.labResultsData.bloodGpRsTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveBloodGpRsTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toBloodGpRsResultValueWithDefault
+                model.labResultsData.bloodGpRsTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveBloodGpRsTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetUrineDipstickTestFormBoolInput formUpdateFunc value ->
             let
@@ -599,31 +554,15 @@ update id isLabTech db msg model =
             )
 
         SaveUrineDipstickResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toUrineDipstickResultValueWithDefault measurement model.labResultsData.urineDipstickTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveUrineDipstickTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toUrineDipstickResultValueWithDefault
+                model.labResultsData.urineDipstickTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveUrineDipstickTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetHemoglobinTestFormBoolInput formUpdateFunc value ->
             let
@@ -677,31 +616,15 @@ update id isLabTech db msg model =
             )
 
         SaveHemoglobinResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toHemoglobinResultValueWithDefault measurement model.labResultsData.hemoglobinTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHemoglobinTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHemoglobinResultValueWithDefault
+                model.labResultsData.hemoglobinTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHemoglobinTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetRandomBloodSugarTestFormBoolInput formUpdateFunc value ->
             let
@@ -755,31 +678,15 @@ update id isLabTech db msg model =
             )
 
         SaveRandomBloodSugarResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toRandomBloodSugarResultValueWithDefault measurement model.labResultsData.randomBloodSugarTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveRandomBloodSugarTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toRandomBloodSugarResultValueWithDefault
+                model.labResultsData.randomBloodSugarTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveRandomBloodSugarTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetHIVPCRTestFormBoolInput formUpdateFunc value ->
             let
@@ -857,31 +764,15 @@ update id isLabTech db msg model =
             )
 
         SaveHIVPCRResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    toHIVPCRResultValueWithDefault measurement model.labResultsData.hivPCRTestForm
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHIVPCRTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHIVPCRResultValueWithDefault
+                model.labResultsData.hivPCRTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHIVPCRTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetHIVTestFormBoolInput formUpdateFunc value ->
             let
@@ -945,32 +836,15 @@ update id isLabTech db msg model =
             )
 
         SaveHIVResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    model.labResultsData.hivTestForm
-                        |> toHIVResultValueWithDefault isLabTech measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHIVTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs (toHIVResultValueWithDefault isLabTech)
+                model.labResultsData.hivTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHIVTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetPartnerHIVTestFormBoolInput formUpdateFunc value ->
             let
@@ -1024,32 +898,15 @@ update id isLabTech db msg model =
             )
 
         SavePartnerHIVResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    model.labResultsData.partnerHIVTestForm
-                        |> toPartnerHIVResultValueWithDefault isLabTech measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SavePartnerHIVTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs (toPartnerHIVResultValueWithDefault isLabTech)
+                model.labResultsData.partnerHIVTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SavePartnerHIVTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetMalariaTestFormBoolInput formUpdateFunc value ->
             let
@@ -1120,32 +977,15 @@ update id isLabTech db msg model =
             )
 
         SaveMalariaResult personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateLabResultsMsgs nextTask
-
-                appMsgs =
-                    model.labResultsData.malariaTestForm
-                        |> toMalariaResultValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMalariaTest personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMalariaResultValueWithDefault
+                model.labResultsData.malariaTestForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMalariaTest personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateLabResultsMsgs nextTask)
 
         SetActiveNextStepsTask task ->
             let
@@ -1214,32 +1054,15 @@ update id isLabTech db msg model =
             )
 
         SaveSendToHC personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.referralForm
-                        |> toPrenatalReferralValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveSendToHC personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toPrenatalReferralValueWithDefault
+                model.nextStepsData.referralForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveSendToHC personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateNextStepsMsgs nextTask)
 
         SetMedicationDistributionBoolInput formUpdateFunc value ->
             let
@@ -1312,32 +1135,15 @@ update id isLabTech db msg model =
             )
 
         SaveMedicationDistribution personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.medicationDistributionForm
-                        |> toMedicationDistributionValueWithDefaultRecurrentPhase measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveMedicationDistribution personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMedicationDistributionValueWithDefaultRecurrentPhase
+                model.nextStepsData.medicationDistributionForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveMedicationDistribution personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateNextStepsMsgs nextTask)
 
         SetHealthEducationBoolInput formUpdateFunc value ->
             let
@@ -1354,32 +1160,15 @@ update id isLabTech db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.healthEducationForm
-                        |> toHealthEducationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.PrenatalEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgPrenatalEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.PrenatalEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id isLabTech db) extraMsgs
+                |> sequenceExtra (update id isLabTech db) (generateNextStepsMsgs nextTask)
 
         SetMalariaPreventionBoolInput formUpdateFunc value ->
             let

--- a/client/src/elm/Pages/Tuberculosis/Activity/Update.elm
+++ b/client/src/elm/Pages/Tuberculosis/Activity/Update.elm
@@ -14,7 +14,7 @@ import Measurement.Utils exposing (ongoingTreatmentReviewFormWithDefault, toFoll
 import Pages.Page exposing (Page(..), UserPage(..))
 import Pages.Tuberculosis.Activity.Model exposing (Model, Msg(..))
 import Pages.Tuberculosis.Activity.Utils exposing (diagnosticsFormWithDefault, dotFormWithDefault, prescribedMedicationFormWithDefault, toDOTValueWithDefault, toDiagnosticsValueWithDefault, toHealthEducationValueWithDefault, toPrescribedMedicationValueWithDefault, toSymptomReviewValueWithDefault)
-import Pages.Utils exposing (setMultiSelectInputValue)
+import Pages.Utils exposing (saveMeasurementMsgs, setMultiSelectInputValue)
 import RemoteData
 
 
@@ -50,6 +50,9 @@ update id db msg model =
         generateNextStepsMsgs nextTask =
             Maybe.map (\task -> [ SetActiveNextStepsTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| TuberculosisEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgTuberculosisEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         SetActivePage page ->
@@ -173,31 +176,15 @@ update id db msg model =
             )
 
         SavePrescribedMedication personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    toPrescribedMedicationValueWithDefault measurement model.medicationData.prescribedMedicationForm
-                        |> Maybe.map
-                            (Backend.TuberculosisEncounter.Model.SavePrescribedMedication personId measurementId
-                                >> Backend.Model.MsgTuberculosisEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toPrescribedMedicationValueWithDefault
+                model.medicationData.prescribedMedicationForm
+                saved
+                (Backend.TuberculosisEncounter.Model.SavePrescribedMedication personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id db) extraMsgs
+                |> sequenceExtra (update id db) (generateMedicationMsgs nextTask)
 
         SetDOTBoolInput formUpdateFunc value ->
             let
@@ -248,31 +235,15 @@ update id db msg model =
             )
 
         SaveDOT personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    toDOTValueWithDefault measurement model.medicationData.dotForm
-                        |> Maybe.map
-                            (Backend.TuberculosisEncounter.Model.SaveDOT personId measurementId
-                                >> Backend.Model.MsgTuberculosisEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toDOTValueWithDefault
+                model.medicationData.dotForm
+                saved
+                (Backend.TuberculosisEncounter.Model.SaveDOT personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id db) extraMsgs
+                |> sequenceExtra (update id db) (generateMedicationMsgs nextTask)
 
         SetTreatmentReviewBoolInput formUpdateFunc value ->
             let
@@ -345,31 +316,15 @@ update id db msg model =
             )
 
         SaveTreatmentReview personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    toOngoingTreatmentReviewValueWithDefault measurement model.medicationData.treatmentReviewForm
-                        |> Maybe.map
-                            (Backend.TuberculosisEncounter.Model.SaveTreatmentReview personId measurementId
-                                >> Backend.Model.MsgTuberculosisEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toOngoingTreatmentReviewValueWithDefault
+                model.medicationData.treatmentReviewForm
+                saved
+                (Backend.TuberculosisEncounter.Model.SaveTreatmentReview personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id db) extraMsgs
+                |> sequenceExtra (update id db) (generateMedicationMsgs nextTask)
 
         SetSymptomReviewBoolInput formUpdateFunc value ->
             let
@@ -437,31 +392,15 @@ update id db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toHealthEducationValueWithDefault measurement model.nextStepsData.healthEducationForm
-                        |> Maybe.map
-                            (Backend.TuberculosisEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgTuberculosisEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.TuberculosisEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id db) extraMsgs
+                |> sequenceExtra (update id db) (generateNextStepsMsgs nextTask)
 
         SetFollowUpOption option ->
             let
@@ -481,31 +420,15 @@ update id db msg model =
             )
 
         SaveFollowUp personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toFollowUpValueWithDefault measurement model.nextStepsData.followUpForm
-                        |> Maybe.map
-                            (Backend.TuberculosisEncounter.Model.SaveFollowUp personId measurementId
-                                >> Backend.Model.MsgTuberculosisEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toFollowUpValueWithDefault
+                model.nextStepsData.followUpForm
+                saved
+                (Backend.TuberculosisEncounter.Model.SaveFollowUp personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id db) extraMsgs
+                |> sequenceExtra (update id db) (generateNextStepsMsgs nextTask)
 
         SetReferToHealthCenter value ->
             let
@@ -559,28 +482,12 @@ update id db msg model =
             )
 
         SaveReferral personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    toSendToHCValueWithDefault measurement model.nextStepsData.sendToHCForm
-                        |> Maybe.map
-                            (Backend.TuberculosisEncounter.Model.SaveReferral personId measurementId
-                                >> Backend.Model.MsgTuberculosisEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSendToHCValueWithDefault
+                model.nextStepsData.sendToHCForm
+                saved
+                (Backend.TuberculosisEncounter.Model.SaveReferral personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update id db) extraMsgs
+                |> sequenceExtra (update id db) (generateNextStepsMsgs nextTask)

--- a/client/src/elm/Pages/Utils.elm
+++ b/client/src/elm/Pages/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
+module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Entities exposing (HealthCenterId, PersonId)
@@ -9,6 +9,7 @@ import Backend.Measurement.Model
         , MedicationDistributionSign(..)
         , MedicationNonAdministrationSign(..)
         )
+import Backend.Measurement.Utils exposing (getMeasurementValueFunc)
 import Backend.Person.Model exposing (Person)
 import Backend.Person.Utils exposing (ageInYears, isPersonAnAdult)
 import Backend.Session.Model exposing (OfflineSession)
@@ -30,6 +31,37 @@ import SyncManager.Model exposing (Site(..), SiteFeature)
 import Translate exposing (Language, TranslationId, translate)
 import Utils.Html exposing (thumbnailImage)
 import Utils.NominalDate exposing (renderAgeMonthsDays, renderAgeYearsMonths)
+
+
+{-| Build the App messages that persist a measurement form.
+
+Every per-program save handler repeats the same shape: read the existing
+measurement id and prior value out of `saved`, run the form's
+`toValueWithDefault` converter, and -- only when it yields a value -- dispatch
+the store message. `toBackendMsg` is the backend `Save` constructor (already
+partially applied with the person id); `wrap` lifts that backend message into
+an `App.Model.Msg`. Both stay point-free at the call site -- the measurement id
+and value are applied here, inside the helper. Polymorphic in the message
+types, so this carries no dependency on `App.Model`.
+
+    saveMeasurementMsgs toHealthEducationValueWithDefault
+        form
+        saved
+        (Backend.HIVEncounter.Model.SaveHealthEducation personId)
+        (Backend.Model.MsgHIVEncounter encounterId >> App.Model.MsgIndexedDb)
+
+-}
+saveMeasurementMsgs :
+    (Maybe value -> form -> Maybe value)
+    -> form
+    -> Maybe ( id, { measurement | value : value } )
+    -> (Maybe id -> value -> backendMsg)
+    -> (backendMsg -> msg)
+    -> List msg
+saveMeasurementMsgs toValueWithDefault form saved toBackendMsg wrap =
+    toValueWithDefault (getMeasurementValueFunc saved) form
+        |> Maybe.map (toBackendMsg (Maybe.map Tuple.first saved) >> wrap >> List.singleton)
+        |> Maybe.withDefault []
 
 
 thumbnailDimensions : { width : Int, height : Int }

--- a/client/src/elm/Pages/WellChild/Activity/Update.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Update.elm
@@ -21,7 +21,7 @@ import Measurement.Model
         )
 import Measurement.Utils exposing (contributingFactorsFormWithDefault, ncdaFormWithDefault, nutritionFormWithDefault, toAdministrationNoteWithDefault, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toSendToHCValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, vaccinationFormWithDefault, vaccineDoseToComparable)
 import Pages.Page exposing (Page(..), UserPage(..))
-import Pages.Utils exposing (insertIntoSet, setMuacValueForSite, setMultiSelectInputValue)
+import Pages.Utils exposing (insertIntoSet, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue)
 import Pages.WellChild.Activity.Model exposing (Model, Msg(..), WarningPopupType(..))
 import Pages.WellChild.Activity.Utils exposing (getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, pregnancySummaryFormWithDefault, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType)
 import RemoteData exposing (RemoteData(..))
@@ -88,6 +88,9 @@ update currentDate site id db msg model =
         generateHomeVisitMsgs nextTask =
             Maybe.map (\task -> [ SetActiveHomeVisitTask task ]) nextTask
                 |> Maybe.withDefault [ SetActivePage <| UserPage <| WellChildEncounterPage id ]
+
+        toIndexedDbMsg =
+            Backend.Model.MsgWellChildEncounter id >> App.Model.MsgIndexedDb
     in
     case msg of
         NoOp ->
@@ -235,32 +238,15 @@ update currentDate site id db msg model =
             )
 
         SaveSymptomsReview personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateDangerSignsMsgs nextTask
-
-                appMsgs =
-                    model.dangerSignsData.symptomsReviewForm
-                        |> toSymptomsReviewValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveSymptomsReview personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSymptomsReviewValueWithDefault
+                model.dangerSignsData.symptomsReviewForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveSymptomsReview personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateDangerSignsMsgs nextTask)
 
         SetVitalsIntInput formUpdateFunc value ->
             let
@@ -343,32 +329,15 @@ update currentDate site id db msg model =
             )
 
         SaveVitals personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateDangerSignsMsgs nextTask
-
-                appMsgs =
-                    model.dangerSignsData.vitalsForm
-                        |> toVitalsValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveVitals personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVitalsValueWithDefault
+                model.dangerSignsData.vitalsForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveVitals personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateDangerSignsMsgs nextTask)
 
         SetActiveNutritionAssessmentTask task ->
             let
@@ -581,32 +550,15 @@ update currentDate site id db msg model =
                 |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SaveHeadCircumference personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNutritionAssessmentMsgs nextTask
-
-                appMsgs =
-                    model.nutritionAssessmentData.headCircumferenceForm
-                        |> toHeadCircumferenceValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveHeadCircumference personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHeadCircumferenceValueWithDefault
+                model.nutritionAssessmentData.headCircumferenceForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveHeadCircumference personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNutritionAssessmentMsgs nextTask)
 
         SetMuac string ->
             let
@@ -626,32 +578,15 @@ update currentDate site id db msg model =
             )
 
         SaveMuac personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNutritionAssessmentMsgs nextTask
-
-                appMsgs =
-                    model.nutritionAssessmentData.muacForm
-                        |> toMuacValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveMuac personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toMuacValueWithDefault
+                model.nutritionAssessmentData.muacForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveMuac personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNutritionAssessmentMsgs nextTask)
 
         SetNutritionSign sign ->
             let
@@ -683,33 +618,17 @@ update currentDate site id db msg model =
             )
 
         SaveNutrition personId saved assessment nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNutritionAssessmentMsgs nextTask
-
-                appMsgs =
-                    model.nutritionAssessmentData.nutritionForm
-                        |> (\form -> { form | assesment = Just assessment })
-                        |> toNutritionValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveNutrition personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionValueWithDefault
+                (model.nutritionAssessmentData.nutritionForm
+                    |> (\form -> { form | assesment = Just assessment })
+                )
+                saved
+                (Backend.WellChildEncounter.Model.SaveNutrition personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNutritionAssessmentMsgs nextTask)
 
         SetWeight string ->
             let
@@ -1008,256 +927,103 @@ update currentDate site id db msg model =
             )
 
         SaveBCGImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.bcgForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveBCGImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.bcgForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveBCGImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveDTPImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.dtpForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveDTPImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.dtpForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveDTPImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveDTPStandaloneImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.dtpForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveDTPStandaloneImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.dtpForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveDTPStandaloneImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveHPVImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.hpvForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveHPVImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.hpvForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveHPVImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveIPVImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.ipvForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveIPVImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.ipvForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveIPVImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveMRImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.mrForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveMRImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.mrForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveMRImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveOPVImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.opvForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveOPVImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.opvForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveOPVImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SavePCV13Immunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.pcv13Form
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SavePCV13Immunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.pcv13Form
+                saved
+                (Backend.WellChildEncounter.Model.SavePCV13Immunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SaveRotarixImmunisation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateImmunisationMsgs nextTask
-
-                appMsgs =
-                    model.immunisationData.rotarixForm
-                        |> toVaccinationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveRotarixImmunisation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toVaccinationValueWithDefault
+                model.immunisationData.rotarixForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveRotarixImmunisation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateImmunisationMsgs nextTask)
 
         SetECDBoolInput formUpdateFunc value ->
             let
@@ -1337,32 +1103,15 @@ update currentDate site id db msg model =
             )
 
         SaveAlbendazole personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.albendazoleForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveAlbendazole personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.albendazoleForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveAlbendazole personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetMebendezoleAdministered value ->
             let
@@ -1395,32 +1144,15 @@ update currentDate site id db msg model =
             )
 
         SaveMebendezole personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.mebendezoleForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveMebendezole personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.mebendezoleForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveMebendezole personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetVitaminAAdministered value ->
             let
@@ -1453,32 +1185,15 @@ update currentDate site id db msg model =
             )
 
         SaveVitaminA personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateMedicationMsgs nextTask
-
-                appMsgs =
-                    model.medicationData.vitaminAForm
-                        |> toAdministrationNoteWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveVitaminA personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toAdministrationNoteWithDefault
+                model.medicationData.vitaminAForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveVitaminA personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetActiveNextStepsTask task ->
             let
@@ -1577,32 +1292,15 @@ update currentDate site id db msg model =
             )
 
         SaveSendToHC personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.sendToHCForm
-                        |> toSendToHCValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveSendToHC personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toSendToHCValueWithDefault
+                model.nextStepsData.sendToHCForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveSendToHC personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs nextTask)
 
         SetProvidedEducationForDiagnosis value ->
             let
@@ -1639,32 +1337,15 @@ update currentDate site id db msg model =
             )
 
         SaveHealthEducation personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.healthEducationForm
-                        |> toHealthEducationValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveHealthEducation personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toHealthEducationValueWithDefault
+                model.nextStepsData.healthEducationForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveHealthEducation personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs nextTask)
 
         SetContributingFactorsSign sign ->
             let
@@ -1696,32 +1377,15 @@ update currentDate site id db msg model =
             )
 
         SaveContributingFactors personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.contributingFactorsForm
-                        |> toContributingFactorsValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveContributingFactors personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toContributingFactorsValueWithDefault
+                model.nextStepsData.contributingFactorsForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveContributingFactors personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs nextTask)
 
         SetFollowUpOption option ->
             let
@@ -1741,68 +1405,36 @@ update currentDate site id db msg model =
             )
 
         SaveFollowUp personId saved assesment nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.followUpForm
-                        |> (\form -> { form | assesment = Just assesment })
-                        |> toNutritionFollowUpValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveFollowUp personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionFollowUpValueWithDefault
+                (model.nextStepsData.followUpForm
+                    |> (\form -> { form | assesment = Just assesment })
+                )
+                saved
+                (Backend.WellChildEncounter.Model.SaveFollowUp personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs nextTask)
 
         SaveNextVisit personId saved nextDateForImmunisationVisit nextDateForPediatricVisit asapImmunisationDate nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateNextStepsMsgs nextTask
-
-                appMsgs =
-                    model.nextStepsData.nextVisitForm
-                        |> (\form ->
-                                { form
-                                    | immunisationDate = nextDateForImmunisationVisit
-                                    , asapImmunisationDate = asapImmunisationDate
-                                    , pediatricVisitDate = nextDateForPediatricVisit
-                                }
-                           )
-                        |> toNextVisitValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveNextVisit personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNextVisitValueWithDefault
+                (model.nextStepsData.nextVisitForm
+                    |> (\form ->
+                            { form
+                                | immunisationDate = nextDateForImmunisationVisit
+                                , asapImmunisationDate = asapImmunisationDate
+                                , pediatricVisitDate = nextDateForPediatricVisit
+                            }
+                       )
+                )
+                saved
+                (Backend.WellChildEncounter.Model.SaveNextVisit personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs nextTask)
 
         DropZoneComplete result ->
             let
@@ -2089,32 +1721,15 @@ update currentDate site id db msg model =
             )
 
         SaveFeeding personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHomeVisitMsgs nextTask
-
-                appMsgs =
-                    model.homeVisitData.feedingForm
-                        |> toNutritionFeedingValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveFeeding personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionFeedingValueWithDefault
+                model.homeVisitData.feedingForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveFeeding personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateHomeVisitMsgs nextTask)
 
         SetHygieneBoolInput formUpdateFunc value ->
             let
@@ -2165,32 +1780,15 @@ update currentDate site id db msg model =
             )
 
         SaveHygiene personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHomeVisitMsgs nextTask
-
-                appMsgs =
-                    model.homeVisitData.hygieneForm
-                        |> toNutritionHygieneValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveHygiene personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionHygieneValueWithDefault
+                model.homeVisitData.hygieneForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveHygiene personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateHomeVisitMsgs nextTask)
 
         SetFoodSecurityBoolInput formUpdateFunc value ->
             let
@@ -2224,32 +1822,15 @@ update currentDate site id db msg model =
             )
 
         SaveFoodSecurity personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHomeVisitMsgs nextTask
-
-                appMsgs =
-                    model.homeVisitData.foodSecurityForm
-                        |> toNutritionFoodSecurityValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveFoodSecurity personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionFoodSecurityValueWithDefault
+                model.homeVisitData.foodSecurityForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveFoodSecurity personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateHomeVisitMsgs nextTask)
 
         SetParentsAliveAndHealthy value ->
             let
@@ -2303,29 +1884,12 @@ update currentDate site id db msg model =
             )
 
         SaveNutritionCaring personId saved nextTask ->
-            let
-                measurementId =
-                    Maybe.map Tuple.first saved
-
-                measurement =
-                    getMeasurementValueFunc saved
-
-                extraMsgs =
-                    generateHomeVisitMsgs nextTask
-
-                appMsgs =
-                    model.homeVisitData.caringForm
-                        |> toNutritionCaringValueWithDefault measurement
-                        |> Maybe.map
-                            (Backend.WellChildEncounter.Model.SaveCaring personId measurementId
-                                >> Backend.Model.MsgWellChildEncounter id
-                                >> App.Model.MsgIndexedDb
-                                >> List.singleton
-                            )
-                        |> Maybe.withDefault []
-            in
             ( model
             , Cmd.none
-            , appMsgs
+            , saveMeasurementMsgs toNutritionCaringValueWithDefault
+                model.homeVisitData.caringForm
+                saved
+                (Backend.WellChildEncounter.Model.SaveCaring personId)
+                toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate site id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) (generateHomeVisitMsgs nextTask)


### PR DESCRIPTION
Fixes #1773

Removes the ~120-copy measurement-save boilerplate (#5's biggest item) by extracting a single helper and applying it across every per-program `Update` module.

## The helper (`Pages.Utils`)
```elm
saveMeasurementMsgs :
    (Maybe value -> form -> Maybe value)
    -> form
    -> Maybe ( id, { measurement | value : value } )
    -> (Maybe id -> value -> backendMsg)   -- the Save constructor (given personId)
    -> (backendMsg -> msg)                  -- per-file wrapper
    -> List msg
```
Polymorphic in the message types (no `App.Model` dependency / import cycle); applies the measurement id and value internally so call sites stay point-free.

## Call site (every converted handler)
Each file defines one `toIndexedDbMsg = Backend.Model.Msg<Prog>Encounter id >> App.Model.MsgIndexedDb` in its `update` let, then:
```elm
SaveHealthEducation personId saved nextTask ->
    ( model
    , Cmd.none
    , saveMeasurementMsgs toHealthEducationValueWithDefault
        model.nextStepsData.healthEducationForm
        saved
        (Backend.HIVEncounter.Model.SaveHealthEducation personId)
        toIndexedDbMsg
    )
        |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs nextTask)
```

## Scope
Converted **~126 handlers** across: HIV, AcuteIllness, ChildScoreboard, NCD (Activity + RecurrentActivity), Nutrition, Prenatal (Activity + RecurrentActivity), Tuberculosis, WellChild.

Deliberately **left as-is** every handler that dispatches multiple messages or branches — skipped-form logic, navigation, conditional close-session, unconditional emits, or converters whose argument order doesn't fit. HomeVisit is untouched (all its handlers emit two messages). This is "shrink the simple majority", not 100%.

## Behavior preservation
Each converted handler produces the **identical** `App` message list — the helper performs exactly the `Maybe.map (Ctor measurementId >> wrap >> List.singleton) |> Maybe.withDefault []` the inline code did. Verified by:
- full `elm make` compile (548 modules) — types rule out wrong converter order / arity / wrapper,
- `elm-format --validate` clean on all files,
- `elm-review` (full project) — no errors,
- a diff audit confirming **no** removed line contained a multi-message token (`unwrap`, `SetActivePage`, `::`, `++ [`) — i.e. no multi-message handler was collapsed.

## Net
**~2,000 lines removed.** New measurements become a few lines, and the old copy-paste bug class (wrong form/constructor pasted in) is now a compile error.
