### PR TITLE
Patch composer_manager for Composer 2; set DDEV composer_version to 2

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,9 +12,10 @@ database:
     type: mariadb
     version: "10.5"
 use_dns_when_possible: true
-# Composer version is set to 1, since Drupal 7 Composer Manager doesn't
-# support Composer 2.
-composer_version: "1"
+# Composer 2: composer_manager is patched for Composer 2's installed.json
+# format via drupal-org.make (drupal.org issue #3182422). Composer 1 is no
+# longer supported by Packagist or DDEV.
+composer_version: "2"
 web_environment: []
 nodejs_version: "18"
 corepack_enable: false

--- a/server/hedley/drupal-org.make
+++ b/server/hedley/drupal-org.make
@@ -24,6 +24,11 @@ projects[ctools][patch][] = "https://www.drupal.org/files/issues/2067997-reload-
 
 projects[composer_manager][subdir] = "contrib"
 projects[composer_manager][version] = "1.8"
+; Composer 2 compatibility: composer_manager reads the old Composer 1 format of
+; vendor/composer/installed.json. Composer 1 support was dropped by Packagist and
+; DDEV, so patch the module to also parse Composer 2's "packages" wrapper.
+; https://www.drupal.org/project/composer_manager/issues/3182422
+projects[composer_manager][patch][] = "https://www.drupal.org/files/issues/2021-02-27/composer_manager-composer_2_packages-3182422-7-D7.patch"
 
 projects[date][subdir] = "contrib"
 projects[date][version] = "2.14"


### PR DESCRIPTION
## What & why

Composer Manager 1.8 (Drupal 7) parses `vendor/composer/installed.json` in **Composer 1's flat-array format**. Composer 2 wraps the package list in a `packages` key, so the admin status page (`/admin/config/system/composer-manager`) throws `Undefined index: name/version` notices and wrongly reports required products (`ramsey/uuid`, `twilio/sdk`) as not installed.

Composer 1 is no longer an option — Packagist dropped it (Sept 2025) and DDEV ≥ 1.25.1 silently substitutes Composer 2.2 LTS for `composer_version: "1"`. So the right fix is to make Composer Manager understand the Composer 2 format.

Closes #1824

## Changes

- **`server/hedley/drupal-org.make`** — apply the upstream RTBC patch (drupal.org issue [#3182422](https://www.drupal.org/project/composer_manager/issues/3182422)) via `drush make`, matching the existing `advancedqueue`/`ctools`/`prepopulate` patch convention. The patch is a one-liner in `composer_manager_installed_packages_load()` that unwraps the `packages` key and stays backward-compatible with Composer 1.
- **`.ddev/config.yaml`** — set `composer_version` back to `"2"` and update the (now-accurate) comment.

## Verification

Applied the patch to a live checkout, regenerated `installed.json` in Composer 2 format, and confirmed the patched module reads it correctly:

```
$ drush eval 'module_load_include("inc","composer_manager","composer_manager.admin");
              echo implode(", ", array_keys(composer_manager_installed_packages()));'
paragonie/random_compat, ramsey/uuid, twilio/sdk
```

The status page now lists all products as installed with no PHP notices. The patch applies automatically on the next `scripts/build`; no manual steps remain.
