### PR TITLE
Stop silently truncating clinic sessions / PMTCT participants in stats

### DIFF
--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -3698,8 +3698,20 @@ function hedley_stats_get_pmtct_participants_by_clinic($clinic_id, $range = 100)
     ->range(0, $range);
 
   $result = $query->execute();
+  $ids = !empty($result['node']) ? array_keys($result['node']) : [];
 
-  return !empty($result['node']) ? array_keys($result['node']) : [];
+  if (count($ids) >= $range) {
+    // Results reached the cap and may be truncated. Log it rather than
+    // silently dropping participants from the statistics.
+    watchdog(
+      'hedley_stats',
+      'Clinic @clinic PMTCT participants hit cap @range; may be truncated.',
+      ['@clinic' => $clinic_id, '@range' => $range],
+      WATCHDOG_WARNING
+    );
+  }
+
+  return $ids;
 }
 
 /**
@@ -3710,12 +3722,12 @@ function hedley_stats_get_pmtct_participants_by_clinic($clinic_id, $range = 100)
  * @param string $period
  *   The wanted period.
  * @param int $range
- *   The queries' range.
+ *   (optional) Max number of results. NULL (the default) returns all sessions.
  *
  * @return array
  *   Node IDs if they exist or empty array if no nodes exist.
  */
-function hedley_stats_get_clinic_sessions_by_period($clinic_id, $period = HEDLEY_STATS_PERIOD_ONE_YEAR, $range = 100) {
+function hedley_stats_get_clinic_sessions_by_period($clinic_id, $period = HEDLEY_STATS_PERIOD_ONE_YEAR, $range = NULL) {
   $dates = hedley_stats_get_period($period);
 
   $query = hedley_general_create_entity_field_query_excluding_deleted();
@@ -3727,12 +3739,28 @@ function hedley_stats_get_clinic_sessions_by_period($clinic_id, $period = HEDLEY
     // Meaning that we are still expecting those participants.
     ->fieldCondition('field_scheduled_date', 'value', $dates['start'], '>=')
     ->fieldCondition('field_scheduled_date', 'value', $dates['end'], '<=')
-    ->propertyOrderBy('nid')
-    ->range(0, $range);
+    ->propertyOrderBy('nid');
+
+  // Sessions per period are inherently bounded, so by default return them all
+  // rather than silently truncating at an arbitrary cap. A caller may still
+  // pass an explicit $range.
+  if ($range !== NULL) {
+    $query->range(0, $range);
+  }
 
   $result = $query->execute();
+  $ids = !empty($result['node']) ? array_keys($result['node']) : [];
 
-  return !empty($result['node']) ? array_keys($result['node']) : [];
+  if ($range !== NULL && count($ids) >= $range) {
+    watchdog(
+      'hedley_stats',
+      'Clinic @clinic sessions hit cap @range; may be truncated.',
+      ['@clinic' => $clinic_id, '@range' => $range],
+      WATCHDOG_WARNING
+    );
+  }
+
+  return $ids;
 }
 
 /**


### PR DESCRIPTION
Fixes #1784

## Problem (correctness)

`hedley_stats_get_clinic_sessions_by_period()` and `hedley_stats_get_pmtct_participants_by_clinic()` applied `->range(0, $range)` with a default `$range = 100` and **silently** dropped anything beyond it. The session-attendance caller uses the default for sessions, so a clinic with >100 sessions in a period gets stats computed on a truncated set, with no indication.

## Fix

- `get_clinic_sessions_by_period()`: default `$range` to `NULL` (uncapped). Sessions per period are inherently bounded → no memory risk, never silently truncated.
- Both functions: when a cap is in effect and reached, log a `watchdog()` warning (clinic + count) so any future truncation is visible. The PMTCT-participants memory guard (caller passes 5000) is kept.

## Real-data result

See the test comment. Short version: identical on the monthly periods that callers actually use; the un-cap **corrects a real silent truncation** in the (default) one-year path (a clinic with 135 sessions was being capped to 100); the participant guard is never reached (max 2293 < 5000).

`php -l` + `ddev phpcs` (Drupal + DrupalPractice) clean.

Finding #6 (correctness) from the backend report/stats performance review (proposal #4).