### PR TITLE
Surface IndexedDB save failures instead of silently swallowing them

### DIFF
--- a/client/src/elm/SyncManager/Decoder.elm
+++ b/client/src/elm/SyncManager/Decoder.elm
@@ -1518,6 +1518,7 @@ decodeIndexDbSaveResult =
         |> required "table" decodeIndexDbSaveResultTable
         |> required "status" decodeIndexDbSaveStatus
         |> required "timestamp" string
+        |> optional "reason" (nullable string) Nothing
 
 
 decodeIndexDbSaveResultTable : Decoder IndexDbSaveResultTable

--- a/client/src/elm/SyncManager/Model.elm
+++ b/client/src/elm/SyncManager/Model.elm
@@ -1,4 +1,4 @@
-module SyncManager.Model exposing (BackendAuthorityEntity(..), BackendEntity, BackendEntityIdentifier, BackendGeneralEntity(..), BackendWhatsAppEntity, DownloadPhotosAllRec, DownloadPhotosBatchRec, DownloadPhotosMode(..), DownloadPhotosStatus(..), DownloadSyncResponse, Flags, IncidentContnentIdentifier, IndexDbDeferredPhotoRemoteData, IndexDbQueryDeferredPhotoBatchResultRecord, IndexDbQueryDeferredPhotoResultRecord, IndexDbQueryType(..), IndexDbQueryTypeResult(..), IndexDbQueryUploadAuthorityResultRecord, IndexDbQueryUploadFileResultRecord, IndexDbQueryUploadGeneralResultRecord, IndexDbQueryUploadPhotoResultRecord, IndexDbQueryUploadWhatsAppResultRecord, IndexDbSaveResult, IndexDbSaveResultTable(..), IndexDbSaveStatus(..), IndexDbUploadRemoteData, Model, Msg(..), PhotoBatchResult, Site(..), SiteFeature(..), SyncCycle(..), SyncIncidentType(..), SyncInfoAuthority, SyncInfoAuthorityForPort, SyncInfoAuthorityZipper, SyncInfoGeneral, SyncInfoGeneralForPort, SyncInfoStatus(..), SyncSpeed, SyncStatus(..), UploadFileError(..), UploadMethod(..), UploadRec, downloadRequestTimeout, emptyModel, emptySyncInfoAuthority, emptyUploadRec, uploadRequestTimeout)
+module SyncManager.Model exposing (BackendAuthorityEntity(..), BackendEntity, BackendEntityIdentifier, BackendGeneralEntity(..), BackendWhatsAppEntity, DownloadPhotosAllRec, DownloadPhotosBatchRec, DownloadPhotosMode(..), DownloadPhotosStatus(..), DownloadSyncResponse, Flags, IncidentContnentIdentifier, IndexDbDeferredPhotoRemoteData, IndexDbQueryDeferredPhotoBatchResultRecord, IndexDbQueryDeferredPhotoResultRecord, IndexDbQueryType(..), IndexDbQueryTypeResult(..), IndexDbQueryUploadAuthorityResultRecord, IndexDbQueryUploadFileResultRecord, IndexDbQueryUploadGeneralResultRecord, IndexDbQueryUploadPhotoResultRecord, IndexDbQueryUploadWhatsAppResultRecord, IndexDbSaveError(..), IndexDbSaveResult, IndexDbSaveResultTable(..), IndexDbSaveStatus(..), IndexDbUploadRemoteData, Model, Msg(..), PhotoBatchResult, Site(..), SiteFeature(..), SyncCycle(..), SyncIncidentType(..), SyncInfoAuthority, SyncInfoAuthorityForPort, SyncInfoAuthorityZipper, SyncInfoGeneral, SyncInfoGeneralForPort, SyncInfoStatus(..), SyncSpeed, SyncStatus(..), UploadFileError(..), UploadMethod(..), UploadRec, downloadRequestTimeout, emptyModel, emptySyncInfoAuthority, emptyUploadRec, uploadRequestTimeout)
 
 import AssocList as Dict exposing (Dict)
 import Backend.AcuteIllnessEncounter.Model exposing (AcuteIllnessEncounter)
@@ -416,6 +416,12 @@ type alias Model =
     -- by the response handler to reconcile per-photo outcomes against
     -- `deferredPhotos`.
     , bulkPhotosInFlight : List IndexDbQueryDeferredPhotoResultRecord
+
+    -- The most recent IndexedDB save failure, if the last save failed.
+    -- `IndexDbSaveErrorStorageFull` means a write hit the device storage
+    -- ceiling; in that state re-downloading is futile until space is freed.
+    -- Cleared on the next successful save.
+    , lastSaveError : Maybe IndexDbSaveError
     }
 
 
@@ -438,6 +444,7 @@ emptyModel flags =
     , bulkPhotosEndpointAvailable = Nothing
     , bulkPhotosConsecutiveBatchErrors = 0
     , bulkPhotosInFlight = []
+    , lastSaveError = Nothing
     }
 
 
@@ -634,6 +641,10 @@ type alias IndexDbSaveResult =
     { table : IndexDbSaveResultTable
     , status : IndexDbSaveStatus
     , timestamp : String
+
+    -- Error name reported by the JS port on failure (e.g.
+    -- "QuotaExceededError"); `Nothing` on success.
+    , reason : Maybe String
     }
 
 
@@ -647,6 +658,15 @@ type IndexDbSaveResultTable
 type IndexDbSaveStatus
     = IndexDbSaveFailure
     | IndexDbSaveSuccess
+
+
+{-| A classified IndexedDB save failure. `IndexDbSaveErrorStorageFull` (the
+device ran out of storage) is distinguished because retrying the same write
+cannot succeed until space is freed.
+-}
+type IndexDbSaveError
+    = IndexDbSaveErrorOther String
+    | IndexDbSaveErrorStorageFull
 
 
 type alias IndexDbQueryUploadPhotoResultRecord =

--- a/client/src/elm/SyncManager/Test.elm
+++ b/client/src/elm/SyncManager/Test.elm
@@ -10,6 +10,7 @@ import SyncManager.Model
     exposing
         ( DownloadPhotosStatus(..)
         , Flags
+        , IndexDbSaveError(..)
         , Model
         , Msg(..)
         , Site(..)
@@ -107,4 +108,66 @@ all =
                     |> .model
                     |> .downloadPhotosStatus
                     |> Expect.notEqual DownloadPhotosIdle
+        , test "SavedAtIndexDbHandle records a storage-full error for a QuotaExceededError failure" <|
+            \() ->
+                let
+                    saveResult =
+                        Json.Encode.object
+                            [ ( "table", Json.Encode.string "Authority" )
+                            , ( "status", Json.Encode.string "Failure" )
+                            , ( "timestamp", Json.Encode.string "" )
+                            , ( "reason", Json.Encode.string "QuotaExceededError" )
+                            ]
+                in
+                SyncManager.Update.update
+                    (Time.millisToPosix 0)
+                    DevicePage
+                    0
+                    testDevice
+                    (SavedAtIndexDbHandle saveResult)
+                    testModel
+                    |> .model
+                    |> .lastSaveError
+                    |> Expect.equal (Just IndexDbSaveErrorStorageFull)
+        , test "SavedAtIndexDbHandle records a non-quota failure as a generic save error" <|
+            \() ->
+                let
+                    saveResult =
+                        Json.Encode.object
+                            [ ( "table", Json.Encode.string "Authority" )
+                            , ( "status", Json.Encode.string "Failure" )
+                            , ( "timestamp", Json.Encode.string "" )
+                            , ( "reason", Json.Encode.string "BulkError" )
+                            ]
+                in
+                SyncManager.Update.update
+                    (Time.millisToPosix 0)
+                    DevicePage
+                    0
+                    testDevice
+                    (SavedAtIndexDbHandle saveResult)
+                    testModel
+                    |> .model
+                    |> .lastSaveError
+                    |> Expect.equal (Just (IndexDbSaveErrorOther "BulkError"))
+        , test "SavedAtIndexDbHandle clears a previous save error on a successful save" <|
+            \() ->
+                let
+                    saveResult =
+                        Json.Encode.object
+                            [ ( "table", Json.Encode.string "AuthorityStats" )
+                            , ( "status", Json.Encode.string "Success" )
+                            , ( "timestamp", Json.Encode.string "" )
+                            ]
+                in
+                SyncManager.Update.update
+                    (Time.millisToPosix 0)
+                    DevicePage
+                    0
+                    testDevice
+                    (SavedAtIndexDbHandle saveResult)
+                    { testModel | lastSaveError = Just IndexDbSaveErrorStorageFull }
+                    |> .model
+                    |> .lastSaveError
+                    |> Expect.equal Nothing
         ]

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -2284,6 +2284,12 @@ update currentTime activePage dbVersion device msg model =
                 Ok indexDbSaveResult ->
                     case indexDbSaveResult.status of
                         IndexDbSaveSuccess ->
+                            let
+                                -- A save just succeeded, so any previously
+                                -- recorded save failure is no longer current.
+                                clearedModel =
+                                    { model | lastSaveError = Nothing }
+                            in
                             case indexDbSaveResult.table of
                                 IndexDbSaveResultTableAutority ->
                                     update
@@ -2292,7 +2298,7 @@ update currentTime activePage dbVersion device msg model =
                                         dbVersion
                                         device
                                         (BackendAuthorityFetchedDataSavedHandle indexDbSaveResult.timestamp)
-                                        model
+                                        clearedModel
 
                                 IndexDbSaveResultTableDeferredPhotos ->
                                     -- Deferred-photo rows have just landed in IndexedDB.
@@ -2304,7 +2310,7 @@ update currentTime activePage dbVersion device msg model =
                                         dbVersion
                                         device
                                         TryDownloadingPhotos
-                                        model
+                                        clearedModel
 
                                 IndexDbSaveResultTableGeneral ->
                                     update
@@ -2313,15 +2319,23 @@ update currentTime activePage dbVersion device msg model =
                                         dbVersion
                                         device
                                         (BackendGeneralFetchedDataSavedHandle indexDbSaveResult.timestamp)
-                                        model
+                                        clearedModel
 
                                 _ ->
-                                    noChange
+                                    SubModelReturn clearedModel Cmd.none noError []
 
                         IndexDbSaveFailure ->
-                            -- For now, we don't make any special handling,
-                            -- so when request times out, we will retry.
-                            noChange
+                            -- A save into IndexedDB actually failed. This used to be a
+                            -- blind no-op: a QuotaExceededError (device storage full)
+                            -- was indistinguishable from success, so the lane retried
+                            -- the same batch forever with no signal. Record the failure
+                            -- so the condition is observable -- and, for storage-full,
+                            -- surfaceable to the user in a later step.
+                            SubModelReturn
+                                { model | lastSaveError = Just (SyncManager.Utils.indexDbSaveErrorFromReason indexDbSaveResult.reason) }
+                                Cmd.none
+                                noError
+                                []
 
                 Err error ->
                     SubModelReturn

--- a/client/src/elm/SyncManager/Utils.elm
+++ b/client/src/elm/SyncManager/Utils.elm
@@ -1,4 +1,4 @@
-module SyncManager.Utils exposing (backendAuthorityEntityToRevision, backendGeneralEntityToRevision, determineDownloadPhotosStatus, determineSyncStatus, encodeBackendAuthorityEntity, encodeBackendGeneralEntity, getBackendAuthorityEntityIdentifier, getBackendGeneralEntityIdentifier, getDataToSendAuthority, getDataToSendGeneral, getDownloadPhotosSpeedForSubscriptions, getImageFromBackendAuthorityEntity, getSyncSpeedForSubscriptions, getSyncedHealthCenters, resolveIncidentDetailsMsg, siteFeaturesFromString, siteFromString, syncInfoAuthorityForPort, syncInfoAuthorityFromPort, syncInfoGeneralForPort, syncInfoGeneralFromPort, syncInfoStatusToString)
+module SyncManager.Utils exposing (backendAuthorityEntityToRevision, backendGeneralEntityToRevision, determineDownloadPhotosStatus, determineSyncStatus, encodeBackendAuthorityEntity, encodeBackendGeneralEntity, getBackendAuthorityEntityIdentifier, getBackendGeneralEntityIdentifier, getDataToSendAuthority, getDataToSendGeneral, getDownloadPhotosSpeedForSubscriptions, getImageFromBackendAuthorityEntity, getSyncSpeedForSubscriptions, getSyncedHealthCenters, indexDbSaveErrorFromReason, resolveIncidentDetailsMsg, siteFeaturesFromString, siteFromString, syncInfoAuthorityForPort, syncInfoAuthorityFromPort, syncInfoGeneralForPort, syncInfoGeneralFromPort, syncInfoStatusToString)
 
 import Activity.Model exposing (Activity(..), ChildActivity(..))
 import Backend.AcuteIllnessEncounter.Encoder
@@ -2793,3 +2793,29 @@ resolveIncidentDetailsMsg error =
 fileUploadFailureThreshold : Int
 fileUploadFailureThreshold =
     5
+
+
+{-| Classify an IndexedDB save failure from the raw error name reported by the
+JS port. `QuotaExceededError` (the device storage is full) is singled out
+because, unlike a transient failure, re-downloading and re-saving the same batch
+cannot succeed until space is freed.
+-}
+indexDbSaveErrorFromReason : Maybe String -> IndexDbSaveError
+indexDbSaveErrorFromReason reason =
+    case reason of
+        Just name ->
+            if isStorageFullError name then
+                IndexDbSaveErrorStorageFull
+
+            else
+                IndexDbSaveErrorOther name
+
+        Nothing ->
+            IndexDbSaveErrorOther "Unknown"
+
+
+isStorageFullError : String -> Bool
+isStorageFullError name =
+    -- Browsers report a full quota as `QuotaExceededError`; older Firefox used
+    -- `NS_ERROR_DOM_QUOTA_REACHED`. Match the substring to cover both casings.
+    String.contains "Quota" name || String.contains "QUOTA" name

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -645,22 +645,57 @@ elmApp.ports.sendSyncedDataToIndexDb.subscribe(function(info) {
 
   table.bulkPut(entities)
       .then(function() {
-          return sendIndexedDbSaveResult('Success', info.table, info.timestamp);
-      }).catch(Dexie.BulkError, function (e) {
-          return sendIndexedDbSaveResult('Failure', info.table, info.timestamp);
+          return sendIndexedDbSaveResult('Success', info.table, info.timestamp, null);
+      }).catch(function (e) {
+          // Catch EVERY failure, not just Dexie.BulkError. A QuotaExceededError
+          // (the device storage is full) or a transaction AbortError is not a
+          // BulkError, so it used to escape this handler as an unhandled
+          // rejection -- Elm was never told the save failed, and the sync lane
+          // silently retried the same batch forever. Report the error name so
+          // Elm can tell a storage-full condition apart from other failures.
+          return sendIndexedDbSaveResult('Failure', info.table, info.timestamp, indexedDbErrorName(e));
       });
 
   /**
-   * Report that save operation was successful.
+   * Report the outcome of a save operation back to Elm.
    */
-  function sendIndexedDbSaveResult(status, table, timestamp) {
+  function sendIndexedDbSaveResult(status, table, timestamp, reason) {
     const dataForSend = {
       'status': status,
       'table': table,
-      'timestamp': timestamp
+      'timestamp': timestamp,
+      'reason': reason || null
     }
 
     elmApp.ports.savedAtIndexedDb.send(dataForSend);
+  }
+
+  /**
+   * Extract a stable error name from a Dexie/IndexedDB failure, surfacing a
+   * QuotaExceededError even when Dexie wraps it (in `inner`, or among the
+   * per-row `failures` of a BulkError), so Elm can detect storage exhaustion.
+   */
+  function indexedDbErrorName(e) {
+    if (!e) {
+      return 'Unknown';
+    }
+
+    var candidates = [e];
+    if (e.inner) {
+      candidates.push(e.inner);
+    }
+    if (e.failures && e.failures.length) {
+      candidates = candidates.concat(e.failures);
+    }
+
+    for (var i = 0; i < candidates.length; i++) {
+      var name = candidates[i] && candidates[i].name;
+      if (typeof name === 'string' && name.indexOf('Quota') !== -1) {
+        return 'QuotaExceededError';
+      }
+    }
+
+    return (e.name && typeof e.name === 'string') ? e.name : 'Unknown';
   }
 
 });


### PR DESCRIPTION
Fixes #1817

## What

E-Heza is offline-first, so IndexedDB is the source of truth for everything a nurse enters until it uploads. A failed write was invisible end-to-end: the `bulkPut` save path caught only `Dexie.BulkError`, so a `QuotaExceededError` (device storage full) or a transaction `AbortError` escaped as an **unhandled promise rejection** and Elm was never told the save failed. Even a reported `Failure` hit a blind no-op (`IndexDbSaveFailure -> noChange`), so the lane silently retried the same batch forever. On a low-storage field device this can mean **silent, unrecoverable clinical data loss**.

This PR is the **reactive layer** (Parts 1–2 of the plan):

**JS port (`app.js`)**
- Broaden the `bulkPut` `.catch` from `Dexie.BulkError`-only to catch-all.
- New `indexedDbErrorName()` surfaces a `QuotaExceededError` even when Dexie wraps it (`inner`, or among a BulkError's per-row `failures`).
- `sendIndexedDbSaveResult` now reports a `reason`.

**Elm (`SyncManager/*`)**
- `IndexDbSaveResult` gains `reason : Maybe String`, decoded with `optional` (old/omitted payloads still decode).
- New `IndexDbSaveError = IndexDbSaveErrorOther String | IndexDbSaveErrorStorageFull` + pure classifier `SyncManager.Utils.indexDbSaveErrorFromReason`.
- New `Model.lastSaveError : Maybe IndexDbSaveError`: the `SavedAtIndexDbHandle` failure branch now records the classified error instead of a blind no-op; the success branch clears it.

## Tests
3 new `SyncManager/Test.elm` cases (quota → `StorageFull`, other → `Other`, success clears it). Full module: 6/6. App compiles (548 modules); `elm-format` clean; `node --check app.js` OK.

## Not in this PR (follow-ups)
- Proactive "storage almost full" banner from the existing `storage.estimate()` poll.
- Eviction hardening via `storage.persist()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)