### PR TITLE
RoboFile: run fra after updb on deploy (stop relying on the manual step)

### DIFF
--- a/server/RoboFile.php
+++ b/server/RoboFile.php
@@ -177,6 +177,11 @@ class RoboFile extends Tasks {
       // A second cache-clear, because Drupal...
       ->exec("terminus remote:drush $pantheonTerminusEnvironment -- cc all")
       ->exec("terminus remote:drush $pantheonTerminusEnvironment -- updb -y")
+      // Revert Features to code. This was a manual post-deploy step, which is
+      // easy to forget and leaves config stale; run it here on every env, then
+      // clear caches again so the reverted config takes effect.
+      ->exec("terminus remote:drush $pantheonTerminusEnvironment -- fra -y")
+      ->exec("terminus remote:drush $pantheonTerminusEnvironment -- cc all")
       ->exec("terminus remote:drush $pantheonTerminusEnvironment -- uli")
       ->run();
   }


### PR DESCRIPTION
## What
`deployPantheonSync` ran the post-deploy/promotion terminus stack `cc all` ×2 → `updb -y` → `uli`, but **not `fra`** (features-revert-all). The deploy process requires `fra` on every env, so it was a manual post-deploy step that's easy to forget — and forgetting it leaves config stale.

This adds `fra -y` after `updb -y`, plus a `cc all` after it so the reverted config takes effect (matching the documented `updb → fra → cc` post-deploy order). New per-env stack:

`cc all` → `cc all` → `updb -y` → **`fra -y`** → **`cc all`** → `uli`

Applies to the Dev deploy (`deploy:pantheon`) and the Test/Live promotions (`deploy:pantheon-sync`).

## Why
Same failure mode as the terminus-auth gap — a required manual post-deploy step that's easy to forget. `fra` reverts **Features** config to code (the intended behavior here; feature **flags** are `drush vset` variables, not Features, so they're unaffected). `fra -y` is non-interactive.

## Verification
`php -l` clean; phpcs Drupal clean; phpcs DrupalPractice adds no new issues (the one warning — `$push_status` at line 139 — is pre-existing, unrelated to this change).

## Follow-up (docs)
Once this lands, the docs that call `fra` a "manual post-deploy step" should be updated: the **Deployment wiki** and the deploy skills' Step 4 / `_deploy-common` reference (on #1827).

🤖 Generated with [Claude Code](https://claude.com/claude-code)