### PR TITLE
Backend decoders: drop unknown clinical enum values instead of falsifying (#1833)

### DIFF
--- a/client/src/elm/Backend/Measurement/Decoder.elm
+++ b/client/src/elm/Backend/Measurement/Decoder.elm
@@ -20,7 +20,7 @@ import Json.Decode exposing (Decoder, andThen, at, bool, fail, field, list, map,
 import Json.Decode.Pipeline exposing (custom, optional, required)
 import Restful.Endpoint exposing (EntityUuid, decodeEntityUuid, toEntityUuid)
 import Translate.Utils exposing (decodeLanguage)
-import Utils.Json exposing (decodeEverySet, decodeWithFallback)
+import Utils.Json exposing (decodeEverySet, decodeEverySetDroppingUnknown, decodeListDroppingUnknown, decodeWithFallback)
 
 
 decodeGroupMeasurement : Decoder value -> Decoder (Measurement SessionId value)
@@ -3834,8 +3834,8 @@ decodeCall114 : Decoder Call114
 decodeCall114 =
     succeed Call114Value
         |> required "114_contact" (decodeEverySet decodeCall114Sign)
-        |> required "114_recommendation" (decodeEverySet (decodeWithFallback NoneOtherRecommendation114 decodeRecommendation114))
-        |> required "site_recommendation" (decodeEverySet (decodeWithFallback RecommendationSiteNotApplicable decodeRecommendationSite))
+        |> required "114_recommendation" (decodeEverySetDroppingUnknown decodeRecommendation114)
+        |> required "site_recommendation" (decodeEverySetDroppingUnknown decodeRecommendationSite)
         |> decodeAcuteIllnessMeasurement
 
 
@@ -4114,7 +4114,7 @@ decodeAcuteIllnessNutrition =
 
 decodeAcuteIllnessContactsTracing : Decoder AcuteIllnessContactsTracing
 decodeAcuteIllnessContactsTracing =
-    decodeWithFallback [] (list decodeContactTraceItemFromString)
+    decodeListDroppingUnknown decodeContactTraceItemFromString
         |> field "contacts_trace_data"
         |> decodeAcuteIllnessMeasurement
 

--- a/client/src/elm/Backend/NCDEncounter/Decoder.elm
+++ b/client/src/elm/Backend/NCDEncounter/Decoder.elm
@@ -4,10 +4,10 @@ import Backend.NCDEncounter.Model exposing (NCDEncounter)
 import Backend.NCDEncounter.Types exposing (NCDDiagnosis(..))
 import EverySet
 import Gizra.NominalDate exposing (decodeYYYYMMDD)
-import Json.Decode exposing (Decoder, andThen, bool, fail, list, map, nullable, string, succeed)
+import Json.Decode exposing (Decoder, andThen, bool, fail, map, nullable, string, succeed)
 import Json.Decode.Pipeline exposing (optional, optionalAt, required, requiredAt)
 import Restful.Endpoint exposing (decodeEntityUuid)
-import Utils.Json exposing (decodeWithFallback)
+import Utils.Json exposing (decodeListDroppingUnknown, decodeWithFallback)
 
 
 decodeNCDEncounter : Decoder NCDEncounter
@@ -23,7 +23,7 @@ decodeNCDEncounter =
                         EverySet.fromList items
                 )
             <|
-                list (decodeWithFallback NoNCDDiagnosis decodeNCDDiagnosis)
+                decodeListDroppingUnknown decodeNCDDiagnosis
     in
     succeed NCDEncounter
         |> required "individual_participant" decodeEntityUuid

--- a/client/src/elm/Backend/PrenatalEncounter/Decoder.elm
+++ b/client/src/elm/Backend/PrenatalEncounter/Decoder.elm
@@ -4,10 +4,10 @@ import Backend.PrenatalEncounter.Model exposing (PrenatalEncounter, PrenatalEnco
 import Backend.PrenatalEncounter.Types exposing (PrenatalDiagnosis(..))
 import EverySet
 import Gizra.NominalDate exposing (decodeYYYYMMDD)
-import Json.Decode exposing (Decoder, andThen, bool, fail, list, map, nullable, string, succeed)
+import Json.Decode exposing (Decoder, andThen, bool, fail, map, nullable, string, succeed)
 import Json.Decode.Pipeline exposing (optional, optionalAt, required, requiredAt)
 import Restful.Endpoint exposing (decodeEntityUuid)
-import Utils.Json exposing (decodeEverySet, decodeWithFallback)
+import Utils.Json exposing (decodeEverySet, decodeListDroppingUnknown, decodeWithFallback)
 
 
 decodePrenatalEncounter : Decoder PrenatalEncounter
@@ -23,7 +23,7 @@ decodePrenatalEncounter =
                         EverySet.fromList items
                 )
             <|
-                list (decodeWithFallback NoPrenatalDiagnosis decodePrenatalDiagnosis)
+                decodeListDroppingUnknown decodePrenatalDiagnosis
     in
     succeed PrenatalEncounter
         |> required "individual_participant" decodeEntityUuid

--- a/client/src/elm/Utils/Json.elm
+++ b/client/src/elm/Utils/Json.elm
@@ -59,6 +59,29 @@ decodeWithFallback fallback decoder =
     oneOf [ decoder, succeed fallback ]
 
 
+{-| Decode a JSON list, dropping any element the inner decoder cannot parse and
+keeping the recognized ones — instead of failing the whole list or coercing an
+unrecognized element into a fallback sentinel value. Use for forward-compatible
+clinical enum lists, where a value introduced by a newer backend than the client
+is running must NOT silently become a "no finding" value. A non-list value
+yields `[]`.
+-}
+decodeListDroppingUnknown : Decoder a -> Decoder (List a)
+decodeListDroppingUnknown decoder =
+    list (oneOf [ map Just decoder, succeed Nothing ])
+        |> map (List.filterMap identity)
+        |> decodeWithFallback []
+
+
+{-| Like `decodeListDroppingUnknown`, but collects the recognized elements into
+an `EverySet`. Unrecognized elements are dropped, rather than collapsing the
+whole set or inserting a sentinel value.
+-}
+decodeEverySetDroppingUnknown : Decoder a -> Decoder (EverySet a)
+decodeEverySetDroppingUnknown decoder =
+    map EverySet.fromList (decodeListDroppingUnknown decoder)
+
+
 encodeIfSet : String -> Maybe a -> (a -> Value) -> List ( String, Value )
 encodeIfSet name maybeVal encoder =
     Maybe.map (\val -> [ ( name, encoder val ) ]) maybeVal

--- a/client/src/elm/Utils/Json/Test.elm
+++ b/client/src/elm/Utils/Json/Test.elm
@@ -1,0 +1,78 @@
+module Utils.Json.Test exposing (all)
+
+import EverySet
+import Expect
+import Json.Decode exposing (Decoder, andThen, decodeString, fail, string, succeed)
+import Test exposing (Test, describe, test)
+import Utils.Json exposing (decodeEverySetDroppingUnknown, decodeListDroppingUnknown)
+
+
+{-| A small enum decoder standing in for the real clinical enum decoders (e.g.
+`decodePrenatalDiagnosis`): it recognizes a fixed set of tokens and `fail`s on
+anything else, exactly like the `_ -> fail ...` branch they all use.
+-}
+decodeSign : Decoder String
+decodeSign =
+    string
+        |> andThen
+            (\s ->
+                case s of
+                    "vaginal-bleeding" ->
+                        succeed s
+
+                    "convulsions" ->
+                        succeed s
+
+                    "fever" ->
+                        succeed s
+
+                    _ ->
+                        fail <| s ++ " is not a recognized sign"
+            )
+
+
+decodeAsList : String -> Result Json.Decode.Error (List String)
+decodeAsList json =
+    decodeString (decodeListDroppingUnknown decodeSign) json
+
+
+decodeAsSet : String -> Result Json.Decode.Error (List String)
+decodeAsSet json =
+    decodeString (decodeEverySetDroppingUnknown decodeSign) json
+        |> Result.map (EverySet.toList >> List.sort)
+
+
+all : Test
+all =
+    describe "Utils.Json drop-unknown decoders"
+        [ describe "decodeListDroppingUnknown"
+            [ test "keeps all recognized values, in order" <|
+                \_ ->
+                    decodeAsList """["vaginal-bleeding","convulsions"]"""
+                        |> Expect.equal (Ok [ "vaginal-bleeding", "convulsions" ])
+            , test "drops only the unrecognized element and keeps the rest" <|
+                -- The bug this fix addresses: previously an unknown value was
+                -- coerced into a "no-finding" sentinel rather than dropped.
+                \_ ->
+                    decodeAsList """["vaginal-bleeding","some-future-sign","convulsions"]"""
+                        |> Expect.equal (Ok [ "vaginal-bleeding", "convulsions" ])
+            , test "an all-unknown list decodes to []" <|
+                \_ ->
+                    decodeAsList """["future-a","future-b"]"""
+                        |> Expect.equal (Ok [])
+            , test "a non-list value falls back to []" <|
+                \_ ->
+                    decodeAsList "null"
+                        |> Expect.equal (Ok [])
+            ]
+        , describe "decodeEverySetDroppingUnknown"
+            [ test "drops the unrecognized element and keeps the recognized ones" <|
+                \_ ->
+                    decodeAsSet """["vaginal-bleeding","some-future-sign","convulsions"]"""
+                        |> Expect.equal (Ok [ "convulsions", "vaginal-bleeding" ])
+            , test "a non-list value falls back to the empty set" <|
+                \_ ->
+                    decodeAsSet "null"
+                        |> Expect.equal (Ok [])
+            ]
+        ]


### PR DESCRIPTION
## What

Make the patient-record decoders **element-tolerant** so an unrecognized clinical enum value is **dropped**, not coerced into a "no-finding" sentinel.

Closes #1833.

## Why

On this offline-first app, an older client routinely sees enum values a newer backend introduced before the tablet updates. Five patient-record decoders handled that by falling back to a sentinel — so a real **prenatal/NCD diagnosis**, **Call-114 / site recommendation**, or **COVID contact** silently decoded to "none" (a clinical false-negative in the record a nurse reads). The sibling `decodeDangerSign` correctly `fail`s, which shows the intent.

Distinct from #1829 (`decodeEverySet`, which collapsed a set to *empty*): here the fallback inserts an affirmatively-wrong value, or — for contacts — drops the whole list on one bad element.

## How

Two element-tolerant helpers in `Utils/Json.elm`:

```elm
decodeListDroppingUnknown    : Decoder a -> Decoder (List a)
decodeEverySetDroppingUnknown : Decoder a -> Decoder (EverySet a)
```

Each decodes element-by-element, dropping what the inner decoder can't parse and keeping the rest (non-list → empty). Applied to the five patient-record sites:

| Site | Field |
|---|---|
| `Backend/PrenatalEncounter/Decoder.elm` | prenatal diagnoses |
| `Backend/NCDEncounter/Decoder.elm` | NCD diagnoses |
| `Backend/Measurement/Decoder.elm` | `114_recommendation`, `site_recommendation` |
| `Backend/Measurement/Decoder.elm` | COVID `contacts_trace_data` |

**Drop, not `fail`.** Failing a clinical-enum decode fails the whole entity decode — which, with the download-side poison-batch (R3-3) unaddressed, would *stall the sync lane* rather than surface a tidy error. Drop is strictly safer than today: no falsification, no stall, recognized values preserved. Visibility for unknown values belongs in the sync layer, not in crashing the decoder.

## Scope / notes

- **Patient-record decoders only.** The same idiom appears ~13× in the dashboard-stats decoder (`Backend/Dashboard/Decoder.elm`), where it skews aggregate counts — **deferred to a follow-up**, lower stakes.
- **Independent of #1829/#1831** (open PRs). Self-contained helpers; no dependency on the in-flight `decodeEverySet` change. (Both this and #1829 add a new `Utils/Json/Test.elm` — expect a trivial add/add merge to combine the two test sets; no logic conflict.)

## Verification

`elm make src/elm/Main.elm` → **Success** (full app type-check); `elm-test` → **2729 passed** (incl. 6 new); `elm-format --validate` clean; no new `elm-review` findings in touched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
