### PR TITLE
Fix prenatal EDD sometimes not persisted from the client

### DIFF
--- a/client/e2e/helpers/common.ts
+++ b/client/e2e/helpers/common.ts
@@ -243,6 +243,60 @@ export function backdateEncounter(personName: string, encounterType: string, day
   console.error(`backdateEncounter(${encounterType}): failed after 5 attempts`);
 }
 
+/**
+ * Returns the EDD (`field_expected_date_concluded`, as a 'YYYY-MM-DD' string)
+ * set on a person's antenatal pregnancy (individual_participant), or null if it
+ * is not populated. Retries up to 10 times (5s apart) so it can be used for
+ * post-sync verification.
+ */
+export function queryPregnancyEdd(personName: string): string | null {
+  const { drushCmd, cwd } = drushEnv();
+  const personNameB64 = Buffer.from(personName, 'utf8').toString('base64');
+
+  const php = `
+    \\$name = base64_decode('${personNameB64}');
+    \\$q = new EntityFieldQuery();
+    \\$r = \\$q->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'person')
+      ->propertyCondition('title', \\$name)
+      ->execute();
+    if (empty(\\$r['node'])) { echo json_encode(['error' => 'Person not found']); return; }
+    \\$nid = key(\\$r['node']);
+
+    \\$pq = new EntityFieldQuery();
+    \\$pr = \\$pq->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'individual_participant')
+      ->fieldCondition('field_person', 'target_id', \\$nid)
+      ->fieldCondition('field_encounter_type', 'value', 'antenatal')
+      ->range(0, 1)
+      ->execute();
+    if (empty(\\$pr['node'])) { echo json_encode(['error' => 'No pregnancy found']); return; }
+
+    \\$p = node_load(key(\\$pr['node']));
+    \\$edd = isset(\\$p->field_expected_date_concluded[LANGUAGE_NONE][0]['value'])
+      ? \\$p->field_expected_date_concluded[LANGUAGE_NONE][0]['value'] : null;
+    echo json_encode(['edd' => \\$edd]);
+  `;
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      const output = execSync(`${drushCmd} eval "${php}"`, {
+        cwd, timeout: 30000, encoding: 'utf-8', stdio: 'pipe',
+      }).trim();
+      const parsed = JSON.parse(output);
+      if (!parsed.error && parsed.edd) {
+        // Stored as 'YYYY-MM-DD HH:MM:SS' or 'YYYY-MM-DD'; return the date part.
+        return String(parsed.edd).slice(0, 10);
+      }
+      console.log(`queryPregnancyEdd attempt ${attempt + 1}: ${parsed.error || 'EDD not set yet'}`);
+    } catch (err) {
+      console.log(`queryPregnancyEdd attempt ${attempt + 1}: error`, err);
+    }
+    if (attempt < 9) execSync('sleep 5');
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Save helpers
 // ---------------------------------------------------------------------------

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -3,7 +3,7 @@ import { setupDevice } from './helpers/auth';
 import { verifyCaseManagementEntry } from './helpers/case-management';
 import { installCursorScript } from './helpers/cursor';
 import { resetDevice } from './helpers/device';
-import { syncAndWait } from './helpers/common';
+import { syncAndWait, queryPregnancyEdd } from './helpers/common';
 import {
   createAdultFemaleAndStartEncounter,
   startPrenatalEncounter,
@@ -100,6 +100,21 @@ test.describe('Nurse: Prenatal Initial Encounter', () => {
 
     // PregnancyDating
     expect(nodes['last_menstrual_period'], 'last_menstrual_period should exist').toBe(true);
+
+    // EDD must be populated on the pregnancy after recording LMP + sync, and
+    // must equal LMP + 280 days. Guards the bug where the EDD update to the
+    // pregnancy was silently dropped while the LMP measurement still saved.
+    const edd = queryPregnancyEdd(fullName);
+    expect(edd, 'pregnancy EDD (field_expected_date_concluded) should be set').not.toBeNull();
+    // EDD = LMP + 280 days. setDate() enters the calendar date using UTC
+    // components, so compute the expected EDD in UTC to match (avoids an
+    // off-by-one when the runner's local date differs from its UTC date).
+    const expectedEdd = new Date(
+      Date.UTC(lmpDate.getUTCFullYear(), lmpDate.getUTCMonth(), lmpDate.getUTCDate() + 280),
+    );
+    const fmtDate = (d: Date) =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+    expect(edd, 'EDD should equal LMP + 280 days').toBe(fmtDate(expectedEdd));
 
     // History
     expect(nodes['obstetric_history'], 'obstetric_history should exist').toBe(true);

--- a/client/src/elm/Backend/IndividualEncounterParticipant/Update.elm
+++ b/client/src/elm/Backend/IndividualEncounterParticipant/Update.elm
@@ -6,8 +6,7 @@ import Backend.Endpoints exposing (individualEncounterParticipantEndpoint)
 import Backend.Entities exposing (IndividualEncounterParticipantId)
 import Backend.IndividualEncounterParticipant.Model exposing (IndividualEncounterParticipant, IndividualEncounterParticipantOutcome(..), Model, Msg(..))
 import Backend.Utils exposing (sw)
-import Gizra.NominalDate exposing (NominalDate, encodeYYYYMMDD)
-import Json.Encode exposing (object)
+import Gizra.NominalDate exposing (NominalDate)
 import Maybe.Extra exposing (unwrap)
 import RemoteData exposing (RemoteData(..))
 import Restful.Endpoint exposing (toCmd, withoutDecoder)
@@ -70,19 +69,11 @@ update currentDate participantId maybeParticipant msg model =
                 model
 
         SetEddDate eddDate ->
-            -- Patch the EDD field on its own, independent of whether the
-            -- participant is currently loaded in the local cache. Routing this
-            -- through updateIndividualEncounterParticipant silently dropped the
-            -- EDD whenever the participant was not loaded yet (e.g. right after a
-            -- pregnancy is created, before its fetch resolves) - which is why
-            -- some pregnancies ended up with no EDD and needed the daily backfill.
-            ( { model | updateIndividualEncounterParticipant = Loading }
-            , object [ ( "expected_date_concluded", encodeYYYYMMDD eddDate ) ]
-                |> sw.patchAny individualEncounterParticipantEndpoint participantId
-                |> withoutDecoder
-                |> toCmd (RemoteData.fromResult >> HandleUpdatedIndividualEncounterParticipant)
-            , []
-            )
+            updateIndividualEncounterParticipant
+                participantId
+                maybeParticipant
+                (\participant -> { participant | eddDate = Just eddDate })
+                model
 
         SetNewborn personId ->
             updateIndividualEncounterParticipant

--- a/client/src/elm/Backend/IndividualEncounterParticipant/Update.elm
+++ b/client/src/elm/Backend/IndividualEncounterParticipant/Update.elm
@@ -6,7 +6,8 @@ import Backend.Endpoints exposing (individualEncounterParticipantEndpoint)
 import Backend.Entities exposing (IndividualEncounterParticipantId)
 import Backend.IndividualEncounterParticipant.Model exposing (IndividualEncounterParticipant, IndividualEncounterParticipantOutcome(..), Model, Msg(..))
 import Backend.Utils exposing (sw)
-import Gizra.NominalDate exposing (NominalDate)
+import Gizra.NominalDate exposing (NominalDate, encodeYYYYMMDD)
+import Json.Encode exposing (object)
 import Maybe.Extra exposing (unwrap)
 import RemoteData exposing (RemoteData(..))
 import Restful.Endpoint exposing (toCmd, withoutDecoder)
@@ -69,11 +70,19 @@ update currentDate participantId maybeParticipant msg model =
                 model
 
         SetEddDate eddDate ->
-            updateIndividualEncounterParticipant
-                participantId
-                maybeParticipant
-                (\participant -> { participant | eddDate = Just eddDate })
-                model
+            -- Patch the EDD field on its own, independent of whether the
+            -- participant is currently loaded in the local cache. Routing this
+            -- through updateIndividualEncounterParticipant silently dropped the
+            -- EDD whenever the participant was not loaded yet (e.g. right after a
+            -- pregnancy is created, before its fetch resolves) - which is why
+            -- some pregnancies ended up with no EDD and needed the daily backfill.
+            ( { model | updateIndividualEncounterParticipant = Loading }
+            , object [ ( "expected_date_concluded", encodeYYYYMMDD eddDate ) ]
+                |> sw.patchAny individualEncounterParticipantEndpoint participantId
+                |> withoutDecoder
+                |> toCmd (RemoteData.fromResult >> HandleUpdatedIndividualEncounterParticipant)
+            , []
+            )
 
         SetNewborn personId ->
             updateIndividualEncounterParticipant

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4690,6 +4690,19 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
                 rollbarOnFailure =
                     triggerRollbarOnFailure data
 
+                -- Cache the freshly created participant so that updates dispatched
+                -- right after creation (e.g. SetEddDate from pregnancy dating) find
+                -- it loaded, instead of being silently dropped while its fetch is
+                -- still in flight. This is why some pregnancies ended up with no
+                -- EDD and needed the daily populate-edd.php backfill.
+                individualParticipantsUpdated =
+                    RemoteData.map
+                        (\( participantId, participant ) ->
+                            Dict.insert participantId (Success participant) model.individualParticipants
+                        )
+                        data
+                        |> RemoteData.withDefault model.individualParticipants
+
                 -- We automatically create new encounter for newly created  session.
                 appMsgs =
                     RemoteData.map
@@ -4772,7 +4785,10 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
                         data
                         |> RemoteData.withDefault []
             in
-            ( { model | postIndividualEncounterParticipant = Dict.insert personId data model.postIndividualEncounterParticipant }
+            ( { model
+                | postIndividualEncounterParticipant = Dict.insert personId data model.postIndividualEncounterParticipant
+                , individualParticipants = individualParticipantsUpdated
+              }
             , Cmd.none
             , rollbarOnFailure ++ appMsgs
             )


### PR DESCRIPTION
## Summary

Fixes #1790.

**Deployment instructions**: Once deployed, comment out `profiles/hedley/modules/custom/hedley_prenatal/scripts/populate-edd.php` execution from Jenkins (overnight tasks). Give it a few weeks, and then make sure there are not encounters that got empty EDD.

A prenatal pregnancy's EDD (`field_expected_date_concluded` on the `individual_participant`) was sometimes not populated from the client, requiring the nightly `populate-edd.php` backfill.

## Root cause

EDD is set by a separate `SetEddDate` message (dispatched alongside the LMP save) that patches the pregnancy entity. It **silently no-ops when the participant isn't loaded** as `Success` in `individualParticipants`. For a freshly created pregnancy — exactly when dating/EDD is entered — the create handler only writes to `postIndividualEncounterParticipant`; `individualParticipants` is populated by a later async `FetchIndividualEncounterParticipant`. Saving dating before that fetch resolves drops the EDD update (no error, no retry) while the LMP measurement, which has no such dependency, still saves.

## Fix

In `HandlePostedIndividualEncounterParticipant` (`Backend/Update.elm`), cache the just-created participant into `individualParticipants` as `Success`, so the existing `patchFull`-based `SetEddDate` finds it loaded. The sync write path is unchanged.

> Note: an earlier attempt patched EDD via `sw.patchAny` directly. That added a *partial-body* participant PATCH to the upload batch, which the backend's all-or-nothing `db_transaction()` rolled back — breaking all prenatal sync in E2E. Reverted in favor of the cache approach above, which keeps the proven `patchFull` path.

## Test

Adds a `queryPregnancyEdd` helper and an assertion in the nurse prenatal E2E spec that after recording LMP + sync, the pregnancy's EDD equals **LMP + 280 days** on the backend — a regression guard that would have caught this bug.

## Verification

- All 9 CI checks green.
- E2E confirms EDD is populated correctly post-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)