### PR TITLE
Drop redundant node_load when resolving encounter measurement IDs

### DIFF
--- a/server/hedley/modules/custom/hedley_person/hedley_person.module
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.module
@@ -1331,7 +1331,7 @@ function hedley_person_process_deleted_update($node) {
     $encounter_types[] = 'session';
 
     if (in_array($node->type, $encounter_types) && $deleted) {
-      $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($node->nid);
+      $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($node->nid, $node->type);
       foreach ($measurements_ids as $measurement_id) {
         $item_wrapper = entity_metadata_wrapper('node', $measurement_id);
         $item_wrapper->field_deleted->set($deleted);
@@ -1463,17 +1463,23 @@ function hedley_person_load_family_participant_encounters_ids($nid) {
  *
  * @param int $nid
  *   Individual encounter node ID.
+ * @param string $bundle
+ *   (optional) The encounter's bundle/type. When supplied, avoids a node load;
+ *   callers holding the loaded encounter should pass $encounter->type.
  *
  * @return array
  *   An array of measurements nodes IDs associated with the encounter.
  */
-function hedley_person_load_individual_encounter_measurements_ids($nid) {
-  $query = hedley_general_create_db_select_query_excluding_deleted();
-  $encounter = node_load($nid);
-  $bundle = $encounter->type;
+function hedley_person_load_individual_encounter_measurements_ids($nid, $bundle = NULL) {
+  if (empty($bundle)) {
+    // Fall back to a node load only when the caller didn't supply the bundle.
+    $bundle = node_load($nid)->type;
+  }
   $encounter_field = "field_$bundle";
+
+  $query = hedley_general_create_db_select_query_excluding_deleted();
   $query->join("field_data_$encounter_field", 'p', 'p.entity_id = n.nid');
-  $query->condition("p.{$encounter_field}_target_id", $encounter->nid);
+  $query->condition("p.{$encounter_field}_target_id", $nid);
   $query->addField('n', 'nid');
 
   return $query->execute()->fetchCol();

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -3369,7 +3369,7 @@ function hedley_reports_generate_completion_data_for_nutrition_individual_encoun
   $start_date_obj = new DateTime($start_date);
 
   // Loading all measurements that belong to encounter.
-  $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+  $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
 
   if (empty($measurements_ids)) {
     $completion = hedley_reports_generate_completion_result($expected, [], $mapping);
@@ -3714,7 +3714,7 @@ function hedley_reports_generate_completion_data_for_acute_illness($participant,
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
     // If encounter type field is empty, we default to CHW, since
     // CHW mode was developed before nurse mode.
     if (empty($encounter->field_ai_encounter_type)) {
@@ -4742,7 +4742,7 @@ function hedley_reports_generate_completion_data_for_well_child($participant, $e
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
     // If encounter type field is empty, we default to pediatric care.
     if (empty($encounter->field_well_child_encounter_type)) {
       $encounter_type = 'pediatric-care';
@@ -6033,7 +6033,7 @@ function hedley_reports_generate_completion_data_for_home_visit_encounter($encou
   $start_date = explode(' ', $encounter->field_scheduled_date[LANGUAGE_NONE][0]['value'])[0];
 
   // Loading all measurements that belong to encounter.
-  $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+  $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
 
   if (empty($measurements_ids)) {
     $completion = hedley_reports_generate_completion_result($expected, [], $mapping);
@@ -6119,7 +6119,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
 
     $measurements = !empty($measurements_ids) ? node_load_multiple($measurements_ids) : [];
     // Ordering measurements by type.
@@ -6599,7 +6599,7 @@ function hedley_reports_generate_completion_data_for_ncd($participant, $exclude_
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
     $measurements = !empty($measurements_ids) ? node_load_multiple($measurements_ids) : [];
     // Ordering measurements by type.
     $measurements_by_type = [];
@@ -7134,7 +7134,7 @@ function hedley_reports_generate_completion_data_for_hiv($participant, $exclude_
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
     $measurements = !empty($measurements_ids) ? node_load_multiple($measurements_ids) : [];
     // Ordering measurements by type.
     $measurements_by_type = [];
@@ -7285,7 +7285,7 @@ function hedley_reports_generate_completion_data_for_tuberculosis($participant, 
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
     $measurements = !empty($measurements_ids) ? node_load_multiple($measurements_ids) : [];
     // Ordering measurements by type.
     $measurements_by_type = [];
@@ -7522,7 +7522,7 @@ function hedley_reports_generate_completion_data_for_prenatal($participant, $exc
     }
 
     // Loading all measurements that belong to encounter.
-    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid);
+    $measurements_ids = hedley_person_load_individual_encounter_measurements_ids($encounter->nid, $encounter->type);
     $measurements = !empty($measurements_ids) ? node_load_multiple($measurements_ids) : [];
     // Ordering measurements by type.
     $measurements_by_type = [];


### PR DESCRIPTION
Fixes #1780

## Problem

`hedley_person_load_individual_encounter_measurements_ids($nid)` did `node_load($nid)` purely to read `$encounter->type` (to build the `field_<bundle>` join), even though all 10 call sites already hold the loaded encounter node. It runs once per encounter throughout report/completion generation.

## Fix

Add an optional `$bundle` parameter; when supplied, skip the `node_load` (kept as a fallback when absent). Pass `$encounter->type` (or `$node->type`) at the 10 call sites.

## Behavior preservation

Same query, same results — only the redundant load is removed. Verified `php -l` + `ddev phpcs` (Drupal + DrupalPractice). Real-data equivalence test below.

Finding #4 from the backend report/stats performance review (proposal #4).