### PR TITLE
NominalDate: compute "today" in the device's local time zone (#1831)

### DIFF
--- a/client/src/elm/App/Fetch.elm
+++ b/client/src/elm/App/Fetch.elm
@@ -99,7 +99,7 @@ fetch model =
     else
         let
             currentDate =
-                fromLocalDateTime model.currentTime
+                fromLocalDateTime model.zone model.currentTime
         in
         case model.activePage of
             DevicePage ->

--- a/client/src/elm/App/Model.elm
+++ b/client/src/elm/App/Model.elm
@@ -137,6 +137,11 @@ type alias Model =
     , memoryQuota : Maybe MemoryQuota
     , configuration : RemoteData String ConfiguredModel
     , currentTime : Time.Posix
+
+    -- The device's local time zone, captured once at startup via `Time.here`.
+    -- Used to derive the local calendar date from `currentTime`; see
+    -- `Gizra.NominalDate.fromLocalDateTime`.
+    , zone : Time.Zone
     , language : Language
     , serviceWorker : ServiceWorker.Model.Model
     , zscores : ZScore.Model.Model
@@ -209,6 +214,7 @@ emptyModel key url flags =
     , dbVersion = flags.dbVersion
     , configuration = NotAsked
     , currentTime = Time.millisToPosix 0
+    , zone = Time.utc
     , dataWanted = Dict.empty
     , indexedDb = Backend.Model.emptyModelIndexedDb
     , language = English
@@ -427,6 +433,7 @@ type Msg
     | SetGPSCoordinates GPSCoordinates
     | SetHealthCenter (Maybe HealthCenterId)
     | SetVillage (Maybe VillageId)
+    | SetTimeZone Time.Zone
     | Tick Time.Posix
     | CheckDataWanted
     | UrlRequested Browser.UrlRequest

--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -194,6 +194,7 @@ init flags url key =
                             -- to fetch it only when we really, really need it).
                             Cmd.batch
                                 [ Task.perform Tick Time.now
+                                , Task.perform SetTimeZone Time.here
                                 , fetchCachedDevice
                                 , Nav.pushUrl model.navigationKey (Url.toString model.url)
                                 ]
@@ -242,7 +243,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     let
         currentDate =
-            fromLocalDateTime model.currentTime
+            fromLocalDateTime model.zone model.currentTime
 
         loggedInData =
             getLoggedInData model
@@ -1248,6 +1249,11 @@ update msg model =
             , cmd
             )
                 |> sequence update extraMsgs
+
+        SetTimeZone zone ->
+            ( { model | zone = zone }
+            , Cmd.none
+            )
 
         Tick time ->
             let

--- a/client/src/elm/App/View.elm
+++ b/client/src/elm/App/View.elm
@@ -369,6 +369,7 @@ viewConfiguredModel model configured =
 
             PinCodePage ->
                 Pages.PinCode.View.view model.language
+                    model.zone
                     model.currentTime
                     features
                     model.activePage
@@ -416,7 +417,7 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
             if selectedAuthorizedHealthCenter then
                 let
                     currentDate =
-                        fromLocalDateTime model.currentTime
+                        fromLocalDateTime model.zone model.currentTime
 
                     ( isChw, isLabTech ) =
                         Tuple.second loggedInModel.nurse
@@ -1189,6 +1190,7 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
                                     |> Maybe.withDefault Pages.MessagingCenter.Model.emptyModel
                         in
                         Pages.MessagingCenter.View.view model.language
+                            model.zone
                             model.currentTime
                             nurseId
                             nurse
@@ -1203,6 +1205,7 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
                                 loggedInModel.nurse
                         in
                         Pages.Wellbeing.View.view model.language
+                            model.zone
                             model.currentTime
                             nurse
                             |> Html.map (MsgLoggedIn << MsgPageMessagingCenter nurseId)
@@ -1234,6 +1237,7 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
 
             else
                 Pages.PinCode.View.view model.language
+                    model.zone
                     model.currentTime
                     features
                     model.activePage
@@ -1247,6 +1251,7 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
 
         Nothing ->
             Pages.PinCode.View.view model.language
+                model.zone
                 model.currentTime
                 features
                 model.activePage

--- a/client/src/elm/Gizra/NominalDate.elm
+++ b/client/src/elm/Gizra/NominalDate.elm
@@ -80,17 +80,19 @@ formatDDMMYY date =
     Date.format "dd/MM/yy" date
 
 
-{-| Converts an `elm-lang/core` `Date` to a `NominalDate`.
+{-| Converts a `Time.Posix` to a `NominalDate`, taking the calendar date as
+seen in the given time zone.
 
-We pick up the date part according to whatever the local browser's time zone
-is. Thus, results will be inconsistent from one locality to the next ... since
-the same universal time might be considered one day in one time zone and a
-different day in a different time zone.
+Pass the device's local zone (captured once at startup via `Time.here`) so the
+date reflects the user's locality. This matters in Rwanda/Burundi (UTC+2) and
+Somalia (UTC+3): a moment just after local midnight is still the previous day
+in UTC, so using `Time.utc` here would stamp the wrong calendar day on
+`dateMeasured`, encounter dates, vaccine due dates, etc.
 
 -}
-fromLocalDateTime : Time.Posix -> NominalDate
-fromLocalDateTime =
-    Date.fromPosix Time.utc
+fromLocalDateTime : Time.Zone -> Time.Posix -> NominalDate
+fromLocalDateTime zone =
+    Date.fromPosix zone
 
 
 {-| Given a date, return date representing it's last month day.

--- a/client/src/elm/Gizra/NominalDate/Test.elm
+++ b/client/src/elm/Gizra/NominalDate/Test.elm
@@ -1,0 +1,33 @@
+module Gizra.NominalDate.Test exposing (all)
+
+import Date
+import Expect
+import Gizra.NominalDate exposing (fromLocalDateTime)
+import Test exposing (Test, describe, test)
+import Time
+
+
+{-| 1970-01-01T23:30:00Z — 23h30m after the epoch, i.e. late evening in UTC.
+-}
+lateEveningUtc : Time.Posix
+lateEveningUtc =
+    Time.millisToPosix ((23 * 3600 + 30 * 60) * 1000)
+
+
+all : Test
+all =
+    describe "Gizra.NominalDate.fromLocalDateTime"
+        [ test "takes the calendar day as seen in UTC" <|
+            \_ ->
+                fromLocalDateTime Time.utc lateEveningUtc
+                    |> Date.toIsoString
+                    |> Expect.equal "1970-01-01"
+        , test "a UTC+2 zone rolls a late-evening UTC instant into the next local day" <|
+            -- The regression this fix addresses: in Rwanda/Burundi (UTC+2) a
+            -- moment just before UTC midnight is already the next calendar day
+            -- locally, so it must stamp that day -- not the UTC one.
+            \_ ->
+                fromLocalDateTime (Time.customZone 120 []) lateEveningUtc
+                    |> Date.toIsoString
+                    |> Expect.equal "1970-01-02"
+        ]

--- a/client/src/elm/Pages/MessagingCenter/View.elm
+++ b/client/src/elm/Pages/MessagingCenter/View.elm
@@ -39,11 +39,11 @@ import Utils.Html exposing (viewModal)
 import Utils.NominalDate exposing (renderDate, sortByDateDesc)
 
 
-view : Language -> Time.Posix -> NurseId -> Nurse -> ModelIndexedDb -> Model -> Html Msg
-view language currentTime nurseId nurse db model =
+view : Language -> Time.Zone -> Time.Posix -> NurseId -> Nurse -> ModelIndexedDb -> Model -> Html Msg
+view language zone currentTime nurseId nurse db model =
     let
         currentDate =
-            fromLocalDateTime currentTime
+            fromLocalDateTime zone currentTime
 
         numberOfUnreadMessages =
             resolveNumberOfUnreadMessages currentTime currentDate nurse

--- a/client/src/elm/Pages/PinCode/View.elm
+++ b/client/src/elm/Pages/PinCode/View.elm
@@ -29,6 +29,7 @@ import Utils.Html exposing (activityCard, activityCardWithCounter, spinner, view
 
 view :
     Language
+    -> Time.Zone
     -> Time.Posix
     -> EverySet SiteFeature
     -> Page
@@ -38,7 +39,7 @@ view :
     -> Model
     -> ModelIndexedDb
     -> Html Msg
-view language currentTime features activePage nurseData ( healthCenterId, villageId ) deviceName model db =
+view language zone currentTime features activePage nurseData ( healthCenterId, villageId ) deviceName model db =
     let
         ( header, content ) =
             case nurseData of
@@ -60,6 +61,7 @@ view language currentTime features activePage nurseData ( healthCenterId, villag
                     in
                     ( viewLoggedInHeader language isChw selectedAuthorizedLocation
                     , viewLoggedInContent language
+                        zone
                         currentTime
                         features
                         nurseId
@@ -177,6 +179,7 @@ viewAnonymousContent language activePage nurseData model =
 
 viewLoggedInContent :
     Language
+    -> Time.Zone
     -> Time.Posix
     -> EverySet SiteFeature
     -> NurseId
@@ -188,7 +191,7 @@ viewLoggedInContent :
     -> ModelIndexedDb
     -> Model
     -> List (Html Msg)
-viewLoggedInContent language currentTime features nurseId nurse ( healthCenterId, villageId ) isChw deviceName selectedAuthorizedLocation db model =
+viewLoggedInContent language zone currentTime features nurseId nurse ( healthCenterId, villageId ) isChw deviceName selectedAuthorizedLocation db model =
     let
         logoutButton =
             button
@@ -203,7 +206,7 @@ viewLoggedInContent language currentTime features nurseId nurse ( healthCenterId
     if selectedAuthorizedLocation then
         let
             currentDate =
-                fromLocalDateTime currentTime
+                fromLocalDateTime zone currentTime
 
             isLabTech =
                 isLabTechnician nurse

--- a/client/src/elm/Pages/Wellbeing/View.elm
+++ b/client/src/elm/Pages/Wellbeing/View.elm
@@ -12,11 +12,11 @@ import Time
 import Translate exposing (Language, translate, translateText)
 
 
-view : Language -> Time.Posix -> Nurse -> Html Msg
-view language currentTime nurse =
+view : Language -> Time.Zone -> Time.Posix -> Nurse -> Html Msg
+view language zone currentTime nurse =
     let
         currentDate =
-            fromLocalDateTime currentTime
+            fromLocalDateTime zone currentTime
 
         numberOfUnreadMessages =
             resolveNumberOfUnreadMessages currentTime currentDate nurse


### PR DESCRIPTION
## What

Compute "today" in the device's **local time zone** instead of UTC.

Closes #1831.

## Why

`Gizra/NominalDate.elm` hardcoded `Time.utc`:

```elm
fromLocalDateTime : Time.Posix -> NominalDate
fromLocalDateTime =
    Date.fromPosix Time.utc
```

(its own docstring claimed local-zone behaviour). The app never captured a zone — no `Time.here` anywhere. In Rwanda/Burundi (UTC+2) and Somalia (UTC+3), an entry made between local midnight and 02:00/03:00 was stamped with the **previous calendar day** on `dateMeasured`, encounter end/concluded dates, and date-keyed clinical logic (vaccine due dates, EGA). `currentDate` is derived once and threaded into ~142 files, so one wrong derivation poisoned everything downstream.

## How (Approach A)

- `App/Model.elm`: new `zone : Time.Zone` field (init `Time.utc`) + `SetTimeZone Time.Zone` msg.
- `App/Update.elm`: `Task.perform SetTimeZone Time.here` in the init `Cmd.batch` (one-shot), a `SetTimeZone` handler, and `currentDate = fromLocalDateTime model.zone model.currentTime`.
- `Gizra/NominalDate.elm`: `fromLocalDateTime : Time.Zone -> Time.Posix -> NominalDate`, docstring corrected.
- Every call site passes a zone: `App/Fetch`, `App/View` (incl. 3 PinCode dispatches + Wellbeing + MessagingCenter), and the `PinCode` / `MessagingCenter` / `Wellbeing` views (PinCode threads through `view` → `viewLoggedInContent`).

These countries have no DST, so a fixed offset derived from the device is safe. **Forward-looking only** — records written during past early-morning windows are not migrated.

## Tests

New `Gizra/NominalDate/Test.elm`: the same `Posix` instant yields `1970-01-01` under `Time.utc` but `1970-01-02` under a UTC+2 `customZone` — locking in the local-day behaviour.

Local verification: **`elm make src/elm/Main.elm` → Success, 548 modules**; `elm-test` → **2725 passed**; `elm-format --validate` clean; no new `elm-review` findings in touched files.

> Note: `elm make Main.elm` (not just `elm-test`) was load-bearing here — it caught a zone-threading gap in `PinCode/View`'s top-level `viewLoggedInContent`, which `elm-test` misses because that module isn't in the test dependency graph.

## Deliberately out of scope
Other `Time.utc` uses with the same root cause but a different surface — resilience-reminder timing in `Pages/PinCode/View.elm` and `Pages/MessagingCenter/Update.elm`. Session/notification timing, not clinical-date correctness; can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
