### PR TITLE
Load well-child and child-scoreboard vaccination history once per child, not per encounter

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -6197,6 +6197,11 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
     ];
   }
 
+  // Load the well-child immunisation history once. It is filtered per
+  // child-scoreboard encounter (by date) in memory below, instead of being
+  // re-queried from the database for every encounter.
+  $wellchild_immunisations = hedley_reports_child_scoreboard_load_well_child_immunisations($person_id);
+
   foreach ($encounters_data as $index => $encounter_data) {
     $encounter = $encounter_data['encounter'];
     $measurements_by_type = $encounter_data['measurements_by_type'];
@@ -6235,7 +6240,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
       $encounter_data['age_in_months'] = hedley_reports_resolve_age_in_months_for_individual_encounter($encounter, $start_date_obj);
       $encounter_data['previous_encounters_data'] = array_slice($encounters_data, 0, $index);
 
-      [$encounter_data['vaccination_history'], $encounter_data['vaccination_progress']] = hedley_reports_child_scoreboard_generate_vaccination_progress_data($person_id, $encounter_data);
+      [$encounter_data['vaccination_history'], $encounter_data['vaccination_progress']] = hedley_reports_child_scoreboard_generate_vaccination_progress_data($wellchild_immunisations, $encounter_data);
 
       $expected_immunisation_activities = hedley_reports_child_scoreboard_get_expected_immunisation_activities($encounter_data, $birth_date_obj, $gender, 'history');
       $expected = array_merge($expected, $expected_immunisation_activities);
@@ -6259,9 +6264,9 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
  * child scoreboard encounters. It merges this data with well-child
  * data to produce comprehensive vaccination progress information.
  *
- * @param int $person_id
- *   The ID of the person (child) whose vaccination data is being
- *   processed.
+ * @param array $wellchild_immunisations
+ *   The well-child immunisation history, preloaded once by
+ *   hedley_reports_child_scoreboard_load_well_child_immunisations().
  * @param array $encounter_data
  *   An associative array containing details of the current encounter,
  *   including previous encounter data and measurements.
@@ -6270,7 +6275,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
  *   An array containing merged vaccination progress data, with history
  *   and progress for the child.
  */
-function hedley_reports_child_scoreboard_generate_vaccination_progress_data($person_id, array $encounter_data) {
+function hedley_reports_child_scoreboard_generate_vaccination_progress_data(array $wellchild_immunisations, array $encounter_data) {
   $previous_encounters_data = $encounter_data['previous_encounters_data'];
 
   $immunisation_types = [
@@ -6309,7 +6314,7 @@ function hedley_reports_child_scoreboard_generate_vaccination_progress_data($per
 
   $history_data_by_well_child = hedley_reports_generate_vaccination_progress_data($immunisations_from_previous_encounters, 'child-scoreboard');
   $progress_data_by_well_child = hedley_reports_generate_vaccination_progress_data($immunisations_from_all_encounters, 'child-scoreboard');
-  $progress_data_by_child_scoreboard = hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child($person_id, $encounter_data['start_date_obj']);
+  $progress_data_by_child_scoreboard = hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child($wellchild_immunisations, $encounter_data['start_date_obj']);
 
   return [
     hedley_reports_merge_vaccination_progress_data($immunisation_types, 'child-scoreboard', $history_data_by_well_child, $progress_data_by_child_scoreboard),
@@ -6439,27 +6444,28 @@ function hedley_reports_child_scoreboard_get_expected_immunisation_activities(ar
 }
 
 /**
- * Generates vaccination progress data based on well-child data.
+ * Loads well-child immunisation history for a person.
  *
- * Retrieves immunisation data for a child from the well-child,
- * considering all encounters up to the current child scoreboard encounter,
- * and returns structured vaccination progress data.
+ * Performs the database work that
+ * hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child()
+ * used to repeat for every child-scoreboard encounter: resolves the well-child
+ * participant, loads all its encounters and their immunisation measurements,
+ * and returns the raw doses and dates per encounter, tagged with the encounter
+ * start date. Callers filter this in memory by date cutoff.
  *
  * @param int $person_id
- *   The ID of the person (child) whose scoreboard data is being
- *   processed.
- * @param DateTime $child_scoreboard_encounter_start_date_obj
- *   The DateTime object representing the start date of the current
- *   child scoreboard encounter.
+ *   The ID of the person (child) whose well-child data is being loaded.
  *
  * @return array
- *   A structured array of vaccination doses and dates, organized by
- *   immunisation type, based on child scoreboard encounters.
+ *   A list, in encounter order, of associative arrays:
+ *     - 'start_date_obj': DateTime, the encounter start date.
+ *     - 'immunisations_by_type': array keyed by immunisation type, each with
+ *       'doses' and 'dates' arrays recorded during that encounter.
  */
-function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child($person_id, DateTime $child_scoreboard_encounter_start_date_obj) {
-  $return = [];
+function hedley_reports_child_scoreboard_load_well_child_immunisations($person_id) {
+  $encounters_immunisations = [];
   if (empty($person_id)) {
-    return $return;
+    return $encounters_immunisations;
   }
 
   $query = hedley_general_create_entity_field_query_excluding_deleted();
@@ -6475,8 +6481,8 @@ function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_w
     ->execute();
 
   if (empty($result['node'])) {
-    // No more items left.
-    return $return;
+    // No well-child participant for this person.
+    return $encounters_immunisations;
   }
 
   $participant_id = key($result['node']);
@@ -6491,8 +6497,96 @@ function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_w
     ->execute();
 
   if (empty($result['node'])) {
-    return $return;
+    return $encounters_immunisations;
   }
+
+  $immunisation_types = [
+    'well_child_bcg_immunisation',
+    'well_child_dtp_immunisation',
+    'well_child_dtp_sa_immunisation',
+    'well_child_ipv_immunisation',
+    'well_child_mr_immunisation',
+    'well_child_opv_immunisation',
+    'well_child_pcv13_immunisation',
+    'well_child_rotarix_immunisation',
+  ];
+
+  $encounters = node_load_multiple(array_keys($result['node']));
+  foreach ($encounters as $encounter) {
+    $start_date = explode(' ', $encounter->field_scheduled_date[LANGUAGE_NONE][0]['value'])[0];
+    $start_date_obj = new DateTime($start_date);
+
+    // Loading all immunisation activities recorded during the encounter.
+    $query = hedley_general_create_entity_field_query_excluding_deleted();
+    $result = $query
+      ->entityCondition('entity_type', 'node')
+      ->entityCondition('bundle', $immunisation_types, 'IN')
+      ->propertyCondition('status', NODE_PUBLISHED)
+      ->fieldCondition('field_well_child_encounter', 'target_id', $encounter->nid)
+      ->execute();
+
+    if (empty($result['node'])) {
+      continue;
+    }
+
+    $immunisations_by_type = [];
+    $immunisations = node_load_multiple(array_keys($result['node']));
+    foreach ($immunisations as $immunisation) {
+      $doses = $immunisation->field_administered_doses;
+      $dates = $immunisation->field_administration_dates;
+      if (empty($doses) || empty($dates)) {
+        continue;
+      }
+
+      $encounter_doses = $encounter_dates = [];
+      foreach ($doses[LANGUAGE_NONE] as $dose) {
+        $encounter_doses[] = $dose['value'];
+      }
+      foreach ($dates[LANGUAGE_NONE] as $date) {
+        $encounter_dates[] = explode(' ', $date['value'])[0];
+      }
+
+      if (empty($immunisations_by_type[$immunisation->type])) {
+        $immunisations_by_type[$immunisation->type] = [
+          'doses' => [],
+          'dates' => [],
+        ];
+      }
+      $immunisations_by_type[$immunisation->type]['doses'] = array_merge($immunisations_by_type[$immunisation->type]['doses'], $encounter_doses);
+      $immunisations_by_type[$immunisation->type]['dates'] = array_merge($immunisations_by_type[$immunisation->type]['dates'], $encounter_dates);
+    }
+
+    $encounters_immunisations[] = [
+      'start_date_obj' => $start_date_obj,
+      'immunisations_by_type' => $immunisations_by_type,
+    ];
+  }
+
+  return $encounters_immunisations;
+}
+
+/**
+ * Generates vaccination progress data based on well-child data.
+ *
+ * Filters the preloaded well-child immunisation history to encounters that
+ * started on or before the current child-scoreboard encounter, then merges the
+ * doses and dates into structured vaccination progress data. Performs no
+ * database queries -- the history is loaded once by
+ * hedley_reports_child_scoreboard_load_well_child_immunisations().
+ *
+ * @param array $wellchild_immunisations
+ *   The preloaded well-child immunisation history (see
+ *   hedley_reports_child_scoreboard_load_well_child_immunisations()).
+ * @param DateTime $child_scoreboard_encounter_start_date_obj
+ *   The DateTime object representing the start date of the current
+ *   child scoreboard encounter.
+ *
+ * @return array
+ *   A structured array of vaccination doses and dates, organized by
+ *   immunisation type, based on child scoreboard encounters.
+ */
+function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child(array $wellchild_immunisations, DateTime $child_scoreboard_encounter_start_date_obj) {
+  $return = [];
 
   $immunisation_types = [
     'well_child_bcg_immunisation',
@@ -6512,46 +6606,15 @@ function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_w
       'dates' => [],
     ];
   }
-  $encounters = node_load_multiple(array_keys($result['node']));
-  foreach ($encounters as $encounter) {
-    $start_date = explode(' ', $encounter->field_scheduled_date[LANGUAGE_NONE][0]['value'])[0];
-    $start_date_obj = new DateTime($start_date);
-    if ($start_date_obj > $child_scoreboard_encounter_start_date_obj) {
-      // This encounter started after well child encounter, so, skip it.
+  foreach ($wellchild_immunisations as $encounter_immunisations) {
+    if ($encounter_immunisations['start_date_obj'] > $child_scoreboard_encounter_start_date_obj) {
+      // This encounter started after child scoreboard encounter, so, skip it.
       continue;
     }
 
-    // Loading all immunisation activities recorded during the encounter.
-    $query = hedley_general_create_entity_field_query_excluding_deleted();
-    $result = $query
-      ->entityCondition('entity_type', 'node')
-      ->entityCondition('bundle', $immunisation_types, 'IN')
-      ->propertyCondition('status', NODE_PUBLISHED)
-      ->fieldCondition('field_well_child_encounter', 'target_id', $encounter->nid)
-      ->execute();
-
-    if (empty($result['node'])) {
-      continue;
-    }
-
-    $immunisations = node_load_multiple(array_keys($result['node']));
-    foreach ($immunisations as $immunisation) {
-      $doses = $immunisation->field_administered_doses;
-      $dates = $immunisation->field_administration_dates;
-      if (empty($doses) || empty($dates)) {
-        continue;
-      }
-
-      $encounter_doses = $encounter_dates = [];
-      foreach ($doses[LANGUAGE_NONE] as $dose) {
-        $encounter_doses[] = $dose['value'];
-      }
-      foreach ($dates[LANGUAGE_NONE] as $date) {
-        $encounter_dates[] = explode(' ', $date['value'])[0];
-      }
-
-      $immunisations_by_type[$immunisation->type]['doses'] = array_merge($immunisations_by_type[$immunisation->type]['doses'], $encounter_doses);
-      $immunisations_by_type[$immunisation->type]['dates'] = array_merge($immunisations_by_type[$immunisation->type]['dates'], $encounter_dates);
+    foreach ($encounter_immunisations['immunisations_by_type'] as $type => $item) {
+      $immunisations_by_type[$type]['doses'] = array_merge($immunisations_by_type[$type]['doses'], $item['doses']);
+      $immunisations_by_type[$type]['dates'] = array_merge($immunisations_by_type[$type]['dates'], $item['dates']);
     }
   }
 

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -4765,6 +4765,11 @@ function hedley_reports_generate_completion_data_for_well_child($participant, $e
     ];
   }
 
+  // Load the child-scoreboard immunisation history once. It is filtered per
+  // well-child encounter (by date) in memory below, instead of being
+  // re-queried from the database for every encounter.
+  $scoreboard_immunisations = hedley_reports_well_child_load_child_scoreboard_immunisations($person_id);
+
   foreach ($encounters_data as $index => $encounter_data) {
     $encounter = $encounter_data['encounter'];
     $measurements_by_type = $encounter_data['measurements_by_type'];
@@ -4778,7 +4783,7 @@ function hedley_reports_generate_completion_data_for_well_child($participant, $e
     $encounter_data['age_in_months'] = hedley_reports_resolve_age_in_months_for_individual_encounter($encounter, $start_date_obj);
     $encounter_data['previous_encounters_data'] = array_slice($encounters_data, 0, $index);
 
-    [$encounter_data['vaccination_history'], $encounter_data['vaccination_progress']] = hedley_reports_well_child_generate_vaccination_progress_data($person_id, $encounter_data);
+    [$encounter_data['vaccination_history'], $encounter_data['vaccination_progress']] = hedley_reports_well_child_generate_vaccination_progress_data($scoreboard_immunisations, $encounter_data);
 
     // So far we were constructing data structures to resolve encounter data.
     // Now we have enough info to determine which activities were expected.
@@ -4811,9 +4816,9 @@ function hedley_reports_generate_completion_data_for_well_child($participant, $e
  * well-child encounters. It merges this data with child scoreboard data
  * to produce comprehensive vaccination progress information.
  *
- * @param int $person_id
- *   The ID of the person (child) whose vaccination data is being
- *   processed.
+ * @param array $scoreboard_immunisations
+ *   The child-scoreboard immunisation history, preloaded once by
+ *   hedley_reports_well_child_load_child_scoreboard_immunisations().
  * @param array $encounter_data
  *   An associative array containing details of the current encounter,
  *   including previous encounter data and measurements.
@@ -4822,7 +4827,7 @@ function hedley_reports_generate_completion_data_for_well_child($participant, $e
  *   An array containing merged vaccination progress data, with history
  *   and progress for the child.
  */
-function hedley_reports_well_child_generate_vaccination_progress_data($person_id, array $encounter_data) {
+function hedley_reports_well_child_generate_vaccination_progress_data(array $scoreboard_immunisations, array $encounter_data) {
   $previous_encounters_data = $encounter_data['previous_encounters_data'];
 
   $immunisation_types = [
@@ -4863,7 +4868,7 @@ function hedley_reports_well_child_generate_vaccination_progress_data($person_id
 
   $history_data_by_well_child = hedley_reports_generate_vaccination_progress_data($immunisations_from_previous_encounters, 'well-child');
   $progress_data_by_well_child = hedley_reports_generate_vaccination_progress_data($immunisations_from_all_encounters, 'well-child');
-  $progress_data_by_child_scoreboard = hedley_reports_well_child_generate_vaccination_progress_data_by_child_scoreboard($person_id, $encounter_data['start_date_obj']);
+  $progress_data_by_child_scoreboard = hedley_reports_well_child_generate_vaccination_progress_data_by_child_scoreboard($scoreboard_immunisations, $encounter_data['start_date_obj']);
 
   return [
     hedley_reports_merge_vaccination_progress_data($immunisation_types, 'well-child', $history_data_by_well_child, $progress_data_by_child_scoreboard),
@@ -4971,27 +4976,28 @@ function hedley_reports_generate_vaccination_progress_data(array $immunisations_
 }
 
 /**
- * Generates vaccination progress data based on child scoreboard data.
+ * Loads child-scoreboard immunisation history for a person.
  *
- * Retrieves immunisation data for a child from the child scoreboard,
- * considering all encounters up to the current well-child encounter,
- * and returns structured vaccination progress data.
+ * Performs the database work that
+ * hedley_reports_well_child_generate_vaccination_progress_data_by_child_scoreboard()
+ * used to repeat for every well-child encounter: resolves the child-scoreboard
+ * participant, loads all its encounters and their immunisation measurements,
+ * and returns the raw doses and dates per encounter, tagged with the encounter
+ * start date. Callers filter this in memory by date cutoff.
  *
  * @param int $person_id
- *   The ID of the person (child) whose scoreboard data is being
- *   processed.
- * @param DateTime $well_child_encounter_start_date_obj
- *   The DateTime object representing the start date of the current
- *   well-child encounter.
+ *   The ID of the person (child) whose scoreboard data is being loaded.
  *
  * @return array
- *   A structured array of vaccination doses and dates, organized by
- *   immunisation type, based on child scoreboard encounters.
+ *   A list, in encounter order, of associative arrays:
+ *     - 'start_date_obj': DateTime, the encounter start date.
+ *     - 'immunisations_by_type': array keyed by immunisation type, each with
+ *       'doses' and 'dates' arrays recorded during that encounter.
  */
-function hedley_reports_well_child_generate_vaccination_progress_data_by_child_scoreboard($person_id, DateTime $well_child_encounter_start_date_obj) {
-  $return = [];
+function hedley_reports_well_child_load_child_scoreboard_immunisations($person_id) {
+  $encounters_immunisations = [];
   if (empty($person_id)) {
-    return $return;
+    return $encounters_immunisations;
   }
 
   $query = hedley_general_create_entity_field_query_excluding_deleted();
@@ -5007,8 +5013,8 @@ function hedley_reports_well_child_generate_vaccination_progress_data_by_child_s
     ->execute();
 
   if (empty($result['node'])) {
-    // No more items left.
-    return $return;
+    // No child-scoreboard participant for this person.
+    return $encounters_immunisations;
   }
 
   $participant_id = key($result['node']);
@@ -5023,8 +5029,96 @@ function hedley_reports_well_child_generate_vaccination_progress_data_by_child_s
     ->execute();
 
   if (empty($result['node'])) {
-    return $return;
+    return $encounters_immunisations;
   }
+
+  $immunisation_types = [
+    'child_scoreboard_bcg_iz',
+    'child_scoreboard_dtp_iz',
+    'child_scoreboard_dtp_sa_iz',
+    'child_scoreboard_ipv_iz',
+    'child_scoreboard_mr_iz',
+    'child_scoreboard_opv_iz',
+    'child_scoreboard_pcv13_iz',
+    'child_scoreboard_rotarix_iz',
+  ];
+
+  $encounters = node_load_multiple(array_keys($result['node']));
+  foreach ($encounters as $encounter) {
+    $start_date = explode(' ', $encounter->field_scheduled_date[LANGUAGE_NONE][0]['value'])[0];
+    $start_date_obj = new DateTime($start_date);
+
+    // Loading all immunisation activities recorded during the encounter.
+    $query = hedley_general_create_entity_field_query_excluding_deleted();
+    $result = $query
+      ->entityCondition('entity_type', 'node')
+      ->entityCondition('bundle', $immunisation_types, 'IN')
+      ->propertyCondition('status', NODE_PUBLISHED)
+      ->fieldCondition('field_child_scoreboard_encounter', 'target_id', $encounter->nid)
+      ->execute();
+
+    if (empty($result['node'])) {
+      continue;
+    }
+
+    $immunisations_by_type = [];
+    $immunisations = node_load_multiple(array_keys($result['node']));
+    foreach ($immunisations as $immunisation) {
+      $doses = $immunisation->field_administered_doses;
+      $dates = $immunisation->field_administration_dates;
+      if (empty($doses) || empty($dates)) {
+        continue;
+      }
+
+      $encounter_doses = $encounter_dates = [];
+      foreach ($doses[LANGUAGE_NONE] as $dose) {
+        $encounter_doses[] = $dose['value'];
+      }
+      foreach ($dates[LANGUAGE_NONE] as $date) {
+        $encounter_dates[] = explode(' ', $date['value'])[0];
+      }
+
+      if (empty($immunisations_by_type[$immunisation->type])) {
+        $immunisations_by_type[$immunisation->type] = [
+          'doses' => [],
+          'dates' => [],
+        ];
+      }
+      $immunisations_by_type[$immunisation->type]['doses'] = array_merge($immunisations_by_type[$immunisation->type]['doses'], $encounter_doses);
+      $immunisations_by_type[$immunisation->type]['dates'] = array_merge($immunisations_by_type[$immunisation->type]['dates'], $encounter_dates);
+    }
+
+    $encounters_immunisations[] = [
+      'start_date_obj' => $start_date_obj,
+      'immunisations_by_type' => $immunisations_by_type,
+    ];
+  }
+
+  return $encounters_immunisations;
+}
+
+/**
+ * Generates vaccination progress data based on child scoreboard data.
+ *
+ * Filters the preloaded child-scoreboard immunisation history to encounters
+ * that started on or before the current well-child encounter, then merges the
+ * doses and dates into structured vaccination progress data. Performs no
+ * database queries -- the history is loaded once by
+ * hedley_reports_well_child_load_child_scoreboard_immunisations().
+ *
+ * @param array $scoreboard_immunisations
+ *   The preloaded child-scoreboard immunisation history (see
+ *   hedley_reports_well_child_load_child_scoreboard_immunisations()).
+ * @param DateTime $well_child_encounter_start_date_obj
+ *   The DateTime object representing the start date of the current
+ *   well-child encounter.
+ *
+ * @return array
+ *   A structured array of vaccination doses and dates, organized by
+ *   immunisation type, based on child scoreboard encounters.
+ */
+function hedley_reports_well_child_generate_vaccination_progress_data_by_child_scoreboard(array $scoreboard_immunisations, DateTime $well_child_encounter_start_date_obj) {
+  $return = [];
 
   $immunisation_types = [
     'child_scoreboard_bcg_iz',
@@ -5044,46 +5138,15 @@ function hedley_reports_well_child_generate_vaccination_progress_data_by_child_s
       'dates' => [],
     ];
   }
-  $encounters = node_load_multiple(array_keys($result['node']));
-  foreach ($encounters as $encounter) {
-    $start_date = explode(' ', $encounter->field_scheduled_date[LANGUAGE_NONE][0]['value'])[0];
-    $start_date_obj = new DateTime($start_date);
-    if ($start_date_obj > $well_child_encounter_start_date_obj) {
+  foreach ($scoreboard_immunisations as $encounter_immunisations) {
+    if ($encounter_immunisations['start_date_obj'] > $well_child_encounter_start_date_obj) {
       // This encounter started after well child encounter, so, skip it.
       continue;
     }
 
-    // Loading all immunisation activities recorded during the encounter.
-    $query = hedley_general_create_entity_field_query_excluding_deleted();
-    $result = $query
-      ->entityCondition('entity_type', 'node')
-      ->entityCondition('bundle', $immunisation_types, 'IN')
-      ->propertyCondition('status', NODE_PUBLISHED)
-      ->fieldCondition('field_child_scoreboard_encounter', 'target_id', $encounter->nid)
-      ->execute();
-
-    if (empty($result['node'])) {
-      continue;
-    }
-
-    $immunisations = node_load_multiple(array_keys($result['node']));
-    foreach ($immunisations as $immunisation) {
-      $doses = $immunisation->field_administered_doses;
-      $dates = $immunisation->field_administration_dates;
-      if (empty($doses) || empty($dates)) {
-        continue;
-      }
-
-      $encounter_doses = $encounter_dates = [];
-      foreach ($doses[LANGUAGE_NONE] as $dose) {
-        $encounter_doses[] = $dose['value'];
-      }
-      foreach ($dates[LANGUAGE_NONE] as $date) {
-        $encounter_dates[] = explode(' ', $date['value'])[0];
-      }
-
-      $immunisations_by_type[$immunisation->type]['doses'] = array_merge($immunisations_by_type[$immunisation->type]['doses'], $encounter_doses);
-      $immunisations_by_type[$immunisation->type]['dates'] = array_merge($immunisations_by_type[$immunisation->type]['dates'], $encounter_dates);
+    foreach ($encounter_immunisations['immunisations_by_type'] as $type => $item) {
+      $immunisations_by_type[$type]['doses'] = array_merge($immunisations_by_type[$type]['doses'], $item['doses']);
+      $immunisations_by_type[$type]['dates'] = array_merge($immunisations_by_type[$type]['dates'], $item['dates']);
     }
   }
 


### PR DESCRIPTION
Fixes #1774

Eliminates a quadratic database-access pattern in vaccination-progress / completion-data generation — in **both** symmetric directions.

## Problem

When generating completion data, the cross-program vaccination history was re-loaded from the database **once per encounter**, even though the data is identical across encounters (only an in-memory date cutoff differs):

- **Well-child completion** re-queried the full **child-scoreboard** history for each well-child encounter → `W × (2 + C)` EntityFieldQueries per child.
- **Child-scoreboard completion** re-queried the full **well-child** history for each child-scoreboard encounter → `C × (2 + W)` per child.

This runs across the whole child population during report recalculation (triggered on sync).

## Fix

For each direction, extract the DB work into a loader called **once per child** before the encounter loop, returning the raw doses/dates per encounter tagged with its start date; the consumer then filters by the date cutoff **in memory**:

- `hedley_reports_well_child_load_child_scoreboard_immunisations()`
- `hedley_reports_child_scoreboard_load_well_child_immunisations()`

Collapses `W×(2+C)` → `(2+C)` and `C×(2+W)` → `(2+W)` per child — quadratic to linear, with identical output.

## Validation

- `php -l` and `ddev phpcs` (Drupal + DrupalPractice) clean.
- Behavior-equivalence reviewed: same encounters considered, same nid merge order, byte-identical `array_unique`/`sort`/trim/build aggregation block.
- **Verified on a ~5M-node production database**: regenerated completion data in both directions on the unfixed (`main`) and fixed branches and diffed the resulting `field_reports_data` → **IDENTICAL** across 370 encounters.

Covers Finding #1 **and its mirror** from the backend report/stats performance review (proposal #4).
