### PR TITLE
Utils.Json: decode EverySet element-tolerantly (#1829)

### DIFF
--- a/client/src/elm/Utils/Json.elm
+++ b/client/src/elm/Utils/Json.elm
@@ -48,10 +48,20 @@ decodeNullAsEmptyArray =
 
 {-| Given a decoder, decodes a JSON list of that type, and then
 turns it into an `EverySet`.
+
+The decode is element-tolerant: any element the inner decoder cannot
+parse (for example an enum value introduced by a client newer than the
+one running) is dropped on its own, rather than collapsing the entire
+set to empty. Recognized elements always survive. A non-list value
+(null, etc.) still falls back to the empty set, preserving the previous
+behaviour.
+
 -}
 decodeEverySet : Decoder a -> Decoder (EverySet a)
 decodeEverySet decoder =
-    decodeWithFallback EverySet.empty (map EverySet.fromList <| list decoder)
+    list (oneOf [ map Just decoder, succeed Nothing ])
+        |> map (List.filterMap identity >> EverySet.fromList)
+        |> decodeWithFallback EverySet.empty
 
 
 decodeWithFallback : a -> Decoder a -> Decoder a

--- a/client/src/elm/Utils/Json/Test.elm
+++ b/client/src/elm/Utils/Json/Test.elm
@@ -1,0 +1,65 @@
+module Utils.Json.Test exposing (all)
+
+import EverySet
+import Expect
+import Json.Decode exposing (andThen, decodeString, fail, string, succeed)
+import Test exposing (Test, describe, test)
+import Utils.Json exposing (decodeEverySet)
+
+
+{-| A small enum decoder standing in for the real clinical sign decoders
+(e.g. `decodeDangerSign`): it recognizes a fixed set of tokens and fails on
+anything else, exactly like the `_ -> fail ...` branch they all use.
+-}
+decodeSign : Json.Decode.Decoder String
+decodeSign =
+    string
+        |> andThen
+            (\s ->
+                case s of
+                    "vaginal-bleeding" ->
+                        succeed s
+
+                    "convulsions" ->
+                        succeed s
+
+                    "fever" ->
+                        succeed s
+
+                    _ ->
+                        fail <| s ++ " is not a recognized sign"
+            )
+
+
+decodeStringSet : String -> Result Json.Decode.Error (List String)
+decodeStringSet json =
+    decodeString (decodeEverySet decodeSign) json
+        |> Result.map EverySet.toList
+
+
+all : Test
+all =
+    describe "Utils.Json.decodeEverySet"
+        [ test "keeps all recognized values" <|
+            \_ ->
+                decodeStringSet """["vaginal-bleeding","convulsions"]"""
+                    |> Expect.equal (Ok [ "convulsions", "vaginal-bleeding" ])
+        , test "drops only the unknown element and keeps the recognized ones" <|
+            -- The regression at the heart of this fix: previously a single
+            -- unknown value collapsed the WHOLE set to empty.
+            \_ ->
+                decodeStringSet """["vaginal-bleeding","some-future-sign","convulsions"]"""
+                    |> Expect.equal (Ok [ "convulsions", "vaginal-bleeding" ])
+        , test "an all-unknown list decodes to empty rather than failing" <|
+            \_ ->
+                decodeStringSet """["future-a","future-b"]"""
+                    |> Expect.equal (Ok [])
+        , test "an empty list decodes to the empty set" <|
+            \_ ->
+                decodeStringSet "[]"
+                    |> Expect.equal (Ok [])
+        , test "a non-list value falls back to the empty set" <|
+            \_ ->
+                decodeStringSet "null"
+                    |> Expect.equal (Ok [])
+        ]

--- a/client/src/elm/Utils/Json/Test.elm
+++ b/client/src/elm/Utils/Json/Test.elm
@@ -34,7 +34,11 @@ decodeSign =
 decodeStringSet : String -> Result Json.Decode.Error (List String)
 decodeStringSet json =
     decodeString (decodeEverySet decodeSign) json
-        |> Result.map EverySet.toList
+        -- Sort so the assertions don't depend on `EverySet`'s internal
+        -- iteration order (a set has no order; comparing sets via their
+        -- AssocList backing is itself order-sensitive, so sorting is the
+        -- robust choice).
+        |> Result.map (EverySet.toList >> List.sort)
 
 
 all : Test


### PR DESCRIPTION
## What

Make `decodeEverySet` (`client/src/elm/Utils/Json.elm`) **element-tolerant** so a single unrecognized enum value no longer collapses an entire clinical sign-set to empty.

Closes #1829.

## Why

`Json.Decode.list` is all-or-nothing, so the previous implementation —

```elm
decodeWithFallback EverySet.empty (map EverySet.fromList <| list decoder)
```

— failed the whole list decode on the first bad element and fell through `oneOf` to `succeed EverySet.empty`. The fallback fired at the **whole-set** granularity instead of **per-element**.

E-Heza is offline-first with the fleet on mixed client versions ("valid" = the running build has a `case` branch for the value). When a newer client records a sign value an older client predates, that value syncs up to Drupal (stored verbatim, no union validation) and back down to the older client, whose `_ -> fail` branch then **empties the whole set** — erasing even the signs it recognized. The emptied set can subsequently be written back to the backend, turning a stale-client display glitch into durable, server-side data loss. The pattern is used in **148 fields** in `Backend/Measurement/Decoder.elm` (danger signs, nutrition signs, breast-exam, CPE, symptoms, lab prerequisites, …).

## How

```elm
decodeEverySet decoder =
    list (oneOf [ map Just decoder, succeed Nothing ])
        |> map (List.filterMap identity >> EverySet.fromList)
        |> decodeWithFallback EverySet.empty
```

- Unknown elements drop **individually**; recognized values always survive.
- A non-list value (null, etc.) still falls back to the empty set — previous behaviour preserved.
- **Signature unchanged**, so all 148 call sites are untouched.

## Tests

New `client/src/elm/Utils/Json/Test.elm` covers: all-known kept, one-unknown-dropped-rest-kept (the regression), all-unknown → empty, empty list → empty, non-list → empty.

Local verification: `elm-format --validate` clean; full `elm-test "src/elm/**/Test.elm"` → **2728 passed** (incl. the 5 new); `Utils.Json` files produce **no** elm-review findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
