### PR TITLE
Cache positive UUID->nid resolutions on the sync upload path

### DIFF
--- a/server/hedley/modules/custom/hedley_restful/hedley_restful.module
+++ b/server/hedley/modules/custom/hedley_restful/hedley_restful.module
@@ -393,9 +393,24 @@ function hedley_restful_resolve_nids_for_uuids(array $uuids) {
  *   The Node ID. False, if not found.
  */
 function hedley_restful_resolve_nid_for_uuid($uuid) {
-  $result = hedley_restful_resolve_nids_for_uuids([$uuid]);
+  // Request-level cache so a UUID that recurs across a sync batch (participant,
+  // encounter, session, health center, ...) is resolved with a single query.
+  $cache = &drupal_static(__FUNCTION__, []);
+  if (isset($cache[$uuid])) {
+    return $cache[$uuid];
+  }
 
-  return empty($result) ? FALSE : reset($result);
+  $result = hedley_restful_resolve_nids_for_uuids([$uuid]);
+  $nid = empty($result) ? FALSE : reset($result);
+
+  // Cache positive results only. A UUID can be looked up before it is created
+  // by a later item in the same batch; caching FALSE would make that later
+  // reference fail. The UUID -> nid mapping, once it exists, is stable.
+  if ($nid !== FALSE) {
+    $cache[$uuid] = $nid;
+  }
+
+  return $nid;
 }
 
 /**


### PR DESCRIPTION
Fixes #1782

## Problem

`handleChanges()` (`HedleyRestfulSync.class.php`) resolves every UUID-valued reference field of every change item via `hedley_restful_uuid_to_nid()` → `hedley_restful_resolve_nid_for_uuid()` → `hedley_restful_resolve_nids_for_uuids([$uuid])` — a single-row DB query with **no caching**. The batch's recurring UUIDs (participant, encounter, session, health center, person) are re-queried once per occurrence.

## Fix

Add a request-level `drupal_static` cache to `hedley_restful_resolve_nid_for_uuid()`, so each distinct UUID is resolved once.

**Positive results only — `FALSE` is never cached.** A UUID can be looked up before it is created by a later item in the same batch (e.g. a measurement referencing an encounter created earlier in the transaction); caching `FALSE` would make that later reference fail with "Could not find UUID". The UUID→nid mapping, once it exists, is stable, so caching it is safe.

## Behavior preservation

Verified `php -l` + `ddev phpcs` (Drupal + DrupalPractice). Real-data equivalence test below.

Finding #5 from the backend report/stats performance review (proposal #4).