### PR TITLE
Batch per-person aggregation encounter loading into one query

### DIFF
--- a/server/hedley/modules/custom/hedley_person/hedley_person.module
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.module
@@ -1414,6 +1414,40 @@ function hedley_person_load_individual_participant_encounters_ids($nid) {
 }
 
 /**
+ * Resolves the encounters IDs associated with several individual participants.
+ *
+ * Batched form of hedley_person_load_individual_participant_encounters_ids():
+ * resolves the encounters for many participants in a single query, to avoid a
+ * query per participant.
+ *
+ * @param array $nids
+ *   Individual participant node IDs.
+ *
+ * @return array
+ *   A map keyed by individual participant node ID; each value is an array of
+ *   the encounter node IDs for that participant, ordered by node ID.
+ */
+function hedley_person_load_individual_participants_encounters_ids(array $nids) {
+  $result = [];
+  if (empty($nids)) {
+    return $result;
+  }
+
+  $query = hedley_general_create_db_select_query_excluding_deleted();
+  $query->join('field_data_field_individual_participant', 'p', 'p.entity_id = n.nid');
+  $query->condition('p.field_individual_participant_target_id', $nids, 'IN');
+  $query->addField('n', 'nid');
+  $query->addField('p', 'field_individual_participant_target_id', 'participant_id');
+  $query->orderBy('n.nid');
+
+  foreach ($query->execute() as $row) {
+    $result[$row->participant_id][] = $row->nid;
+  }
+
+  return $result;
+}
+
+/**
  * Resolves family_participant nodes IDs where person is the adult.
  *
  * @param int $nid

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -939,8 +939,11 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
   ];
   $individual_participants_ids = hedley_person_individual_participants_for_person($person->nid, $encounter_types_to_load);
   $individual_participants = node_load_multiple($individual_participants_ids);
+  $encounters_ids_by_participant = hedley_person_load_individual_participants_encounters_ids(array_keys($individual_participants));
   foreach ($individual_participants as $individual_participant) {
-    $encounters_ids = hedley_person_load_individual_participant_encounters_ids($individual_participant->nid);
+    $encounters_ids = isset($encounters_ids_by_participant[$individual_participant->nid])
+      ? $encounters_ids_by_participant[$individual_participant->nid]
+      : [];
     if (empty($encounters_ids)) {
       continue;
     }


### PR DESCRIPTION
Fixes #1778

## Problem

`hedley_reports_calculate_aggregated_data_for_person()` (`hedley_reports.module:508`) loops a person's individual participants and calls `hedley_person_load_individual_participant_encounters_ids()` **per participant** — one DB query each (N+1). This worker re-runs for each person on every measurement/encounter save during sync (Advanced Queue), so it executes across the whole patient population during recalculation.

## Fix

Add `hedley_person_load_individual_participants_encounters_ids(array $nids)` — resolves all participants' encounter IDs in a single `IN (...)` query returning `[participant_nid => [encounter_nids]]` (ordered by nid) — and use it once before the loop.

## Behavior preservation

Same encounters, nid order preserved. Verified:
- `php -l`, `ddev phpcs` (Drupal + DrupalPractice) clean.
- **Production data**: regenerated `field_reports_data` for the 80 persons with the most individual participants on `develop` vs this branch → **IDENTICAL**.

Finding #3 from the backend report/stats performance review (proposal #4).