### PR TITLE
Extend prenatal diagnosis tests: CHW, anemia, malaria+anemia, pre-eclampsia

### DIFF
--- a/client/src/elm/Pages/Prenatal/Activity/Test.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Test.elm
@@ -5,16 +5,23 @@ import Backend.IndividualEncounterParticipant.Model exposing (IndividualEncounte
 import Backend.Measurement.Model
     exposing
         ( BloodSmearResult(..)
+        , DangerSign(..)
+        , DangerSignsValue
         , Gender(..)
         , HIVTestValue
+        , HemoglobinTestValue
         , HepatitisBTestValue
         , MalariaTestValue
         , Measurement
+        , PrenatalAssesment(..)
         , PrenatalMeasurements
+        , ProteinValue(..)
         , SyphilisTestValue
         , TestExecutionNote(..)
         , TestPrerequisite(..)
         , TestResult(..)
+        , UrineDipstickTestValue
+        , VitalsValue
         , emptyPrenatalMeasurements
         )
 import Backend.Person.Model exposing (Person)
@@ -25,7 +32,7 @@ import EverySet exposing (EverySet)
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
 import Pages.Prenatal.Activity.Types exposing (PrePregnancyClassification(..))
-import Pages.Prenatal.Activity.Utils exposing (bmiToPrePregnancyClassification, generatePrenatalDiagnosesForNurse, zscoreToPrePregnancyClassification)
+import Pages.Prenatal.Activity.Utils exposing (bmiToPrePregnancyClassification, generatePrenatalAssesmentForChw, generatePrenatalDiagnosesForNurse, zscoreToPrePregnancyClassification)
 import Pages.Prenatal.Model exposing (AssembledData)
 import Restful.Endpoint exposing (EntityUuid, toEntityUuid)
 import Test exposing (Test, describe, test)
@@ -229,6 +236,44 @@ testAssembled measurements =
     }
 
 
+{-| LMP ~28 weeks before `currentDate`, putting EGA safely mid-window for the
+moderate-preeclampsia [20,37) gate (away from either boundary).
+-}
+lmpDate28Weeks : NominalDate
+lmpDate28Weeks =
+    Date.add Date.Weeks -28 currentDate
+
+
+{-| The `testAssembled` fixture with a CHW antenatal encounter type
+(`ChwFirstEncounter`, a regular -- not postpartum -- CHW encounter). The CHW
+assessment reads danger signs from the `.signs` set, which the non-postpartum
+branch of `noDangerSigns` consults.
+-}
+chwAssembled : PrenatalMeasurements -> AssembledData
+chwAssembled measurements =
+    let
+        base =
+            testAssembled measurements
+
+        encounter =
+            base.encounter
+    in
+    { base | encounter = { encounter | encounterType = ChwFirstEncounter } }
+
+
+{-| The `testAssembled` fixture with EGA ~28 weeks, used by the
+moderate-preeclampsia group so the result is insensitive to the exact gate
+boundary.
+-}
+testAssembled28Weeks : PrenatalMeasurements -> AssembledData
+testAssembled28Weeks measurements =
+    let
+        base =
+            testAssembled measurements
+    in
+    { base | globalLmpDate = Just lmpDate28Weeks }
+
+
 
 -- LAB VALUE BUILDERS / SETTERS
 --
@@ -312,6 +357,87 @@ withMalariaTest result measurements =
     { measurements | malariaTest = wrapMeasurement (malariaTestValueWith result) }
 
 
+{-| Hemoglobin test, run today with the given count, immediate result. The
+anemia/malaria-with-anemia diagnoses gate on `immediateResult .hemoglobinTest`,
+so the `PrerequisiteImmediateResult` prerequisite is required just like the
+disease labs.
+-}
+hemoglobinTestValueWith : Float -> HemoglobinTestValue
+hemoglobinTestValueWith count =
+    { executionNote = TestNoteRunToday
+    , executionDate = Just dummyDate
+    , testPrerequisites = immediateResultPrerequisites
+    , hemoglobinCount = Just count
+    }
+
+
+withHemoglobin : Float -> PrenatalMeasurements -> PrenatalMeasurements
+withHemoglobin count measurements =
+    { measurements | hemoglobinTest = wrapMeasurement (hemoglobinTestValueWith count) }
+
+
+{-| Vitals with the given systolic/diastolic blood pressure. Respiratory rate
+is left unset so the anemia-complication and severe-preeclampsia paths that key
+off an elevated respiratory rate stay inert.
+-}
+vitalsValueWith : Float -> Float -> VitalsValue
+vitalsValueWith sys dia =
+    { sys = Just sys
+    , dia = Just dia
+    , heartRate = Nothing
+    , respiratoryRate = Nothing
+    , bodyTemperature = Nothing
+    , sysRepeated = Nothing
+    , diaRepeated = Nothing
+    }
+
+
+withVitals : Float -> Float -> PrenatalMeasurements -> PrenatalMeasurements
+withVitals sys dia measurements =
+    { measurements | vitals = wrapMeasurement (vitalsValueWith sys dia) }
+
+
+{-| Urine dipstick with the given protein level, immediate result.
+`highUrineProteinInitialPhase` also gates on `PrerequisiteImmediateResult`.
+-}
+urineDipstickValueWith : ProteinValue -> UrineDipstickTestValue
+urineDipstickValueWith protein =
+    { testVariant = Nothing
+    , executionNote = TestNoteRunToday
+    , executionDate = Just dummyDate
+    , testPrerequisites = immediateResultPrerequisites
+    , protein = Just protein
+    , ph = Nothing
+    , glucose = Nothing
+    , leukocytes = Nothing
+    , nitrite = Nothing
+    , urobilinogen = Nothing
+    , haemoglobin = Nothing
+    , ketone = Nothing
+    , bilirubin = Nothing
+    }
+
+
+withUrineProtein : ProteinValue -> PrenatalMeasurements -> PrenatalMeasurements
+withUrineProtein protein measurements =
+    { measurements | urineDipstickTest = wrapMeasurement (urineDipstickValueWith protein) }
+
+
+{-| Danger-signs measurement carrying the given antenatal danger signs.
+-}
+dangerSignsValueWith : EverySet DangerSign -> DangerSignsValue
+dangerSignsValueWith signs =
+    { signs = signs
+    , postpartumMother = EverySet.empty
+    , postpartumChild = EverySet.empty
+    }
+
+
+withDangerSigns : EverySet DangerSign -> PrenatalMeasurements -> PrenatalMeasurements
+withDangerSigns signs measurements =
+    { measurements | dangerSigns = wrapMeasurement (dangerSignsValueWith signs) }
+
+
 {-| Run the function under test on an initial-phase nurse encounter with the
 given measurements. Hemoglobin is left unset throughout, so malaria stays at
 the plain (non-anemia) variant.
@@ -380,10 +506,154 @@ generatePrenatalDiagnosesForNurseLabsTest =
         ]
 
 
+
+-- GROUP 1 -- CHW ASSESSMENT
+--
+-- `generatePrenatalAssesmentForChw` collapses to: any danger sign present ->
+-- HighRisk, otherwise Normal. Oracle: ANC CHW tab ("any danger sign present ->
+-- refer"). Uses a regular CHW antenatal encounter (`ChwFirstEncounter`), whose
+-- danger signs come from the `.signs` set of the danger-signs measurement.
+
+
+generatePrenatalAssesmentForChwTest : Test
+generatePrenatalAssesmentForChwTest =
+    describe "generatePrenatalAssesmentForChw - CHW danger-sign assessment (ANC CHW tab)"
+        [ test "no danger-signs measurement -> AssesmentNormalPregnancy" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> chwAssembled
+                    |> generatePrenatalAssesmentForChw
+                    |> Expect.equal AssesmentNormalPregnancy
+        , test "danger sign present (VaginalBleeding) -> AssesmentHighRiskPregnancy" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withDangerSigns (EverySet.singleton VaginalBleeding)
+                    |> chwAssembled
+                    |> generatePrenatalAssesmentForChw
+                    |> Expect.equal AssesmentHighRiskPregnancy
+        ]
+
+
+
+-- GROUP 2 -- ANEMIA (nurse)
+--
+-- Hb comes from `measurements.hemoglobinTest`. Oracle: WHO pregnancy / Labs
+-- tab -- severe <7, moderate 7..<11, none >=11. Anemia only fires when malaria
+-- is NOT positive (here malaria is left unset, so never positive).
+
+
+generatePrenatalDiagnosesForNurseAnemiaTest : Test
+generatePrenatalDiagnosesForNurseAnemiaTest =
+    describe "generatePrenatalDiagnosesForNurse - anemia by hemoglobin count (no malaria; WHO Labs tab)"
+        [ test "Hb 9 (7..<11), no malaria -> DiagnosisModerateAnemiaInitialPhase present" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withHemoglobin 9
+                    |> diagnoseNurse
+                    |> EverySet.member DiagnosisModerateAnemiaInitialPhase
+                    |> Expect.equal True
+        , test "Hb 6 (<7), no malaria, no anemia-complication danger signs -> DiagnosisSevereAnemiaInitialPhase present" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withHemoglobin 6
+                    |> diagnoseNurse
+                    |> EverySet.member DiagnosisSevereAnemiaInitialPhase
+                    |> Expect.equal True
+        , test "Hb 12 (>=11) -> neither moderate nor severe anemia present" <|
+            \_ ->
+                let
+                    diagnoses =
+                        emptyPrenatalMeasurements
+                            |> withHemoglobin 12
+                            |> diagnoseNurse
+                in
+                ( EverySet.member DiagnosisModerateAnemiaInitialPhase diagnoses
+                , EverySet.member DiagnosisSevereAnemiaInitialPhase diagnoses
+                )
+                    |> Expect.equal ( False, False )
+        ]
+
+
+
+-- GROUP 3 -- MALARIA WITH ANEMIA (nurse)
+--
+-- Positive malaria RDT combined with an anemic Hb. Hb 7..<11 -> moderate
+-- (MalariaWithAnemia); Hb <7 -> MalariaWithSevereAnemia. Plain anemia does
+-- not fire because anemia requires malaria to be negative (expected).
+
+
+generatePrenatalDiagnosesForNurseMalariaWithAnemiaTest : Test
+generatePrenatalDiagnosesForNurseMalariaWithAnemiaTest =
+    describe "generatePrenatalDiagnosesForNurse - malaria combined with anemia"
+        [ test "malaria RDT positive + Hb 9 (7..<11) -> DiagnosisMalariaWithAnemiaInitialPhase present" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withMalariaTest TestPositive
+                    |> withHemoglobin 9
+                    |> diagnoseNurse
+                    |> EverySet.member DiagnosisMalariaWithAnemiaInitialPhase
+                    |> Expect.equal True
+        , test "malaria RDT positive + Hb 6 (<7) -> DiagnosisMalariaWithSevereAnemiaInitialPhase present" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withMalariaTest TestPositive
+                    |> withHemoglobin 6
+                    |> diagnoseNurse
+                    |> EverySet.member DiagnosisMalariaWithSevereAnemiaInitialPhase
+                    |> Expect.equal True
+        ]
+
+
+
+-- GROUP 4 -- MODERATE PRE-ECLAMPSIA (nurse)
+--
+-- `DiagnosisModeratePreeclampsiaInitialPhase` requires EGA in [20,37) AND high
+-- blood pressure AND (high urine protein OR edema). FINDING-adjacent nuance:
+-- the code's `highBloodPressureCondition dia sys = dia >= 110 || sys >= 160`
+-- uses the SEVERE BP threshold (>=160/110), NOT the clinical >=140/90 starting
+-- point at which pre-eclampsia screening normally begins. EGA is set to ~28
+-- weeks so the result is insensitive to the [20,37) boundaries.
+
+
+diagnoseNurse28Weeks : PrenatalMeasurements -> EverySet PrenatalDiagnosis
+diagnoseNurse28Weeks measurements =
+    generatePrenatalDiagnosesForNurse currentDate (testAssembled28Weeks measurements)
+
+
+generatePrenatalDiagnosesForNurseModeratePreeclampsiaTest : Test
+generatePrenatalDiagnosesForNurseModeratePreeclampsiaTest =
+    describe "generatePrenatalDiagnosesForNurse - moderate pre-eclampsia (EGA ~28 weeks)"
+        [ test "BP 165/115 (>=160/110) + urine protein +1 -> DiagnosisModeratePreeclampsiaInitialPhase present" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withVitals 165 115
+                    |> withUrineProtein ProteinPlus1
+                    |> diagnoseNurse28Weeks
+                    |> EverySet.member DiagnosisModeratePreeclampsiaInitialPhase
+                    |> Expect.equal True
+
+        -- FINDING: marginal BP 145/95 is hypertensive by the clinical
+        -- >=140/90 definition, but the code's "moderate pre-eclampsia" gate
+        -- demands the SEVERE >=160/110 threshold, so no diagnosis fires here.
+        , test "BP 145/95 (marginal, <160/110) + urine protein +1 -> DiagnosisModeratePreeclampsiaInitialPhase NOT present (severe BP threshold)" <|
+            \_ ->
+                emptyPrenatalMeasurements
+                    |> withVitals 145 95
+                    |> withUrineProtein ProteinPlus1
+                    |> diagnoseNurse28Weeks
+                    |> EverySet.member DiagnosisModeratePreeclampsiaInitialPhase
+                    |> Expect.equal False
+        ]
+
+
 all : Test
 all =
     describe "Prenatal Activity tests"
         [ bmiToPrePregnancyClassificationTest
         , zscoreToPrePregnancyClassificationTest
         , generatePrenatalDiagnosesForNurseLabsTest
+        , generatePrenatalAssesmentForChwTest
+        , generatePrenatalDiagnosesForNurseAnemiaTest
+        , generatePrenatalDiagnosesForNurseMalariaWithAnemiaTest
+        , generatePrenatalDiagnosesForNurseModeratePreeclampsiaTest
         ]

--- a/client/src/elm/Pages/Prenatal/Activity/Test.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Test.elm
@@ -377,8 +377,8 @@ withHemoglobin count measurements =
 
 
 {-| Vitals with the given systolic/diastolic blood pressure. Respiratory rate
-is left unset so the anemia-complication and severe-preeclampsia paths that key
-off an elevated respiratory rate stay inert.
+is left unset so the anemia-complication path (which keys off an elevated
+respiratory rate) stays inert.
 -}
 vitalsValueWith : Float -> Float -> VitalsValue
 vitalsValueWith sys dia =


### PR DESCRIPTION
Fixes #1807.

## Summary

Extends #1806 with **9 assertions across 4 groups**, reusing the prenatal `AssembledData` fixture. Membership-based assertions, each anchored to an independent oracle:

| Group | Oracle | Key cases |
|-------|--------|-----------|
| **CHW assessment** | ANC CHW tab (danger → refer) | danger sign → HighRisk; none → Normal |
| **Anemia** | WHO / Labs tab: severe <7, moderate 7–<11 | Hb 9 → Moderate, Hb 6 → Severe, Hb 12 → none |
| **Malaria + anemia** | malaria+ + low Hb | Hb 9 → MalariaWithAnemia, Hb 6 → MalariaWithSevereAnemia |
| **Moderate pre-eclampsia** | high BP + proteinuria, EGA 20–36 | 165/115 + protein+1 → ModeratePreeclampsia |

## Finding (pinned)

The code's "moderate" pre-eclampsia requires the **severe** BP threshold (`dia≥110 || sys≥160`), not the clinical ≥140/90 start. Marginal BP (145/95) + proteinuria → **no** moderate-pre-eclampsia at initial phase. Negative test + FINDING comment.

## Verification
- elm-test: **2620 passed, 0 failed** (9 new); elm-format ✓; full-project elm-review ✓; no Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)