### PR TITLE
Address Copilot review comments from the review-and-fix sweep

### DIFF
--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -1244,8 +1244,8 @@ update currentTime activePage dbVersion device msg model =
                                     , HttpBuilder.post (device.backendUrl ++ "/api/sync")
                                         |> withQueryParams [ ( "access_token", device.accessToken ) ]
                                         |> withJsonBody (Json.Encode.object <| SyncManager.Encoder.encodeIndexDbQueryUploadAuthorityResultRecord dbVersion result)
-                                        -- We don't need to decode anything, as we just want to have
-                                        -- the browser download it.
+                                        -- We don't need to decode the response body; the upload only
+                                        -- needs to know whether it succeeded.
                                         |> HttpBuilder.withTimeout uploadRequestTimeout
                                         |> HttpBuilder.send (RemoteData.fromResult >> BackendUploadAuthorityHandle result)
                                     )
@@ -1437,8 +1437,8 @@ update currentTime activePage dbVersion device msg model =
                                     , HttpBuilder.post (device.backendUrl ++ "/api/sync")
                                         |> withQueryParams [ ( "access_token", device.accessToken ) ]
                                         |> withJsonBody (Json.Encode.object <| SyncManager.Encoder.encodeIndexDbQueryUploadGeneralResultRecord dbVersion result)
-                                        -- We don't need to decode anything, as we just want to have
-                                        -- the browser download it.
+                                        -- We don't need to decode the response body; the upload only
+                                        -- needs to know whether it succeeded.
                                         |> HttpBuilder.withTimeout uploadRequestTimeout
                                         |> HttpBuilder.send (RemoteData.fromResult >> BackendUploadGeneralHandle result)
                                     )

--- a/server/hedley/modules/custom/hedley_person/hedley_person.module
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.module
@@ -1414,7 +1414,7 @@ function hedley_person_load_individual_participant_encounters_ids($nid) {
 }
 
 /**
- * Resolves the encounters IDs associated with several individual participants.
+ * Resolves the encounter IDs associated with several individual participants.
  *
  * Batched form of hedley_person_load_individual_participant_encounters_ids():
  * resolves the encounters for many participants in a single query, to avoid a
@@ -1510,6 +1510,13 @@ function hedley_person_load_individual_encounter_measurements_ids($nid, $bundle 
     $bundle = node_load($nid)->type;
   }
   $encounter_field = "field_$bundle";
+
+  // The bundle is interpolated into the table and column names below, which the
+  // query builder does not escape. Make sure it resolves to a real field before
+  // it reaches the query so an unexpected bundle can't produce invalid SQL.
+  if (!field_info_field($encounter_field)) {
+    return [];
+  }
 
   $query = hedley_general_create_db_select_query_excluding_deleted();
   $query->join("field_data_$encounter_field", 'p', 'p.entity_id = n.nid');

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -6203,7 +6203,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
   // Load the well-child immunisation history once. It is filtered per
   // child-scoreboard encounter (by date) in memory below, instead of being
   // re-queried from the database for every encounter.
-  $wellchild_immunisations = hedley_reports_child_scoreboard_load_well_child_immunisations($person_id);
+  $well_child_immunisations = hedley_reports_child_scoreboard_load_well_child_immunisations($person_id);
 
   foreach ($encounters_data as $index => $encounter_data) {
     $encounter = $encounter_data['encounter'];
@@ -6243,7 +6243,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
       $encounter_data['age_in_months'] = hedley_reports_resolve_age_in_months_for_individual_encounter($encounter, $start_date_obj);
       $encounter_data['previous_encounters_data'] = array_slice($encounters_data, 0, $index);
 
-      [$encounter_data['vaccination_history'], $encounter_data['vaccination_progress']] = hedley_reports_child_scoreboard_generate_vaccination_progress_data($wellchild_immunisations, $encounter_data);
+      [$encounter_data['vaccination_history'], $encounter_data['vaccination_progress']] = hedley_reports_child_scoreboard_generate_vaccination_progress_data($well_child_immunisations, $encounter_data);
 
       $expected_immunisation_activities = hedley_reports_child_scoreboard_get_expected_immunisation_activities($encounter_data, $birth_date_obj, $gender, 'history');
       $expected = array_merge($expected, $expected_immunisation_activities);
@@ -6267,7 +6267,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
  * child scoreboard encounters. It merges this data with well-child
  * data to produce comprehensive vaccination progress information.
  *
- * @param array $wellchild_immunisations
+ * @param array $well_child_immunisations
  *   The well-child immunisation history, preloaded once by
  *   hedley_reports_child_scoreboard_load_well_child_immunisations().
  * @param array $encounter_data
@@ -6278,7 +6278,7 @@ function hedley_reports_generate_completion_data_for_child_scoreboard_encounter(
  *   An array containing merged vaccination progress data, with history
  *   and progress for the child.
  */
-function hedley_reports_child_scoreboard_generate_vaccination_progress_data(array $wellchild_immunisations, array $encounter_data) {
+function hedley_reports_child_scoreboard_generate_vaccination_progress_data(array $well_child_immunisations, array $encounter_data) {
   $previous_encounters_data = $encounter_data['previous_encounters_data'];
 
   $immunisation_types = [
@@ -6317,7 +6317,7 @@ function hedley_reports_child_scoreboard_generate_vaccination_progress_data(arra
 
   $history_data_by_well_child = hedley_reports_generate_vaccination_progress_data($immunisations_from_previous_encounters, 'child-scoreboard');
   $progress_data_by_well_child = hedley_reports_generate_vaccination_progress_data($immunisations_from_all_encounters, 'child-scoreboard');
-  $progress_data_by_child_scoreboard = hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child($wellchild_immunisations, $encounter_data['start_date_obj']);
+  $progress_data_by_child_scoreboard = hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child($well_child_immunisations, $encounter_data['start_date_obj']);
 
   return [
     hedley_reports_merge_vaccination_progress_data($immunisation_types, 'child-scoreboard', $history_data_by_well_child, $progress_data_by_child_scoreboard),
@@ -6577,7 +6577,7 @@ function hedley_reports_child_scoreboard_load_well_child_immunisations($person_i
  * database queries -- the history is loaded once by
  * hedley_reports_child_scoreboard_load_well_child_immunisations().
  *
- * @param array $wellchild_immunisations
+ * @param array $well_child_immunisations
  *   The preloaded well-child immunisation history (see
  *   hedley_reports_child_scoreboard_load_well_child_immunisations()).
  * @param DateTime $child_scoreboard_encounter_start_date_obj
@@ -6588,7 +6588,7 @@ function hedley_reports_child_scoreboard_load_well_child_immunisations($person_i
  *   A structured array of vaccination doses and dates, organized by
  *   immunisation type, based on child scoreboard encounters.
  */
-function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child(array $wellchild_immunisations, DateTime $child_scoreboard_encounter_start_date_obj) {
+function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_well_child(array $well_child_immunisations, DateTime $child_scoreboard_encounter_start_date_obj) {
   $return = [];
 
   $immunisation_types = [
@@ -6609,7 +6609,7 @@ function hedley_reports_child_scoreboard_generate_vaccination_progress_data_by_w
       'dates' => [],
     ];
   }
-  foreach ($wellchild_immunisations as $encounter_immunisations) {
+  foreach ($well_child_immunisations as $encounter_immunisations) {
     if ($encounter_immunisations['start_date_obj'] > $child_scoreboard_encounter_start_date_obj) {
       // This encounter started after child scoreboard encounter, so, skip it.
       continue;

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -3721,8 +3721,8 @@ function hedley_stats_get_pmtct_participants_by_clinic($clinic_id, $range = 100)
     // silently dropping participants from the statistics.
     watchdog(
       'hedley_stats',
-      'Clinic @clinic PMTCT participants hit cap @range; may be truncated.',
-      ['@clinic' => $clinic_id, '@range' => $range],
+      'Clinic @clinic PMTCT participants: @count/@range; may be truncated.',
+      ['@clinic' => $clinic_id, '@range' => $range, '@count' => count($ids)],
       WATCHDOG_WARNING
     );
   }
@@ -3737,7 +3737,7 @@ function hedley_stats_get_pmtct_participants_by_clinic($clinic_id, $range = 100)
  *   The clinic node ID.
  * @param string $period
  *   The wanted period.
- * @param int $range
+ * @param int|null $range
  *   (optional) Max number of results. NULL (the default) returns all sessions.
  *
  * @return array
@@ -3772,8 +3772,8 @@ function hedley_stats_get_clinic_sessions_by_period($clinic_id, $period = HEDLEY
   if ($range !== NULL && count($ids) >= $range) {
     watchdog(
       'hedley_stats',
-      'Clinic @clinic sessions hit cap @range; may be truncated.',
-      ['@clinic' => $clinic_id, '@range' => $range],
+      'Clinic @clinic sessions: @count/@range; may be truncated.',
+      ['@clinic' => $clinic_id, '@range' => $range, '@count' => count($ids)],
       WATCHDOG_WARNING
     );
   }


### PR DESCRIPTION
## Summary

Follow-up branch that resolves every actionable **GitHub Copilot** review comment left on the (now-merged) PRs from the recent review-and-fix sweep. One PR each was reviewed by Copilot; this consolidates the fixes.

| Source PR | Comments | Fix |
|-----------|----------|-----|
| #1770 | 2 | Reworded the two upload-`POST` comments that copy-pasted *"have the browser download it"* from the photo-download path. The genuine `GET` download comment (line ~1769) is intentionally left intact. |
| #1775 | 1 | Renamed `$wellchild_immunisations` → `$well_child_immunisations` to match the module's `well_child_*` convention. |
| #1779 | 1 | Docblock grammar: *"encounters IDs"* → *"encounter IDs"*. |
| #1781 | 1 | Guarded `hedley_person_load_individual_encounter_measurements_ids()` with `field_info_field()` so a caller-supplied `$bundle` (interpolated into table/column names) can't reach the query builder unless it maps to a real field. |
| #1785 | 3 | Documented `$range` as `int\|null`; both truncation watchdog warnings now log the returned `@count` alongside the cap. |

## Notes

- The #1768 grammar nit (`let's` / `created in`) was intentionally **excluded**.
- **#1781 is the only behavior-adjacent change** and is non-regressive by construction (it only converts a previously-fatal unknown-bundle input into a graceful empty result). Verified on live data: all 10 real encounter/session bundles (`acute_illness_encounter` … `well_child_encounter`, `session`) resolve to an existing field, so valid data never hits the new guard path.

## Verification

- Elm: `elm-format --validate` clean.
- PHP: `php -l` clean; `phpcs` (Drupal + DrupalPractice) clean, including line-length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)