### PR TITLE
Batch FBF session-attendance lookup into one query per clinic

### DIFF
--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -475,3 +475,45 @@ function hedley_activity_count_person_measurements_taken_during_sessions($person
 
   return $query->countQuery()->execute()->fetchField();
 }
+
+/**
+ * Loads, per person, the sessions during which they have measurements.
+ *
+ * Batched companion to
+ * hedley_activity_count_person_measurements_taken_during_sessions(): instead of
+ * one COUNT query per person, this resolves attendance for many persons at once
+ * with a single query, so callers can determine it in memory.
+ *
+ * @param array $sessions_ids
+ *   The session node IDs to consider.
+ *
+ * @return array
+ *   A map keyed by person node ID; each value is a set of session node IDs (as
+ *   array keys) during which that person has at least one measurement.
+ */
+function hedley_activity_get_persons_sessions_with_measurements(array $sessions_ids) {
+  $persons_sessions = [];
+  if (empty($sessions_ids)) {
+    return $persons_sessions;
+  }
+
+  $query = hedley_general_create_db_select_query_excluding_deleted('node');
+  $query->condition('status', NODE_PUBLISHED);
+
+  $person_field = 'field_person';
+  hedley_general_join_field_to_query($query, 'node', $person_field);
+
+  $session_field = 'field_session';
+  hedley_general_join_field_to_query($query, 'node', $session_field);
+  $session_field_name = $session_field . '.' . $session_field . '_target_id';
+  $query->condition($session_field_name, $sessions_ids, 'IN');
+
+  $query->distinct();
+
+  $result = $query->execute();
+  foreach ($result as $row) {
+    $persons_sessions[$row->field_person][$row->field_session] = TRUE;
+  }
+
+  return $persons_sessions;
+}

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -2693,6 +2693,15 @@ function hedley_stats_get_session_attendance_stats_by_health_center($health_cent
       $periods_ranges[$period] = hedley_stats_get_period($period);
     }
 
+    // Load, in a single query, the sessions during which each person has
+    // measurements, so attendance can be determined in memory below instead of
+    // with a COUNT query per (participant, period).
+    $all_sessions_ids = [];
+    foreach ($sessions_by_period as $period_sessions_ids) {
+      $all_sessions_ids = array_merge($all_sessions_ids, $period_sessions_ids);
+    }
+    $persons_sessions = hedley_activity_get_persons_sessions_with_measurements(array_unique($all_sessions_ids));
+
     // Get PMTCT participants by clinic.
     $participants_ids = hedley_stats_get_pmtct_participants_by_clinic($clinic_id, 5000);
     $participants_info = [];
@@ -2785,8 +2794,14 @@ function hedley_stats_get_session_attendance_stats_by_health_center($health_cent
 
         $sessions_ids = $sessions_by_period[$period];
         if (!empty($sessions_ids)) {
-          $count = hedley_activity_count_person_measurements_taken_during_sessions($child_id, $sessions_ids);
-          if ($count == 0) {
+          $attended = FALSE;
+          foreach ($sessions_ids as $session_id) {
+            if (isset($persons_sessions[$child_id][$session_id])) {
+              $attended = TRUE;
+              break;
+            }
+          }
+          if (!$attended) {
             // The child missed the session during given period, because
             // no measurements was taken for them.
             $missed_session[] = $expected_person;


### PR DESCRIPTION
Fixes #1776

## Problem

`hedley_stats_get_session_attendance_stats_by_health_center` (`hedley_stats.module`) decided whether a child missed a session by running a **two-JOIN `COUNT`** query per **(PMTCT participant × period)** — `hedley_activity_count_person_measurements_taken_during_sessions()` once for every participant, for each of 3 periods.

For a clinic with **P** participants that's **P × 3** COUNT queries; a health center with hundreds of participants issues hundreds-to-thousands of queries per stats recalculation, which runs across the population on sync (Advanced Queue).

## Fix

Added `hedley_activity_get_persons_sessions_with_measurements($sessions_ids)` — a **single** query that returns, for the clinic, the `(person → set of session IDs they have measurements in)` map. The attendance loop now determines each participant's per-period attendance by **in-memory set membership**.

**P × 3 queries → 1 per clinic.**

## Behavior preservation

The batched query mirrors the COUNT helper's exact semantics — same `hedley_general_create_db_select_query_excluding_deleted('node')`, `status = published`, inner joins on `field_person` and `field_session`, and `field_session …_target_id IN (sessions)` — just without the per-person condition, selecting the (person, session) pairs instead of counting.

`isset($persons_sessions[$child_id][$session_id])` is set iff a matching published/non-deleted measurement exists, so the membership check is exactly equivalent to the old `count > 0`:
- A child with no measurement in any of a period's sessions → not attended → `missed_session` (same as `count == 0`).
- Extra persons in the map (mothers, non-participants) are never looked up.
- The period-window guards (`join_date`/`graduate_date`) and `completed_program` accounting are untouched — only the attendance COUNT moved.

The now-unused `hedley_activity_count_person_measurements_taken_during_sessions()` is left in place (no other callers) and can be removed in a follow-up.

## Testing

- `php -l` clean (both files).
- `ddev phpcs` → exit 0 (Drupal + DrupalPractice).
- Runtime equivalence relies on the **SimpleTest** suite (CI); reviewers may also want a before/after check of the attendance / missed-session counts on a representative dataset.

Finding #2 from the backend report/stats performance review (proposal #4).