### PR TITLE
Add guided Pantheon deploy skills: deploy-release + deploy-multidev

### DIFF
--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -1,16 +1,17 @@
 # Deploy reference — internals, setup, troubleshooting
 
-Background detail for the `deploy-release` skill. Source of truth: the wiki
-(https://github.com/Gizra/ihangane/wiki/Deployment) and `server/RoboFile.php`.
+Background detail shared by the `deploy-release` and `deploy-multidev` skills.
+Source of truth: the wiki (https://github.com/Gizra/ihangane/wiki/Deployment)
+and `server/RoboFile.php`.
 
 ## Pantheon sites
 
-| Pantheon site (`PANTHEON_NAME`) | `EHEZA_SITE` | Dashboard |
-| ------------------------------- | ------------ | --------- |
-| `ihangane`                      | `rwanda`     | https://dashboard.pantheon.io/sites/ef0f3448-d0e5-4e83-b26c-875cfc77228b |
-| `vhw`                           | `burundi`    | https://dashboard.pantheon.io/sites/7a63355a-86c4-4823-b9bd-145d24969627 |
-| `tip-somalia`                   | `somalia`    | https://dashboard.pantheon.io/sites/6e2186e4-348e-432d-bd54-25da6834cd12 |
-| `uvl`                           | `burundi`    | https://dashboard.pantheon.io/sites/22e92340-dfa5-40cb-a5b8-58af49317149 |
+| `PANTHEON_NAME` | `EHEZA_SITE` | Clone dir (under `server/`) | Dashboard |
+| --------------- | ------------ | --------------------------- | --------- |
+| `ihangane`      | `rwanda`     | `.pantheon-ihangane`        | https://dashboard.pantheon.io/sites/ef0f3448-d0e5-4e83-b26c-875cfc77228b |
+| `vhw`           | `burundi`    | `.pantheon-vhw`             | https://dashboard.pantheon.io/sites/7a63355a-86c4-4823-b9bd-145d24969627 |
+| `tip-somalia`   | `somalia`    | `.pantheon-tip-somalia`     | https://dashboard.pantheon.io/sites/6e2186e4-348e-432d-bd54-25da6834cd12 |
+| `uvl`           | `burundi`    | `.pantheon-uvl`             | https://dashboard.pantheon.io/sites/22e92340-dfa5-40cb-a5b8-58af49317149 |
 
 `vhw` and `uvl` are two separate Burundi deployments — same `EHEZA_SITE`, different `PANTHEON_NAME`. Always confirm which one.
 

--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -63,6 +63,23 @@ git clone ssh://codeserver.dev.22e92340-dfa5-40cb-a5b8-58af49317149@codeserver.d
 ```
 Also required (one-time): a Pantheon team membership + SSH key on the Pantheon account, and the `.ddev/config.local.yaml` `web_environment` entries (`EHEZA_SITE`, `PANTHEON_NAME`, and for infra also `EHEZA_INFRA_REPO_REMOTE`, `GITHUB_USERNAME`, `GITHUB_ACCESS_TOKEN`).
 
+## Reinstall-on-restart toggle (`config.local.yaml` → `post-start`)
+
+`ddev restart` re-runs the `post-start` hook. By default only one line there is active —
+`- exec-host: ddev client-install` (installs the Elm client deps; **not** a reinstall) — and
+everything below it is commented out, so **a normal restart does not reinstall** the local site.
+
+To make a restart **reinstall the project**, uncomment the *entire* commented `post-start` block —
+from `- exec: "cd .. && chmod +x ./scripts/build && ./scripts/build"` down through the final
+`- exec: drush uli`. That runs the full local rebuild for the selected `$EHEZA_SITE`: build, copy
+the site CSVs, `drush site-install`, enable modules, run the `default`/`counseling`/`forms`
+migrations, and set feature flags. Re-comment the block afterward if you don't want every future
+restart to reinstall.
+
+A reinstall is **not** needed to deploy — the deploy builds the client and rsyncs `www/` from
+source, independent of the local DB. Only reinstall if you want your local environment to reflect
+the newly-selected site's data.
+
 ## Troubleshooting preflight / deploy failures
 
 - **"The GitHub working directory is dirty"** — commit/stash/`.gitignore` pending changes in the eheza-app repo, then retry.

--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -68,6 +68,8 @@ Also required (one-time): a Pantheon team membership + SSH key on the Pantheon a
 `ddev restart` re-runs the `post-start` hook. By default only one line there is active —
 `- exec-host: ddev client-install` (installs the Elm client deps; **not** a reinstall) — and
 everything below it is commented out, so **a normal restart does not reinstall** the local site.
+The deploy skills run this restart on **every** deploy (Step 2) and always ask the reinstall
+question first — default **No**.
 
 To make a restart **reinstall the project**, uncomment the *entire* commented `post-start` block —
 from `- exec: "cd .. && chmod +x ./scripts/build && ./scripts/build"` down through the final
@@ -76,9 +78,17 @@ the site CSVs, `drush site-install`, enable modules, run the `default`/`counseli
 migrations, and set feature flags. Re-comment the block afterward if you don't want every future
 restart to reinstall.
 
-A reinstall is **not** needed to deploy — the deploy builds the client and rsyncs `www/` from
-source, independent of the local DB. Only reinstall if you want your local environment to reflect
-the newly-selected site's data.
+A reinstall is usually **not** needed to deploy. The deploy builds the client (`gulp publish`) and
+rsyncs `www/` independent of the local DB, and `www/profiles/hedley` is a **symlink** → `server/hedley`,
+which the deploy's `rsync -L` follows — so the **custom** E-Heza server code always reflects the
+checked-out branch live, no rebuild required.
+
+The one exception: `www/`'s Drupal **core + contrib** are assembled by `server/scripts/build`
+(`drush make`) and are **copied**, not symlinked. So if the branch you're deploying changed
+`drupal-org.make` / `drupal-org-core.make` (contrib versions) versus the currently-built `www/`,
+those are stale and only a **reinstall** (which re-runs `scripts/build`) refreshes them. For branches
+that didn't touch contrib, deploy as-is. Reinstall also when you want your local environment to
+reflect the newly-selected site's data.
 
 ## Troubleshooting preflight / deploy failures
 

--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -63,6 +63,8 @@ git clone ssh://codeserver.dev.22e92340-dfa5-40cb-a5b8-58af49317149@codeserver.d
 ```
 Also required (one-time): a Pantheon team membership + SSH key on the Pantheon account, and the `.ddev/config.local.yaml` `web_environment` entries (`EHEZA_SITE`, `PANTHEON_NAME`, and for infra also `EHEZA_INFRA_REPO_REMOTE`, `GITHUB_USERNAME`, `GITHUB_ACCESS_TOKEN`).
 
+**`TERMINUS_MACHINE_TOKEN` (required for deploys).** SSH keys cover the git *push* to Pantheon, but `terminus` — used for the post-deploy `remote:drush` `cc all`/`updb`/`fra` steps — has its own auth. Create a machine token at https://dashboard.pantheon.io/machine-token/create (shown once; copy it), then add it to `web_environment` in `.ddev/config.local.yaml` so terminus auto-authenticates: `- TERMINUS_MACHINE_TOKEN=<token>` (then `ddev restart`). Without it, the deploy pushes code but every `remote:drush` step fails with *"You are not logged in"*, leaving the env on new code with a stale cache/registry.
+
 ## Reinstall-on-restart toggle (`config.local.yaml` → `post-start`)
 
 `ddev restart` re-runs the `post-start` hook. By default only one line there is active —
@@ -97,7 +99,8 @@ reflect the newly-selected site's data.
 - **"pantheon.upstream.yml is missing / php_version directive is missing"** — the Pantheon clone is stale or wrong; re-pull it (`git -C server/.pantheon-<name> pull`).
 - **Pushed to the wrong site** — caused by a stale `PANTHEON_NAME`. Fix `.ddev/config.local.yaml` and **`ddev restart`** (env vars only reload on restart) before re-deploying.
 - **Empty changelog** — you passed the *new* tag to `generate:release-notes` instead of the previous one.
-- **terminus / SSH auth errors** — re-run `ddev auth ssh`; confirm Pantheon team membership and that your SSH key is on the Pantheon account.
+- **SSH auth errors (git push to Pantheon)** — re-run `ddev auth ssh`; confirm Pantheon team membership and that your SSH key is on the Pantheon account.
+- **`terminus` "You are not logged in"** — `ddev auth ssh` does **not** authenticate terminus. Set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see prerequisites) and `ddev restart`, or run `ddev exec terminus auth:login --machine-token=<token>`; verify with `ddev exec terminus auth:whoami`. The `robo` deploy may already have **pushed the code** before failing here — so after authenticating, just re-run the post-deploy `remote:drush` steps (`cc all` ×2, `updb -y`, `uli`, `fra -y`) rather than the whole deploy.
 
 ## Branch note
 

--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -100,7 +100,7 @@ reflect the newly-selected site's data.
 - **Pushed to the wrong site** — caused by a stale `PANTHEON_NAME`. Fix `.ddev/config.local.yaml` and **`ddev restart`** (env vars only reload on restart) before re-deploying.
 - **Empty changelog** — you passed the *new* tag to `generate:release-notes` instead of the previous one.
 - **SSH auth errors (git push to Pantheon)** — re-run `ddev auth ssh`; confirm Pantheon team membership and that your SSH key is on the Pantheon account.
-- **`terminus` "You are not logged in"** — `ddev auth ssh` does **not** authenticate terminus. Set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see prerequisites) and `ddev restart`, or run `ddev exec terminus auth:login --machine-token=<token>`; verify with `ddev exec terminus auth:whoami`. The `robo` deploy may already have **pushed the code** before failing here — so after authenticating, just re-run the post-deploy `remote:drush` steps (`cc all` ×2, `updb -y`, `uli`, `fra -y`) rather than the whole deploy.
+- **`terminus` "You are not logged in"** — `ddev auth ssh` does **not** authenticate terminus. Set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see prerequisites) and `ddev restart`, or run **`ddev terminus-auth`** (logs terminus in from the token; or `ddev terminus-auth <token>`); verify with `ddev exec terminus auth:whoami`. The `robo` deploy may already have **pushed the code** before failing here — so after authenticating, just re-run the post-deploy `remote:drush` steps (`cc all` ×2, `updb -y`, `uli`, `fra -y`) rather than the whole deploy.
 
 ## Branch note
 

--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -26,27 +26,29 @@ and `server/RoboFile.php`.
 6. rsyncs `www/.` (server) and `client/dist/.` (app) into the clone, excluding `.git`, `.ddev`, `client`, etc.
 7. Prints `git status`, then asks **"Commit changes and deploy?"** (interactive — needs a human).
 8. On confirm: `git pull && git add . && git commit -am 'Site update' && git push` to Pantheon.
-9. Calls `deployPantheonSync(<env>, FALSE)` → runs `cc all` (×2), `updb -y`, `uli` on that env. **Does not run `fra`.**
+9. Calls `deployPantheonSync(<env>, FALSE)` → runs `cc all` (×2), `updb -y`, `fra -y`, `cc all`, `uli` on that env.
 
 `$branchName == 'master'` maps to the Pantheon **`dev`** environment.
 
 ### `deployPantheonSync($env = 'test', $doDeploy = TRUE)` — `ddev robo deploy:pantheon-sync <env>`
 - If `$doDeploy`: `terminus env:deploy <PANTHEON_NAME>.<env>` (promotes code from the previous env).
-- Then always: `terminus remote:drush <env> -- cc all` (×2), `updb -y`, `uli`.
-- Again, **no `fra`** — run it manually after.
+- Then always: `terminus remote:drush <env> -- cc all` (×2), `updb -y`, `fra -y`, `cc all`, `uli`.
 
 ### `generateReleaseNotes($tag = NULL)` — `ddev robo generate:release-notes [tag]`
 - Lists changes **since** `$tag`. So `$tag` is the **previous** release tag (releasing `v1.17.2` → pass `v1.17.1`).
 - If `$tag` is omitted it prompts to compare from the latest tag; pass it explicitly to avoid the prompt.
 - Detects org/repo from `git remote get-url origin` to enrich entries via the GitHub API.
 
-## `fra` is the manual post-deploy step
+## `fra` runs automatically on deploy
 
-None of the robo commands run `drush fra` (features-revert-all). After every env you deploy/promote to:
-```bash
-ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y
-```
-`cc all` / `updb -y` / `uli` are already handled by the robo command for that env.
+The robo deploy commands now run `drush fra` (features-revert-all) themselves — `deployPantheonSync` runs it after `updb`, followed by a `cc all`, on every env. So `cc all` / `updb -y` / **`fra -y`** / `uli` are all handled by `ddev robo deploy:pantheon[-sync]`; you no longer run `fra` by hand.
+
+> ⚠️ **Exception — the Pantheon dashboard GUI.** If you promote to Test/Live via the dashboard (Test/Live tabs) instead of `ddev robo deploy:pantheon-sync`, the robo command never runs, so **none of `updb`/`fra`/`cc all` run** on that env — you must perform them manually:
+> ```bash
+> ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- updb -y
+> ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y
+> ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- cc all
+> ```
 
 ## One-time setup (prerequisites)
 

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -60,6 +60,11 @@ Report a ✅/❌ checklist. **Stop and surface any ❌.**
      || git -C server/.pantheon-<PANTHEON_NAME> rev-parse --verify origin/<env>
    ```
    - If the multidev branch is missing: the env must exist on Pantheon first. Tell the user to create the multidev environment in the Pantheon dashboard (or via terminus), then in the clone `git fetch origin && git checkout <env>`. Without it, the deploy can't proceed.
+4. **Terminus authenticated.** `ddev auth ssh` covers the git *push* to Pantheon, but the deploy's post-deploy `terminus remote:drush` (`cc all` / `updb` / `uli`) has separate auth — without it the deploy pushes code and *then* fails with *"You are not logged in"*, leaving the env on new code with a stale cache/registry:
+   ```bash
+   ddev exec terminus auth:whoami   # expect an email, not "You are not logged in"
+   ```
+   - If not logged in: set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see shared reference) and `ddev restart`, or run `ddev exec terminus auth:login --machine-token=<token>`.
 
 ## Step 2 — Local prep
 

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: deploy-multidev
+description: Deploy an arbitrary branch to a Pantheon multidev (review/feature) environment for ONE E-Heza site — build from the selected branch and push it to a named multidev env. Trigger when the user wants to deploy a branch to a multidev/review/feature/test env, spin up or update a review environment, or push a non-`main` branch to Pantheon for testing. NOT for production — use the `deploy-release` skill for the full `main` → Live release. Drives the safe steps itself and pauses for the interactive or production-affecting commands.
+---
+
+# Deploy to Multidev (E-Heza → Pantheon)
+
+This skill deploys a chosen **git branch** to a Pantheon **multidev** (review/feature) environment for one **single site**. It's the low-risk path: it only updates an isolated multidev env — never Dev/Test/Live, and it never cuts a release.
+
+> Releasing to production (`main` → Dev → Test → Live + GitHub release)? Use the **`deploy-release`** skill instead.
+
+**Shared reference** (site table, RoboFile internals, one-time Pantheon clone setup, troubleshooting): **`.claude/skills/_deploy-common/deploy-reference.md`** — read it before running.
+
+## Execution model — who runs what
+
+You (Claude) **drive the safe steps** and **pause at the risky ones**. Never run a step marked 🔴 yourself.
+
+- 🟢 **You run** (via Bash on the host): git prep (checkout/pull the source branch) and all read-only preflight checks.
+- 🔴 **User runs** (give them the exact command; they run it with `! <command>` so output lands here, then you continue): `ddev auth ssh`, `ddev gulp publish`, `ddev robo deploy:pantheon <env>`, and post-deploy `fra`.
+
+Pausing matters because `ddev robo deploy:pantheon <env>` shows a `git status` of the Pantheon repo and an interactive **"Commit changes and deploy?"** prompt — a human must review that change-set before confirming. `ddev auth ssh` is also interactive.
+
+**One site per run.**
+
+## Site → config mapping
+
+Look up the chosen site's `EHEZA_SITE`, `PANTHEON_NAME`, and Pantheon clone dir (`server/.pantheon-<PANTHEON_NAME>`) in the **site table** in `.claude/skills/_deploy-common/deploy-reference.md`.
+
+⚠️ Two distinct Burundi sites (`vhw`, `uvl`) share `EHEZA_SITE=burundi` but have different `PANTHEON_NAME`. Always pin the exact Pantheon site with the user — never assume "burundi".
+
+---
+
+## Step 0 — Gather inputs (ask the user)
+
+Use **AskUserQuestion** (and free text where needed) to collect:
+
+1. **Target site** — Rwanda / Burundi-vhw / Burundi-uvl / Somalia. Resolve to `EHEZA_SITE` + `PANTHEON_NAME` via the shared site table.
+2. **Source branch to deploy** — any git branch (default: the current branch). This is what gets *built*; it is independent of the multidev env name.
+3. **Target multidev env name** — the existing Pantheon multidev environment to deploy into (e.g. `review-x`). The build is pushed to the Pantheon branch of the same name.
+
+Confirm the plan back in one line (site, `PANTHEON_NAME`, source branch → multidev `<env>`) before proceeding.
+
+## Step 1 — Preflight checks (🟢 you run; all must pass)
+
+Report a ✅/❌ checklist. **Stop and surface any ❌.**
+
+1. **Config matches the target site.** Read `.ddev/config.local.yaml`; confirm `EHEZA_SITE` and `PANTHEON_NAME` equal the chosen site's values.
+   - If not: tell the user to fix `.ddev/config.local.yaml` **and then `ddev restart`** (web_environment vars only reload on restart). Wrong `PANTHEON_NAME` pushes to the **wrong Pantheon site**.
+2. **Source branch exists & working tree clean.** The branch is real, and the eheza-app working tree has no *tracked* changes (the deploy aborts on tracked changes; untracked files like `.ddev/` are ignored):
+   ```bash
+   git rev-parse --verify <source-branch>   # exists locally...
+   git ls-remote --heads origin <source-branch>   # ...or on origin
+   git status -s -uno                        # expect empty (no tracked changes)
+   ```
+3. **Pantheon clone exists, clean, and has the target multidev branch.** The deploy runs `git checkout <env>` inside the clone and aborts with *"Specified branch `<env>` does not exist"* if that branch isn't there:
+   ```bash
+   git -C server/.pantheon-<PANTHEON_NAME> status -s -uno              # clean
+   git -C server/.pantheon-<PANTHEON_NAME> fetch origin                # refresh
+   git -C server/.pantheon-<PANTHEON_NAME> rev-parse --verify <env> 2>/dev/null \
+     || git -C server/.pantheon-<PANTHEON_NAME> rev-parse --verify origin/<env>
+   ```
+   - If the multidev branch is missing: the env must exist on Pantheon first. Tell the user to create the multidev environment in the Pantheon dashboard (or via terminus), then in the clone `git fetch origin && git checkout <env>`. Without it, the deploy can't proceed.
+
+## Step 2 — Local prep
+
+- 🟢 You run: `git checkout <source-branch> && git pull` (pull only if it tracks a remote).
+- 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
+- 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client from the checked-out branch. Long; let it finish.
+
+## Step 3 — Deploy to the multidev env
+
+🔴 User runs (paused): `ddev robo deploy:pantheon <env>`
+
+Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect.
+
+What this does automatically (so you don't double-run it): rsyncs the build into the clone, checks out the `<env>` branch, commits + pushes to it, then runs on that **multidev** env `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`, and it touches **only** that multidev env.
+
+## Step 4 — Post-deploy
+
+🔴 User runs (paused) — the one step the robo command skips:
+```bash
+ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features revert all
+```
+Then verify: open the `uli` login link from the deploy output (or the multidev URL `https://<env>-<PANTHEON_NAME>.pantheonsite.io`) and smoke-test. Run any manual steps the change introduced.
+
+---
+
+## Wrap-up
+
+Report: site, `PANTHEON_NAME`, source branch, multidev `<env>` deployed to, and that `fra` was run. No Test/Live promotion and no release happen here — for that, switch to `deploy-release`. Note any preflight ❌ that blocked progress.

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -66,7 +66,7 @@ Report a ✅/❌ checklist. **Stop and surface any ❌.**
    ```bash
    ddev exec terminus auth:whoami   # expect an email, not "You are not logged in"
    ```
-   - If not logged in: set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see shared reference) and `ddev restart`, or run `ddev exec terminus auth:login --machine-token=<token>`.
+   - If not logged in: run **`ddev terminus-auth`** (logs terminus in from `TERMINUS_MACHINE_TOKEN`, or `ddev terminus-auth <token>`). If the token isn't set yet, add `TERMINUS_MACHINE_TOKEN` to `.ddev/config.local.yaml` (see shared reference) and `ddev restart`.
 
 ## Step 2 — Local prep
 

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -45,7 +45,7 @@ Confirm the plan back in one line (site, `PANTHEON_NAME`, source branch → mult
 Report a ✅/❌ checklist. **Stop and surface any ❌.**
 
 1. **Config matches the target site.** Read `.ddev/config.local.yaml`; confirm `EHEZA_SITE` and `PANTHEON_NAME` equal the chosen site's values.
-   - If not: tell the user to fix `.ddev/config.local.yaml`, then restart so the new `web_environment` vars load (they only reload on restart). **Before restarting, ask (AskUserQuestion) whether to reinstall the project on restart — default No** (No = leave the `post-start` hook as-is, only `ddev client-install` runs; Yes = first uncomment the full commented `post-start` block — see *Reinstall-on-restart toggle* in the shared reference). Then `ddev restart`. Wrong `PANTHEON_NAME` pushes to the **wrong Pantheon site**.
+   - If not: tell the user to fix `.ddev/config.local.yaml` (the mandatory restart in Step 2 loads the new values). Wrong `PANTHEON_NAME` pushes to the **wrong Pantheon site**.
 2. **Source branch exists & working tree clean.** The branch is real, and the eheza-app working tree has no *tracked* changes (the deploy aborts on tracked changes; untracked files like `.ddev/` are ignored):
    ```bash
    git rev-parse --verify <source-branch>   # exists locally...
@@ -63,9 +63,13 @@ Report a ✅/❌ checklist. **Stop and surface any ❌.**
 
 ## Step 2 — Local prep
 
-- 🟢 You run: `git checkout <source-branch> && git pull` (pull only if it tracks a remote).
-- 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
-- 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client from the checked-out branch. Long; let it finish.
+1. 🟢 You run: `git checkout <source-branch> && git pull` (pull only if it tracks a remote).
+2. **Restart DDEV — always, deciding reinstall first.** Ask the user (AskUserQuestion) whether to reinstall the project on this restart — **default No**:
+   - **No (default):** ensure the `post-start` hook in `.ddev/config.local.yaml` is in its default state (only `- exec-host: ddev client-install` active; everything below commented). No reinstall.
+   - **Yes:** uncomment the entire commented `post-start` block (see *Reinstall-on-restart toggle* in the shared reference) so the restart runs `site-install` + migrations + feature flags for the selected `$EHEZA_SITE`. Re-comment afterward if future restarts shouldn't reinstall.
+   Then run `ddev restart` (local-only and safe to run; the reinstall answer is the confirmation for the destructive local-DB wipe a reinstall performs).
+3. 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
+4. 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client from the checked-out branch. Long; let it finish.
 
 ## Step 3 — Deploy to the multidev env
 

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -45,7 +45,7 @@ Confirm the plan back in one line (site, `PANTHEON_NAME`, source branch → mult
 Report a ✅/❌ checklist. **Stop and surface any ❌.**
 
 1. **Config matches the target site.** Read `.ddev/config.local.yaml`; confirm `EHEZA_SITE` and `PANTHEON_NAME` equal the chosen site's values.
-   - If not: tell the user to fix `.ddev/config.local.yaml` **and then `ddev restart`** (web_environment vars only reload on restart). Wrong `PANTHEON_NAME` pushes to the **wrong Pantheon site**.
+   - If not: tell the user to fix `.ddev/config.local.yaml`, then restart so the new `web_environment` vars load (they only reload on restart). **Before restarting, ask (AskUserQuestion) whether to reinstall the project on restart — default No** (No = leave the `post-start` hook as-is, only `ddev client-install` runs; Yes = first uncomment the full commented `post-start` block — see *Reinstall-on-restart toggle* in the shared reference). Then `ddev restart`. Wrong `PANTHEON_NAME` pushes to the **wrong Pantheon site**.
 2. **Source branch exists & working tree clean.** The branch is real, and the eheza-app working tree has no *tracked* changes (the deploy aborts on tracked changes; untracked files like `.ddev/` are ignored):
    ```bash
    git rev-parse --verify <source-branch>   # exists locally...

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -15,7 +15,7 @@ This skill deploys a chosen **git branch** to a Pantheon **multidev** (review/fe
 
 You (Claude) **drive every step except the deploy command itself** — that one needs a human to review the change-set.
 
-- 🟢 **You run** (via Bash on the host): git prep, all preflight checks, `ddev restart`, `ddev auth ssh`, `ddev gulp publish`, the terminus auth check/login, and the post-deploy `terminus remote:drush` / `fra`. None of these are destructive, and on a normal ddev setup they're non-interactive (SSH keys are already in the agent, `TERMINUS_MACHINE_TOKEN` is in the env). Only hand `ddev auth ssh` to the user if it actually prompts for a key passphrase.
+- 🟢 **You run** (via Bash on the host): git prep, all preflight checks, `ddev restart`, `ddev auth ssh`, `ddev gulp publish`, and the terminus auth check/login. (The deploy command itself runs the post-deploy `cc`/`updb`/`fra`/`uli`.) None of these are destructive, and on a normal ddev setup they're non-interactive (SSH keys are already in the agent, `TERMINUS_MACHINE_TOKEN` is in the env). Only hand `ddev auth ssh` to the user if it actually prompts for a key passphrase.
 - 🔴 **User runs — only `ddev robo deploy:pantheon <env>`.** It prints a `git status` of the Pantheon clone and an interactive **"Commit changes and deploy?"** prompt, so a human must review the change-set before confirming. **Offer it tee'd to a log** so you read the outcome yourself instead of asking for a paste:
   ```bash
   ddev robo deploy:pantheon <env> 2>&1 | tee /tmp/deploy-<env>.log
@@ -84,17 +84,13 @@ Report a ✅/❌ checklist. **Stop and surface any ❌.**
 ```bash
 ddev robo deploy:pantheon <env> 2>&1 | tee /tmp/deploy-<env>.log
 ```
-Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon clone** and confirm only if the change-set is exactly what they expect. When it returns, `Read` `/tmp/deploy-<env>.log` to verify the push + auto-run `cc all`/`updb`/`uli` — don't ask for a paste.
+Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon clone** and confirm only if the change-set is exactly what they expect. When it returns, `Read` `/tmp/deploy-<env>.log` to verify the push + auto-run `cc all`/`updb`/`fra`/`uli` — don't ask for a paste.
 
-What this does automatically (so you don't double-run it): rsyncs the build into the clone, checks out the `<env>` branch, commits + pushes to it, then runs on that **multidev** env `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`, and it touches **only** that multidev env.
+What this does automatically (so you don't double-run it): rsyncs the build into the clone, checks out the `<env>` branch, commits + pushes to it, then runs on that **multidev** env `cc all` (twice), `updb -y`, **`fra -y`**, **`cc all`**, and `uli`. It touches **only** that multidev env.
 
-## Step 4 — Post-deploy
+## Step 4 — Post-deploy / verify
 
-🟢 You run — the one step the robo command skips:
-```bash
-ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features revert all
-```
-Then verify: open the `uli` login link from the deploy output (or the multidev URL `https://<env>-<PANTHEON_NAME>.pantheonsite.io`) and smoke-test. Run any manual steps the change introduced.
+The deploy already ran `cc all`/`updb`/`fra`/`cc all`/`uli` itself — confirm in the log. So just verify: open the `uli` login link from the deploy output (or the multidev URL `https://<env>-<PANTHEON_NAME>.pantheonsite.io`) and smoke-test. Run any manual steps the change introduced (new variables, migrations).
 
 ---
 

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -13,12 +13,14 @@ This skill deploys a chosen **git branch** to a Pantheon **multidev** (review/fe
 
 ## Execution model — who runs what
 
-You (Claude) **drive the safe steps** and **pause at the risky ones**. Never run a step marked 🔴 yourself.
+You (Claude) **drive every step except the deploy command itself** — that one needs a human to review the change-set.
 
-- 🟢 **You run** (via Bash on the host): git prep (checkout/pull the source branch) and all read-only preflight checks.
-- 🔴 **User runs** (give them the exact command; they run it with `! <command>` so output lands here, then you continue): `ddev auth ssh`, `ddev gulp publish`, `ddev robo deploy:pantheon <env>`, and post-deploy `fra`.
-
-Pausing matters because `ddev robo deploy:pantheon <env>` shows a `git status` of the Pantheon repo and an interactive **"Commit changes and deploy?"** prompt — a human must review that change-set before confirming. `ddev auth ssh` is also interactive.
+- 🟢 **You run** (via Bash on the host): git prep, all preflight checks, `ddev restart`, `ddev auth ssh`, `ddev gulp publish`, the terminus auth check/login, and the post-deploy `terminus remote:drush` / `fra`. None of these are destructive, and on a normal ddev setup they're non-interactive (SSH keys are already in the agent, `TERMINUS_MACHINE_TOKEN` is in the env). Only hand `ddev auth ssh` to the user if it actually prompts for a key passphrase.
+- 🔴 **User runs — only `ddev robo deploy:pantheon <env>`.** It prints a `git status` of the Pantheon clone and an interactive **"Commit changes and deploy?"** prompt, so a human must review the change-set before confirming. **Offer it tee'd to a log** so you read the outcome yourself instead of asking for a paste:
+  ```bash
+  ddev robo deploy:pantheon <env> 2>&1 | tee /tmp/deploy-<env>.log
+  ```
+  Once it returns, `Read` `/tmp/deploy-<env>.log` to confirm the push and the auto-run `cc all`/`updb`/`uli`.
 
 **One site per run.**
 
@@ -73,20 +75,22 @@ Report a ✅/❌ checklist. **Stop and surface any ❌.**
    - **No (default):** ensure the `post-start` hook in `.ddev/config.local.yaml` is in its default state (only `- exec-host: ddev client-install` active; everything below commented). No reinstall.
    - **Yes:** uncomment the entire commented `post-start` block (see *Reinstall-on-restart toggle* in the shared reference) so the restart runs `site-install` + migrations + feature flags for the selected `$EHEZA_SITE`. Re-comment afterward if future restarts shouldn't reinstall.
    Then run `ddev restart` (local-only and safe to run; the reinstall answer is the confirmation for the destructive local-DB wipe a reinstall performs).
-3. 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
-4. 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client from the checked-out branch. Long; let it finish.
+3. 🟢 You run: `ddev auth ssh` — injects SSH keys so the deploy can push to Pantheon. (Hand to the user only if it prompts for a key passphrase.)
+4. 🟢 You run: `ddev gulp publish` — minified production build of the Elm client from the checked-out branch. Long (allow several minutes); let it finish before deploying.
 
 ## Step 3 — Deploy to the multidev env
 
-🔴 User runs (paused): `ddev robo deploy:pantheon <env>`
-
-Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect.
+🔴 User runs (the one human-review step) — offer it **tee'd to a log** so you read the outcome yourself:
+```bash
+ddev robo deploy:pantheon <env> 2>&1 | tee /tmp/deploy-<env>.log
+```
+Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon clone** and confirm only if the change-set is exactly what they expect. When it returns, `Read` `/tmp/deploy-<env>.log` to verify the push + auto-run `cc all`/`updb`/`uli` — don't ask for a paste.
 
 What this does automatically (so you don't double-run it): rsyncs the build into the clone, checks out the `<env>` branch, commits + pushes to it, then runs on that **multidev** env `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`, and it touches **only** that multidev env.
 
 ## Step 4 — Post-deploy
 
-🔴 User runs (paused) — the one step the robo command skips:
+🟢 You run — the one step the robo command skips:
 ```bash
 ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features revert all
 ```

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -1,50 +1,43 @@
 ---
 name: deploy-release
-description: Guide and perform an E-Heza deploy to Pantheon for ONE site, then optionally promote Dev→Test→Live and cut the GitHub release + changelog. Trigger when the user wants to deploy, release, ship, push to Pantheon, promote to Test/Live, go live, or generate release notes for a site (rwanda / burundi / somalia). Drives the safe/preparatory steps itself and pauses for the interactive or production-affecting commands.
+description: Guide and perform a FULL E-Heza production release for ONE site — build from `main`, deploy to Pantheon Dev, promote Dev → Test → Live, then cut the GitHub release + changelog. Trigger when the user wants to release, ship to production, go live, promote to Test/Live, or generate release notes for a site (rwanda / burundi / somalia). For deploying an arbitrary branch to a multidev/review env instead, use the `deploy-multidev` skill. Drives the safe steps itself and pauses for the interactive or production-affecting commands.
 ---
 
-# Deploy & Release (E-Heza → Pantheon)
+# Full Release (E-Heza → Pantheon, `main` → Live)
 
-This skill walks one **single site** through deploy → (optionally) Test/Live promotion → GitHub release. It mirrors the team runbook at https://github.com/Gizra/ihangane/wiki/Deployment and the commands in `server/RoboFile.php`.
+This skill performs a **full production release** for one **single site**: build from `main`, deploy to Pantheon **Dev**, promote **Dev → Test → Live**, then cut the **GitHub release + changelog**. It mirrors the runbook at https://github.com/Gizra/ihangane/wiki/Deployment and the commands in `server/RoboFile.php`.
+
+> Just need to push a branch to a multidev/review env for testing? Use the **`deploy-multidev`** skill — this one is production-only and `main`-only.
+
+**Shared reference** (site table, RoboFile internals, one-time Pantheon clone setup, troubleshooting): **`.claude/skills/_deploy-common/deploy-reference.md`** — read it before running.
 
 ## Execution model — who runs what
 
 You (Claude) **drive the safe steps** and **pause at the risky ones**. Never run a step marked 🔴 yourself.
 
 - 🟢 **You run** (via Bash on the host): git prep on `main`, all read-only preflight checks, tag math, `generate:release-notes`, and the GitHub release (`gh`).
-- 🔴 **User runs** (tell them the exact command; they run it with `! <command>` so output lands here, then you continue): anything interactive or production-affecting — `ddev auth ssh`, `ddev gulp publish`, `ddev robo deploy:pantheon`, `ddev robo deploy:pantheon-sync`, and post-deploy `fra`.
+- 🔴 **User runs** (give them the exact command; they run it with `! <command>` so output lands here, then you continue): anything interactive or production-affecting — `ddev auth ssh`, `ddev gulp publish`, `ddev robo deploy:pantheon`, `ddev robo deploy:pantheon-sync`, and post-deploy `fra`.
 
 Pausing matters because `ddev robo deploy:pantheon` shows a `git status` of the Pantheon repo and an interactive **"Commit changes and deploy?"** prompt — a human must review that change-set before confirming. `ddev auth ssh` is also interactive.
 
-**One site per run.** To deploy several sites, finish this flow, then re-invoke the skill for the next site.
+**One site per run.** To release several sites, finish this flow, then re-invoke for the next site.
 
-## Site → config mapping (memorize before anything else)
+## Site → config mapping
 
-| Target          | `EHEZA_SITE` | `PANTHEON_NAME` | Pantheon clone dir (under `server/`) |
-| --------------- | ------------ | --------------- | ------------------------------------ |
-| Rwanda          | `rwanda`     | `ihangane`      | `.pantheon-ihangane`                 |
-| Burundi (vhw)   | `burundi`    | `vhw`           | `.pantheon-vhw`                      |
-| Burundi (uvl)   | `burundi`    | `uvl`           | `.pantheon-uvl`                      |
-| Somalia         | `somalia`    | `tip-somalia`   | `.pantheon-tip-somalia`             |
+Look up the chosen site's `EHEZA_SITE`, `PANTHEON_NAME`, and Pantheon clone dir (`server/.pantheon-<PANTHEON_NAME>`) in the **site table** in `.claude/skills/_deploy-common/deploy-reference.md`.
 
-⚠️ Two distinct Burundi sites share `EHEZA_SITE=burundi` but have different `PANTHEON_NAME`. Always pin the exact Pantheon site with the user — never assume "burundi".
+⚠️ Two distinct Burundi sites (`vhw`, `uvl`) share `EHEZA_SITE=burundi` but have different `PANTHEON_NAME`. Always pin the exact Pantheon site with the user — never assume "burundi".
 
 ---
 
 ## Step 0 — Gather inputs (ask the user)
 
-Use **AskUserQuestion** to collect:
+This skill always runs the **full path** (`main` → Dev → Test → Live). Use **AskUserQuestion** to collect:
 
-1. **Target site** — Rwanda / Burundi-vhw / Burundi-uvl / Somalia. Resolve to `EHEZA_SITE` + `PANTHEON_NAME` from the table.
-2. **What to do** —
-   - *Deploy to Dev* (push Pantheon `master`) — the normal path.
-   - *Deploy to a multidev env* (feature env by branch name).
-   - *Promote Dev → Test*.
-   - *Promote Test → Live*.
-   - *Full release*: Deploy to Dev → promote to Test → promote to Live → cut GitHub release.
-3. **Cut a GitHub release at the end?** (yes/no) — only relevant once code is on Live.
+1. **Target site** — Rwanda / Burundi-vhw / Burundi-uvl / Somalia. Resolve to `EHEZA_SITE` + `PANTHEON_NAME` via the shared site table.
+2. **Cut the GitHub release at the end?** (yes/no) — the tag + changelog + GitHub release, done once code is on Live.
 
-Confirm the resolved plan back to the user in one line (site, `PANTHEON_NAME`, target env, release y/n) before proceeding.
+Confirm the plan back in one line (site, `PANTHEON_NAME`, full release to Live, release-notes y/n) before proceeding.
 
 ## Step 1 — Preflight checks (🟢 you run; all must pass before deploying)
 
@@ -63,7 +56,7 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
    ```bash
    git -C server/.pantheon-<PANTHEON_NAME> status -s -uno
    ```
-   If the directory is missing, point the user to the one-time clone command in the wiki / reference file — they must create it before deploying.
+   If the directory is missing, point the user to the one-time clone command in the shared reference — they must create it before deploying.
 
 ## Step 2 — Local prep
 
@@ -71,20 +64,17 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
 - 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
 - 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client. This is long; let it finish before deploying.
 
-## Step 3 — Deploy
+## Step 3 — Deploy to Dev
 
-🔴 User runs (paused). Pick by target env:
-
-- **Dev:** `ddev robo deploy:pantheon`
-- **Multidev `<env>`:** `ddev robo deploy:pantheon <env>`
+🔴 User runs (paused): `ddev robo deploy:pantheon`
 
 Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect.
 
-What this command does automatically (so you don't double-run it): rsyncs the build into the Pantheon clone, commits + pushes, then runs on that env `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`.
+What this command does automatically (so you don't double-run it): rsyncs the build into the Pantheon clone, commits + pushes to Pantheon `master`, then runs on **Dev** `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`.
 
-> Pantheon's `master` branch = the **Dev** environment, not production. Deploying to `master` only updates Dev.
+> Pantheon's `master` branch = the **Dev** environment, not production. This step only updates Dev; promotion to Test/Live is Step 5.
 
-## Step 4 — Post-deploy (every env you touched)
+## Step 4 — Post-deploy (every env you touch)
 
 🔴 User runs (paused) — the one step the robo command skips:
 ```bash
@@ -92,7 +82,7 @@ ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features rev
 ```
 Then sanity-check the env (open the `uli` login link from the deploy output, smoke-test the app). If the deploy added manual steps (new variables, migrations), run those too.
 
-## Step 5 — Promote Dev → Test → Live (only for a full release / promotion)
+## Step 5 — Promote Dev → Test → Live
 
 Do these **in order**, pausing for the user and re-verifying between each. Each `deploy:pantheon-sync` runs `terminus env:deploy` then `cc all`×2 + `updb -y` + `uli` on that env (but again **not** `fra`).
 
@@ -102,7 +92,7 @@ Do these **in order**, pausing for the user and re-verifying between each. Each 
 
 (Equivalent GUI path: Pantheon dashboard → Test tab → confirm deploy → Live tab → confirm deploy.)
 
-## Step 6 — Cut the GitHub release (only after code is on Live, if requested)
+## Step 6 — Cut the GitHub release (after code is on Live, if requested)
 
 Run from the **eheza-app** repo (`origin` = `TIP-Global-Health/eheza-app`).
 
@@ -135,6 +125,6 @@ Run from the **eheza-app** repo (`origin` = `TIP-Global-Health/eheza-app`).
 
 ## Wrap-up
 
-Report what was deployed: site, `PANTHEON_NAME`, each env reached (Dev/Test/Live), `fra` run per env, and the release tag/URL if cut. Note anything skipped or any preflight ❌ that blocked progress.
+Report what was released: site, `PANTHEON_NAME`, each env reached (Dev/Test/Live), `fra` run per env, and the release tag/URL if cut. Note anything skipped or any preflight ❌ that blocked progress.
 
-For deeper details (RoboFile internals, the one-time Pantheon clone setup, troubleshooting preflight failures), see `references/deploy-reference.md`.
+For deeper details (RoboFile internals, the one-time Pantheon clone setup, troubleshooting preflight failures), see `.claude/skills/_deploy-common/deploy-reference.md`.

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -57,6 +57,11 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
    git -C server/.pantheon-<PANTHEON_NAME> status -s -uno
    ```
    If the directory is missing, point the user to the one-time clone command in the shared reference — they must create it before deploying.
+5. **Terminus authenticated.** `ddev auth ssh` covers the git *push* to Pantheon, but the post-deploy/promotion `terminus remote:drush` (`cc all` / `updb` / `uli`) and `fra` have separate auth — without it the deploy pushes code and *then* fails with *"You are not logged in"*, leaving the env on new code with a stale cache/registry:
+   ```bash
+   ddev exec terminus auth:whoami   # expect an email, not "You are not logged in"
+   ```
+   - If not logged in: set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see shared reference) and `ddev restart`, or run `ddev exec terminus auth:login --machine-token=<token>`.
 
 ## Step 2 — Local prep
 

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: deploy-release
+description: Guide and perform an E-Heza deploy to Pantheon for ONE site, then optionally promote Dev→Test→Live and cut the GitHub release + changelog. Trigger when the user wants to deploy, release, ship, push to Pantheon, promote to Test/Live, go live, or generate release notes for a site (rwanda / burundi / somalia). Drives the safe/preparatory steps itself and pauses for the interactive or production-affecting commands.
+---
+
+# Deploy & Release (E-Heza → Pantheon)
+
+This skill walks one **single site** through deploy → (optionally) Test/Live promotion → GitHub release. It mirrors the team runbook at https://github.com/Gizra/ihangane/wiki/Deployment and the commands in `server/RoboFile.php`.
+
+## Execution model — who runs what
+
+You (Claude) **drive the safe steps** and **pause at the risky ones**. Never run a step marked 🔴 yourself.
+
+- 🟢 **You run** (via Bash on the host): git prep on `main`, all read-only preflight checks, tag math, `generate:release-notes`, and the GitHub release (`gh`).
+- 🔴 **User runs** (tell them the exact command; they run it with `! <command>` so output lands here, then you continue): anything interactive or production-affecting — `ddev auth ssh`, `ddev gulp publish`, `ddev robo deploy:pantheon`, `ddev robo deploy:pantheon-sync`, and post-deploy `fra`.
+
+Pausing matters because `ddev robo deploy:pantheon` shows a `git status` of the Pantheon repo and an interactive **"Commit changes and deploy?"** prompt — a human must review that change-set before confirming. `ddev auth ssh` is also interactive.
+
+**One site per run.** To deploy several sites, finish this flow, then re-invoke the skill for the next site.
+
+## Site → config mapping (memorize before anything else)
+
+| Target          | `EHEZA_SITE` | `PANTHEON_NAME` | Pantheon clone dir (under `server/`) |
+| --------------- | ------------ | --------------- | ------------------------------------ |
+| Rwanda          | `rwanda`     | `ihangane`      | `.pantheon-ihangane`                 |
+| Burundi (vhw)   | `burundi`    | `vhw`           | `.pantheon-vhw`                      |
+| Burundi (uvl)   | `burundi`    | `uvl`           | `.pantheon-uvl`                      |
+| Somalia         | `somalia`    | `tip-somalia`   | `.pantheon-tip-somalia`             |
+
+⚠️ Two distinct Burundi sites share `EHEZA_SITE=burundi` but have different `PANTHEON_NAME`. Always pin the exact Pantheon site with the user — never assume "burundi".
+
+---
+
+## Step 0 — Gather inputs (ask the user)
+
+Use **AskUserQuestion** to collect:
+
+1. **Target site** — Rwanda / Burundi-vhw / Burundi-uvl / Somalia. Resolve to `EHEZA_SITE` + `PANTHEON_NAME` from the table.
+2. **What to do** —
+   - *Deploy to Dev* (push Pantheon `master`) — the normal path.
+   - *Deploy to a multidev env* (feature env by branch name).
+   - *Promote Dev → Test*.
+   - *Promote Test → Live*.
+   - *Full release*: Deploy to Dev → promote to Test → promote to Live → cut GitHub release.
+3. **Cut a GitHub release at the end?** (yes/no) — only relevant once code is on Live.
+
+Confirm the resolved plan back to the user in one line (site, `PANTHEON_NAME`, target env, release y/n) before proceeding.
+
+## Step 1 — Preflight checks (🟢 you run; all must pass before deploying)
+
+Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not deploy past a failure.**
+
+1. **Config matches the target site.** Read `.ddev/config.local.yaml` and confirm `EHEZA_SITE` and `PANTHEON_NAME` equal the chosen site's values.
+   - If they don't match: tell the user to fix `.ddev/config.local.yaml` **and then run `ddev restart`** (web_environment vars only reload on restart). This is the #1 footgun — wrong `PANTHEON_NAME` pushes code to the **wrong Pantheon site**; wrong `EHEZA_SITE` builds the wrong site's data/config.
+2. **`main` clean & level with `origin/main`.** Step 2 runs `git checkout main`, so you need not be sitting on `main` now — but it must be deploy-ready: in sync with the remote and free of *tracked* changes. The deploy aborts only on **tracked** changes; untracked files (e.g. `.ddev/`, `server/.pantheon-*`) are ignored, so check with `-uno` (not `-sb`, which would false-alarm on those):
+   ```bash
+   git fetch origin main --tags
+   git rev-list --left-right --count main...origin/main   # expect "0	0" (level with origin/main)
+   git status -s -uno                                     # expect empty (no tracked changes)
+   ```
+3. **All intended PRs merged into `main`.** Ask the user to confirm the release content is fully merged (you can show `git log --oneline origin/main -5` for context).
+4. **Pantheon clone exists & clean.** Confirm `server/.pantheon-<PANTHEON_NAME>/` exists and is clean:
+   ```bash
+   git -C server/.pantheon-<PANTHEON_NAME> status -s -uno
+   ```
+   If the directory is missing, point the user to the one-time clone command in the wiki / reference file — they must create it before deploying.
+
+## Step 2 — Local prep
+
+- 🟢 You run: `git checkout main && git pull`.
+- 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
+- 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client. This is long; let it finish before deploying.
+
+## Step 3 — Deploy
+
+🔴 User runs (paused). Pick by target env:
+
+- **Dev:** `ddev robo deploy:pantheon`
+- **Multidev `<env>`:** `ddev robo deploy:pantheon <env>`
+
+Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect.
+
+What this command does automatically (so you don't double-run it): rsyncs the build into the Pantheon clone, commits + pushes, then runs on that env `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`.
+
+> Pantheon's `master` branch = the **Dev** environment, not production. Deploying to `master` only updates Dev.
+
+## Step 4 — Post-deploy (every env you touched)
+
+🔴 User runs (paused) — the one step the robo command skips:
+```bash
+ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features revert all
+```
+Then sanity-check the env (open the `uli` login link from the deploy output, smoke-test the app). If the deploy added manual steps (new variables, migrations), run those too.
+
+## Step 5 — Promote Dev → Test → Live (only for a full release / promotion)
+
+Do these **in order**, pausing for the user and re-verifying between each. Each `deploy:pantheon-sync` runs `terminus env:deploy` then `cc all`×2 + `updb -y` + `uli` on that env (but again **not** `fra`).
+
+1. 🔴 `ddev robo deploy:pantheon-sync test` → then Step 4 `fra` on `test` → verify on the Test URL.
+2. Pause for explicit user go-ahead (this next one hits production).
+3. 🔴 `ddev robo deploy:pantheon-sync live` → then Step 4 `fra` on `live` → verify on the Live URL.
+
+(Equivalent GUI path: Pantheon dashboard → Test tab → confirm deploy → Live tab → confirm deploy.)
+
+## Step 6 — Cut the GitHub release (only after code is on Live, if requested)
+
+Run from the **eheza-app** repo (`origin` = `TIP-Global-Health/eheza-app`).
+
+1. 🟢 Find the latest tag (this becomes the *previous* tag for the changelog):
+   ```bash
+   git fetch --tags origin
+   git describe --tags --abbrev=0 origin/main
+   ```
+2. Decide the next tag **with the user**: patch bump (`v1.17.1 → v1.17.2`) for minor changes, minor bump (`→ v1.18.0`) for a new feature. Confirm before tagging.
+3. 🟢 Create & push the new tag:
+   ```bash
+   git tag <new-tag> && git push origin <new-tag>
+   ```
+4. 🟢 Generate the changelog — **pass the PREVIOUS tag**, since `generate:release-notes` lists changes *since* the tag you give it:
+   ```bash
+   ddev robo generate:release-notes <previous-tag>
+   ```
+5. 🟢 Draft the release with `gh` (or hand the user the GitHub "new release" URL). Use the new tag, target `main`, title `Release <new-number>`. The body's first line states the deploy date and sites, e.g. `Deployed in production on <Month DD, YYYY> (<sites>)`, followed by the generator output starting at `## Changelog`:
+   ```bash
+   gh release create <new-tag> --target main --title "Release <new-number>" --notes "$(cat <<'EOF'
+   Deployed in production on <Month DD, YYYY> (<sites>)
+
+   <## Changelog ... output>
+   EOF
+   )"
+   ```
+   Confirm the date and site list with the user before publishing.
+
+---
+
+## Wrap-up
+
+Report what was deployed: site, `PANTHEON_NAME`, each env reached (Dev/Test/Live), `fra` run per env, and the release tag/URL if cut. Note anything skipped or any preflight ❌ that blocked progress.
+
+For deeper details (RoboFile internals, the one-time Pantheon clone setup, troubleshooting preflight failures), see `references/deploy-reference.md`.

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -13,12 +13,14 @@ This skill performs a **full production release** for one **single site**: build
 
 ## Execution model — who runs what
 
-You (Claude) **drive the safe steps** and **pause at the risky ones**. Never run a step marked 🔴 yourself.
+You (Claude) **drive every step except the deploy/promote commands** — those move code to Dev/Test/Live and need a human to review and confirm.
 
-- 🟢 **You run** (via Bash on the host): git prep on `main`, all read-only preflight checks, tag math, `generate:release-notes`, and the GitHub release (`gh`).
-- 🔴 **User runs** (give them the exact command; they run it with `! <command>` so output lands here, then you continue): anything interactive or production-affecting — `ddev auth ssh`, `ddev gulp publish`, `ddev robo deploy:pantheon`, `ddev robo deploy:pantheon-sync`, and post-deploy `fra`.
-
-Pausing matters because `ddev robo deploy:pantheon` shows a `git status` of the Pantheon repo and an interactive **"Commit changes and deploy?"** prompt — a human must review that change-set before confirming. `ddev auth ssh` is also interactive.
+- 🟢 **You run** (via Bash on the host): git prep on `main`, all preflight checks, `ddev restart`, `ddev auth ssh`, `ddev gulp publish`, the terminus auth check/login, the post-deploy `fra`, plus tag math, `generate:release-notes`, and the GitHub release (`gh`). None of these are destructive, and on a normal ddev setup they're non-interactive (SSH keys in the agent, `TERMINUS_MACHINE_TOKEN` in the env). Only hand `ddev auth ssh` to the user if it prompts for a key passphrase.
+- 🔴 **User runs — the deploy/promote commands only**: `ddev robo deploy:pantheon` (Dev) and `ddev robo deploy:pantheon-sync test|live`. **Offer each tee'd to a log** so you read the outcome yourself instead of asking for a paste:
+  ```bash
+  ddev robo deploy:pantheon 2>&1 | tee /tmp/deploy-dev.log
+  ```
+  `deploy:pantheon` has an interactive **"Commit changes and deploy?"** prompt (a human must review the change-set before confirming), and the Test→Live promotions are production, so a human triggers them. After each returns, `Read` its log.
 
 **One site per run.** To release several sites, finish this flow, then re-invoke for the next site.
 
@@ -70,14 +72,16 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
    - **No (default):** ensure the `post-start` hook in `.ddev/config.local.yaml` is in its default state (only `- exec-host: ddev client-install` active; everything below commented). No reinstall.
    - **Yes:** uncomment the entire commented `post-start` block (see *Reinstall-on-restart toggle* in the shared reference) so the restart runs `site-install` + migrations + feature flags for the selected `$EHEZA_SITE`. Re-comment afterward if future restarts shouldn't reinstall.
    Then run `ddev restart` (local-only and safe to run; the reinstall answer is the confirmation for the destructive local-DB wipe a reinstall performs).
-3. 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
-4. 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client. This is long; let it finish before deploying.
+3. 🟢 You run: `ddev auth ssh` — injects SSH keys so the deploy can push to Pantheon. (Hand to the user only if it prompts for a key passphrase.)
+4. 🟢 You run: `ddev gulp publish` — minified production build of the Elm client. Long (allow several minutes); let it finish before deploying.
 
 ## Step 3 — Deploy to Dev
 
-🔴 User runs (paused): `ddev robo deploy:pantheon`
-
-Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect.
+🔴 User runs (the one human-review step) — offer it **tee'd to a log** so you read the outcome yourself:
+```bash
+ddev robo deploy:pantheon 2>&1 | tee /tmp/deploy-dev.log
+```
+Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect. When it returns, `Read` `/tmp/deploy-dev.log` to verify the push + auto-run `cc all`/`updb`/`uli` — don't ask for a paste.
 
 What this command does automatically (so you don't double-run it): rsyncs the build into the Pantheon clone, commits + pushes to Pantheon `master`, then runs on **Dev** `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`.
 
@@ -85,7 +89,7 @@ What this command does automatically (so you don't double-run it): rsyncs the bu
 
 ## Step 4 — Post-deploy (every env you touch)
 
-🔴 User runs (paused) — the one step the robo command skips:
+🟢 You run — the one step the robo command skips:
 ```bash
 ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features revert all
 ```
@@ -95,9 +99,9 @@ Then sanity-check the env (open the `uli` login link from the deploy output, smo
 
 Do these **in order**, pausing for the user and re-verifying between each. Each `deploy:pantheon-sync` runs `terminus env:deploy` then `cc all`×2 + `updb -y` + `uli` on that env (but again **not** `fra`).
 
-1. 🔴 `ddev robo deploy:pantheon-sync test` → then Step 4 `fra` on `test` → verify on the Test URL.
+1. 🔴 User runs (tee'd): `ddev robo deploy:pantheon-sync test 2>&1 | tee /tmp/deploy-test.log` → `Read` the log → then you run Step 4 `fra` on `test` (🟢) → verify on the Test URL.
 2. Pause for explicit user go-ahead (this next one hits production).
-3. 🔴 `ddev robo deploy:pantheon-sync live` → then Step 4 `fra` on `live` → verify on the Live URL.
+3. 🔴 User runs (tee'd): `ddev robo deploy:pantheon-sync live 2>&1 | tee /tmp/deploy-live.log` → `Read` the log → then you run Step 4 `fra` on `live` (🟢) → verify on the Live URL.
 
 (Equivalent GUI path: Pantheon dashboard → Test tab → confirm deploy → Live tab → confirm deploy.)
 

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -44,10 +44,7 @@ Confirm the plan back in one line (site, `PANTHEON_NAME`, full release to Live, 
 Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not deploy past a failure.**
 
 1. **Config matches the target site.** Read `.ddev/config.local.yaml` and confirm `EHEZA_SITE` and `PANTHEON_NAME` equal the chosen site's values.
-   - If they don't match: tell the user to fix `.ddev/config.local.yaml`, then restart so the new `web_environment` vars load (they only reload on restart). **Before restarting, ask the user (AskUserQuestion) whether to reinstall the project on restart — default No:**
-     - **No (default):** leave the `post-start` hook as-is (only `ddev client-install` runs) — a deploy doesn't need a reinstall. Then `ddev restart`.
-     - **Yes:** first uncomment the full commented `post-start` block in `.ddev/config.local.yaml` (see *Reinstall-on-restart toggle* in the shared reference), then `ddev restart` so it runs `site-install` + migrations + feature flags for the selected `$EHEZA_SITE`. Re-comment afterward if future restarts shouldn't reinstall.
-   - Why it matters: wrong `PANTHEON_NAME` pushes code to the **wrong Pantheon site**; wrong `EHEZA_SITE` builds the wrong site's data/config.
+   - If they don't match: tell the user to fix `.ddev/config.local.yaml` (the mandatory restart in Step 2 loads the new values). This is the #1 footgun — wrong `PANTHEON_NAME` pushes code to the **wrong Pantheon site**; wrong `EHEZA_SITE` builds the wrong site's data/config.
 2. **`main` clean & level with `origin/main`.** Step 2 runs `git checkout main`, so you need not be sitting on `main` now — but it must be deploy-ready: in sync with the remote and free of *tracked* changes. The deploy aborts only on **tracked** changes; untracked files (e.g. `.ddev/`, `server/.pantheon-*`) are ignored, so check with `-uno` (not `-sb`, which would false-alarm on those):
    ```bash
    git fetch origin main --tags
@@ -63,9 +60,13 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
 
 ## Step 2 — Local prep
 
-- 🟢 You run: `git checkout main && git pull`.
-- 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
-- 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client. This is long; let it finish before deploying.
+1. 🟢 You run: `git checkout main && git pull`.
+2. **Restart DDEV — always, deciding reinstall first.** Ask the user (AskUserQuestion) whether to reinstall the project on this restart — **default No**:
+   - **No (default):** ensure the `post-start` hook in `.ddev/config.local.yaml` is in its default state (only `- exec-host: ddev client-install` active; everything below commented). No reinstall.
+   - **Yes:** uncomment the entire commented `post-start` block (see *Reinstall-on-restart toggle* in the shared reference) so the restart runs `site-install` + migrations + feature flags for the selected `$EHEZA_SITE`. Re-comment afterward if future restarts shouldn't reinstall.
+   Then run `ddev restart` (local-only and safe to run; the reinstall answer is the confirmation for the destructive local-DB wipe a reinstall performs).
+3. 🔴 User runs (paused): `ddev auth ssh` — authenticates to Pantheon over SSH (interactive).
+4. 🔴 User runs (paused): `ddev gulp publish` — minified production build of the Elm client. This is long; let it finish before deploying.
 
 ## Step 3 — Deploy to Dev
 

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -63,7 +63,7 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
    ```bash
    ddev exec terminus auth:whoami   # expect an email, not "You are not logged in"
    ```
-   - If not logged in: set `TERMINUS_MACHINE_TOKEN` in `.ddev/config.local.yaml` (see shared reference) and `ddev restart`, or run `ddev exec terminus auth:login --machine-token=<token>`.
+   - If not logged in: run **`ddev terminus-auth`** (logs terminus in from `TERMINUS_MACHINE_TOKEN`, or `ddev terminus-auth <token>`). If the token isn't set yet, add `TERMINUS_MACHINE_TOKEN` to `.ddev/config.local.yaml` (see shared reference) and `ddev restart`.
 
 ## Step 2 — Local prep
 

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -44,7 +44,10 @@ Confirm the plan back in one line (site, `PANTHEON_NAME`, full release to Live, 
 Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not deploy past a failure.**
 
 1. **Config matches the target site.** Read `.ddev/config.local.yaml` and confirm `EHEZA_SITE` and `PANTHEON_NAME` equal the chosen site's values.
-   - If they don't match: tell the user to fix `.ddev/config.local.yaml` **and then run `ddev restart`** (web_environment vars only reload on restart). This is the #1 footgun — wrong `PANTHEON_NAME` pushes code to the **wrong Pantheon site**; wrong `EHEZA_SITE` builds the wrong site's data/config.
+   - If they don't match: tell the user to fix `.ddev/config.local.yaml`, then restart so the new `web_environment` vars load (they only reload on restart). **Before restarting, ask the user (AskUserQuestion) whether to reinstall the project on restart — default No:**
+     - **No (default):** leave the `post-start` hook as-is (only `ddev client-install` runs) — a deploy doesn't need a reinstall. Then `ddev restart`.
+     - **Yes:** first uncomment the full commented `post-start` block in `.ddev/config.local.yaml` (see *Reinstall-on-restart toggle* in the shared reference), then `ddev restart` so it runs `site-install` + migrations + feature flags for the selected `$EHEZA_SITE`. Re-comment afterward if future restarts shouldn't reinstall.
+   - Why it matters: wrong `PANTHEON_NAME` pushes code to the **wrong Pantheon site**; wrong `EHEZA_SITE` builds the wrong site's data/config.
 2. **`main` clean & level with `origin/main`.** Step 2 runs `git checkout main`, so you need not be sitting on `main` now — but it must be deploy-ready: in sync with the remote and free of *tracked* changes. The deploy aborts only on **tracked** changes; untracked files (e.g. `.ddev/`, `server/.pantheon-*`) are ignored, so check with `-uno` (not `-sb`, which would false-alarm on those):
    ```bash
    git fetch origin main --tags

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -15,7 +15,7 @@ This skill performs a **full production release** for one **single site**: build
 
 You (Claude) **drive every step except the deploy/promote commands** — those move code to Dev/Test/Live and need a human to review and confirm.
 
-- 🟢 **You run** (via Bash on the host): git prep on `main`, all preflight checks, `ddev restart`, `ddev auth ssh`, `ddev gulp publish`, the terminus auth check/login, the post-deploy `fra`, plus tag math, `generate:release-notes`, and the GitHub release (`gh`). None of these are destructive, and on a normal ddev setup they're non-interactive (SSH keys in the agent, `TERMINUS_MACHINE_TOKEN` in the env). Only hand `ddev auth ssh` to the user if it prompts for a key passphrase.
+- 🟢 **You run** (via Bash on the host): git prep on `main`, all preflight checks, `ddev restart`, `ddev auth ssh`, `ddev gulp publish`, the terminus auth check/login, plus tag math, `generate:release-notes`, and the GitHub release (`gh`). None of these are destructive, and on a normal ddev setup they're non-interactive (SSH keys in the agent, `TERMINUS_MACHINE_TOKEN` in the env). Only hand `ddev auth ssh` to the user if it prompts for a key passphrase.
 - 🔴 **User runs — the deploy/promote commands only**: `ddev robo deploy:pantheon` (Dev) and `ddev robo deploy:pantheon-sync test|live`. **Offer each tee'd to a log** so you read the outcome yourself instead of asking for a paste:
   ```bash
   ddev robo deploy:pantheon 2>&1 | tee /tmp/deploy-dev.log
@@ -81,27 +81,25 @@ Run these and report a ✅/❌ checklist. **Stop and surface any ❌ — do not 
 ```bash
 ddev robo deploy:pantheon 2>&1 | tee /tmp/deploy-dev.log
 ```
-Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect. When it returns, `Read` `/tmp/deploy-dev.log` to verify the push + auto-run `cc all`/`updb`/`uli` — don't ask for a paste.
+Tell the user explicitly: **at the "Commit changes and deploy?" prompt, review the printed `git status` of the Pantheon repo** and confirm only if the change-set is exactly what they expect. When it returns, `Read` `/tmp/deploy-dev.log` to verify the push + auto-run `cc all`/`updb`/`fra`/`uli` — don't ask for a paste.
 
-What this command does automatically (so you don't double-run it): rsyncs the build into the Pantheon clone, commits + pushes to Pantheon `master`, then runs on **Dev** `cc all` (twice), `updb -y`, and `uli`. It does **NOT** run `fra`.
+What this command does automatically (so you don't double-run it): rsyncs the build into the Pantheon clone, commits + pushes to Pantheon `master`, then runs on **Dev** `cc all` (twice), `updb -y`, **`fra -y`**, **`cc all`**, and `uli`.
 
 > Pantheon's `master` branch = the **Dev** environment, not production. This step only updates Dev; promotion to Test/Live is Step 5.
 
-## Step 4 — Post-deploy (every env you touch)
+## Step 4 — Post-deploy / verify (every env you touch)
 
-🟢 You run — the one step the robo command skips:
-```bash
-ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y   # features revert all
-```
-Then sanity-check the env (open the `uli` login link from the deploy output, smoke-test the app). If the deploy added manual steps (new variables, migrations), run those too.
+The robo deploy already ran `cc all`/`updb`/`fra`/`cc all`/`uli` itself — confirm in the log. So just sanity-check the env (open the `uli` login link from the deploy output, smoke-test the app). If the deploy added manual steps (new variables, migrations), run those too.
+
+> ⚠️ **If you promote via the Pantheon dashboard GUI** (Test/Live tabs) instead of `deploy:pantheon-sync`, the robo command never runs, so **`updb`/`fra`/`cc all` do NOT run** on that env — do them by hand: `ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- updb -y`, then `-- fra -y`, then `-- cc all`.
 
 ## Step 5 — Promote Dev → Test → Live
 
-Do these **in order**, pausing for the user and re-verifying between each. Each `deploy:pantheon-sync` runs `terminus env:deploy` then `cc all`×2 + `updb -y` + `uli` on that env (but again **not** `fra`).
+Do these **in order**, pausing for the user and re-verifying between each. Each `deploy:pantheon-sync` runs `terminus env:deploy` then `cc all`×2 + `updb -y` + **`fra -y` + `cc all`** + `uli` on that env.
 
-1. 🔴 User runs (tee'd): `ddev robo deploy:pantheon-sync test 2>&1 | tee /tmp/deploy-test.log` → `Read` the log → then you run Step 4 `fra` on `test` (🟢) → verify on the Test URL.
+1. 🔴 User runs (tee'd): `ddev robo deploy:pantheon-sync test 2>&1 | tee /tmp/deploy-test.log` → `Read` the log (confirm `updb`/`fra`/`cc` ran) → verify on the Test URL.
 2. Pause for explicit user go-ahead (this next one hits production).
-3. 🔴 User runs (tee'd): `ddev robo deploy:pantheon-sync live 2>&1 | tee /tmp/deploy-live.log` → `Read` the log → then you run Step 4 `fra` on `live` (🟢) → verify on the Live URL.
+3. 🔴 User runs (tee'd): `ddev robo deploy:pantheon-sync live 2>&1 | tee /tmp/deploy-live.log` → `Read` the log (confirm `updb`/`fra`/`cc` ran) → verify on the Live URL.
 
 (Equivalent GUI path: Pantheon dashboard → Test tab → confirm deploy → Live tab → confirm deploy.)
 

--- a/.claude/skills/deploy-release/references/deploy-reference.md
+++ b/.claude/skills/deploy-release/references/deploy-reference.md
@@ -1,0 +1,76 @@
+# Deploy reference — internals, setup, troubleshooting
+
+Background detail for the `deploy-release` skill. Source of truth: the wiki
+(https://github.com/Gizra/ihangane/wiki/Deployment) and `server/RoboFile.php`.
+
+## Pantheon sites
+
+| Pantheon site (`PANTHEON_NAME`) | `EHEZA_SITE` | Dashboard |
+| ------------------------------- | ------------ | --------- |
+| `ihangane`                      | `rwanda`     | https://dashboard.pantheon.io/sites/ef0f3448-d0e5-4e83-b26c-875cfc77228b |
+| `vhw`                           | `burundi`    | https://dashboard.pantheon.io/sites/7a63355a-86c4-4823-b9bd-145d24969627 |
+| `tip-somalia`                   | `somalia`    | https://dashboard.pantheon.io/sites/6e2186e4-348e-432d-bd54-25da6834cd12 |
+| `uvl`                           | `burundi`    | https://dashboard.pantheon.io/sites/22e92340-dfa5-40cb-a5b8-58af49317149 |
+
+`vhw` and `uvl` are two separate Burundi deployments — same `EHEZA_SITE`, different `PANTHEON_NAME`. Always confirm which one.
+
+## What the robo commands actually do (`server/RoboFile.php`)
+
+### `deployPantheon($branchName = 'master')` — `ddev robo deploy:pantheon [env]`
+1. Resolves `PANTHEON_NAME` from the env var (falls back to the `PANTHEON_NAME` const, `eheza-app`, if unset — which is why the env var must be set correctly).
+2. **Aborts if the eheza-app working tree is dirty.**
+3. **Aborts if the Pantheon clone (`.pantheon-<name>`) is dirty.**
+4. **Aborts if `pantheon.upstream.yml` is missing or has no `php_version:`.**
+5. Checks out the target branch in the Pantheon clone (`master` for Dev, else the multidev branch name).
+6. rsyncs `www/.` (server) and `client/dist/.` (app) into the clone, excluding `.git`, `.ddev`, `client`, etc.
+7. Prints `git status`, then asks **"Commit changes and deploy?"** (interactive — needs a human).
+8. On confirm: `git pull && git add . && git commit -am 'Site update' && git push` to Pantheon.
+9. Calls `deployPantheonSync(<env>, FALSE)` → runs `cc all` (×2), `updb -y`, `uli` on that env. **Does not run `fra`.**
+
+`$branchName == 'master'` maps to the Pantheon **`dev`** environment.
+
+### `deployPantheonSync($env = 'test', $doDeploy = TRUE)` — `ddev robo deploy:pantheon-sync <env>`
+- If `$doDeploy`: `terminus env:deploy <PANTHEON_NAME>.<env>` (promotes code from the previous env).
+- Then always: `terminus remote:drush <env> -- cc all` (×2), `updb -y`, `uli`.
+- Again, **no `fra`** — run it manually after.
+
+### `generateReleaseNotes($tag = NULL)` — `ddev robo generate:release-notes [tag]`
+- Lists changes **since** `$tag`. So `$tag` is the **previous** release tag (releasing `v1.17.2` → pass `v1.17.1`).
+- If `$tag` is omitted it prompts to compare from the latest tag; pass it explicitly to avoid the prompt.
+- Detects org/repo from `git remote get-url origin` to enrich entries via the GitHub API.
+
+## `fra` is the manual post-deploy step
+
+None of the robo commands run `drush fra` (features-revert-all). After every env you deploy/promote to:
+```bash
+ddev exec terminus remote:drush <PANTHEON_NAME>.<env> -- fra -y
+```
+`cc all` / `updb -y` / `uli` are already handled by the robo command for that env.
+
+## One-time setup (prerequisites)
+
+Per site, from inside `server/`, clone the Pantheon repo into `.pantheon-<PANTHEON_NAME>`:
+```bash
+# Rwanda (ihangane)
+git clone ssh://codeserver.dev.ef0f3448-d0e5-4e83-b26c-875cfc77228b@codeserver.dev.ef0f3448-d0e5-4e83-b26c-875cfc77228b.drush.in:2222/~/repository.git -b master .pantheon-ihangane
+# vhw
+git clone ssh://codeserver.dev.7a63355a-86c4-4823-b9bd-145d24969627@codeserver.dev.7a63355a-86c4-4823-b9bd-145d24969627.drush.in:2222/~/repository.git -b master .pantheon-vhw
+# tip-somalia
+git clone ssh://codeserver.dev.6e2186e4-348e-432d-bd54-25da6834cd12@codeserver.dev.6e2186e4-348e-432d-bd54-25da6834cd12.drush.in:2222/~/repository.git -b master .pantheon-tip-somalia
+# uvl
+git clone ssh://codeserver.dev.22e92340-dfa5-40cb-a5b8-58af49317149@codeserver.dev.22e92340-dfa5-40cb-a5b8-58af49317149.drush.in:2222/~/repository.git -b master .pantheon-uvl
+```
+Also required (one-time): a Pantheon team membership + SSH key on the Pantheon account, and the `.ddev/config.local.yaml` `web_environment` entries (`EHEZA_SITE`, `PANTHEON_NAME`, and for infra also `EHEZA_INFRA_REPO_REMOTE`, `GITHUB_USERNAME`, `GITHUB_ACCESS_TOKEN`).
+
+## Troubleshooting preflight / deploy failures
+
+- **"The GitHub working directory is dirty"** — commit/stash/`.gitignore` pending changes in the eheza-app repo, then retry.
+- **"The Pantheon working directory is dirty"** — `cd server/.pantheon-<name> && git status`; the deploy offers to `git checkout . && git clean -fd` if you decline the commit. Clean it before retrying.
+- **"pantheon.upstream.yml is missing / php_version directive is missing"** — the Pantheon clone is stale or wrong; re-pull it (`git -C server/.pantheon-<name> pull`).
+- **Pushed to the wrong site** — caused by a stale `PANTHEON_NAME`. Fix `.ddev/config.local.yaml` and **`ddev restart`** (env vars only reload on restart) before re-deploying.
+- **Empty changelog** — you passed the *new* tag to `generate:release-notes` instead of the previous one.
+- **terminus / SSH auth errors** — re-run `ddev auth ssh`; confirm Pantheon team membership and that your SSH key is on the Pantheon account.
+
+## Branch note
+
+The eheza-app default branch is `main`; releases are tagged on `main` and the release target is `main`.

--- a/.ddev/commands/web/terminus-auth
+++ b/.ddev/commands/web/terminus-auth
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+## Description: Authenticate terminus (Pantheon CLI) for deploys, using TERMINUS_MACHINE_TOKEN.
+## Usage: terminus-auth [machine-token]
+## Example: "ddev terminus-auth"  (uses $TERMINUS_MACHINE_TOKEN from .ddev/config.local.yaml)
+## Example: "ddev terminus-auth <token>"
+
+# Companion to `ddev auth ssh`: that authenticates the git push to Pantheon;
+# this authenticates terminus for the post-deploy `terminus remote:drush`
+# (cc all / updb / fra) steps. Without it, those steps fail with
+# "You are not logged in".
+
+set -e
+
+# Use an explicit token arg if given (but ignore flags like --help / -h); else the env var.
+TOKEN="$TERMINUS_MACHINE_TOKEN"
+if [ -n "$1" ] && [ "${1#-}" = "$1" ]; then
+  TOKEN="$1"
+fi
+
+if [ -z "$TOKEN" ]; then
+  echo "No machine token found."
+  echo "Set TERMINUS_MACHINE_TOKEN in .ddev/config.local.yaml (then 'ddev restart'),"
+  echo "or pass one explicitly: 'ddev terminus-auth <token>'."
+  echo "Generate a token at https://dashboard.pantheon.io/machine-token/create"
+  exit 1
+fi
+
+terminus auth:login --machine-token="$TOKEN"
+terminus auth:whoami


### PR DESCRIPTION
## What

Adds two project Claude Code skills (plus a shared reference) that guide and perform E-Heza deploys to Pantheon, mirroring the [Deployment wiki](https://github.com/Gizra/ihangane/wiki/Deployment) and `server/RoboFile.php`:

- **`deploy-release`** — the full production path for one site: build from `main` → Pantheon **Dev** → promote **Test** → **Live** → cut the **GitHub release + changelog**.
- **`deploy-multidev`** — deploy an arbitrary **branch** to a Pantheon **multidev** (review/feature) env for one site. No Test/Live, no release.
- **`_deploy-common/deploy-reference.md`** — shared single source of truth (site→config map, RoboFile internals, one-time Pantheon clone setup, troubleshooting). Both skills point to it.

## How they work

- **Drive-it, pause at risky steps:** each skill runs the safe steps itself (git prep, read-only preflight; for release also tag math, `generate:release-notes`, `gh release`) and **pauses** for the interactive/production-affecting commands (`ddev auth ssh`, `gulp publish`, `robo deploy:pantheon[-sync]`, post-deploy `fra`). They stop at the `robo` "Commit changes and deploy?" prompt so a human reviews the change-set.
- **One site per run;** Step 0 pins `EHEZA_SITE` + `PANTHEON_NAME` (incl. the two-Burundi-sites `vhw`/`uvl` caveat).
- Preflight centers on the biggest footgun — `.ddev/config.local.yaml` must match the target site (a wrong `PANTHEON_NAME` pushes to the **wrong Pantheon site**) — and both document that `robo` auto-runs `cc`/`updb`/`uli` but **not** `fra`.

## Issue

Part of #1826 (deployment process documentation), task 2 ("Create Claude Code skill that will help with the deployment"). Task 1 (update the Deployment wiki so a new developer can follow it unaided) was done directly on the wiki: the `generate:release-notes` command/tag fixes, the **master = Dev env** warning, and typo cleanups.

Leaving #1826 open intentionally — to be closed after the skills are exercised on a real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
