### PR TITLE
Use exclusive upper bound for stats period ranges (fix boundary double-count)

### DIFF
--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -3525,10 +3525,11 @@ function hedley_stats_get_base_query($health_center_id, $node_type, $period = FA
     $date_field_name = $date_field . '.' . $date_field . '_value';
 
     $date = hedley_stats_get_period($period, $extend);
-    $query->condition($date_field_name, [
-      $date['start'],
-      $date['end'],
-    ], 'BETWEEN');
+    // Lower bound inclusive, upper bound exclusive: a period's end equals the
+    // next period's start (both at midnight), so an inclusive BETWEEN would
+    // count a boundary record in both adjacent periods.
+    $query->condition($date_field_name, $date['start'], '>=');
+    $query->condition($date_field_name, $date['end'], '<');
   }
 
   return $query;
@@ -3752,8 +3753,10 @@ function hedley_stats_get_clinic_sessions_by_period($clinic_id, $period = HEDLEY
     ->propertyCondition('status', NODE_PUBLISHED)
     ->fieldCondition('field_clinic', 'target_id', $clinic_id)
     // Meaning that we are still expecting those participants.
+    // Upper bound is exclusive: a period's end equals the next period's start
+    // (both at midnight), so '<=' would count a boundary session in both.
     ->fieldCondition('field_scheduled_date', 'value', $dates['start'], '>=')
-    ->fieldCondition('field_scheduled_date', 'value', $dates['end'], '<=')
+    ->fieldCondition('field_scheduled_date', 'value', $dates['end'], '<')
     ->propertyOrderBy('nid');
 
   // Sessions per period are inherently bounded, so by default return them all


### PR DESCRIPTION
Fixes #1786

## Problem (correctness)

`hedley_stats_get_range_for_period()` sets each period's `end` to the next period's `start` (both at midnight). Two consumers used an **inclusive** upper bound:
- `hedley_stats_get_base_query()` — `BETWEEN [start, end]`
- `hedley_stats_get_clinic_sessions_by_period()` — `field_scheduled_date <= end`

So a record timestamped exactly at a boundary midnight is counted in **both** adjacent periods (and mis-attributed to the earlier one). Date-only fields (e.g. session `field_scheduled_date`, time `00:00:00`) make this common.

## Fix

Make the upper bound **exclusive** (`>= start AND < end`). A boundary record then belongs only to the period that *starts* there (the correct attribution), and adjacent periods are disjoint.

## Real-data result

See the test comment — at a single month boundary, the old inclusive bound double-counted **27 sessions** and **337 measurements**; the fix brings the overlap to **0** while preserving the union (no records lost, just counted once).

`php -l` + `ddev phpcs` (Drupal + DrupalPractice) clean.

Finding #7 (correctness) from the backend report/stats performance review (proposal #4).