### PR TITLE
Dashboard decoder: drop unknown clinical enum values instead of falsifying (#1835)

### DIFF
--- a/client/src/elm/Backend/Dashboard/Decoder.elm
+++ b/client/src/elm/Backend/Dashboard/Decoder.elm
@@ -22,17 +22,6 @@ import Backend.Measurement.Decoder
         , decodeTestExecutionNote
         , decodeTestResult
         )
-import Backend.Measurement.Model
-    exposing
-        ( Call114Sign(..)
-        , DangerSign(..)
-        , HCContactSign(..)
-        , HCRecommendation(..)
-        , IsolationSign(..)
-        , MedicalCondition(..)
-        , Recommendation114(..)
-        , SendToHCSign(..)
-        )
 import Backend.NCDEncounter.Decoder exposing (decodeNCDDiagnosis)
 import Backend.NCDEncounter.Types exposing (NCDDiagnosis(..))
 import Backend.NutritionEncounter.Decoder exposing (decodeNutritionEncounterType)
@@ -51,7 +40,7 @@ import Json.Decode exposing (Decoder, andThen, bool, dict, float, list, map, nul
 import Json.Decode.Pipeline exposing (hardcoded, optional, required)
 import Pages.Report.Utils exposing (compareAcuteIllnessEncountersDesc)
 import Restful.Endpoint exposing (toEntityUuid)
-import Utils.Json exposing (decodeEverySet, decodeWithFallback)
+import Utils.Json exposing (decodeEverySet, decodeListDroppingUnknown, decodeWithFallback)
 
 
 decodeDashboardStatsRaw : Decoder DashboardStatsRaw
@@ -294,12 +283,12 @@ decodeAcuteIllnessEncounterDataItem =
         |> hardcoded 0
         |> required "diagnosis" decodeAcuteIllnessDiagnosis
         |> required "fever" bool
-        |> required "isolation" (decodeEverySet (decodeWithFallback NoIsolationSigns decodeIsolationSign))
-        |> required "send_to_hc" (decodeEverySet (decodeWithFallback NoSendToHCSigns decodeSendToHCSign))
-        |> required "call_114" (decodeEverySet (decodeWithFallback NoCall114Signs decodeCall114Sign))
-        |> required "recommendation_114" (decodeEverySet (decodeWithFallback NoneOtherRecommendation114 decodeRecommendation114))
-        |> required "contact_hc" (decodeEverySet (decodeWithFallback NoHCContactSigns decodeHCContactSign))
-        |> required "recommendation_hc" (decodeEverySet (decodeWithFallback HCRecommendationNotApplicable decodeHCRecommendation))
+        |> required "isolation" (decodeEverySet decodeIsolationSign)
+        |> required "send_to_hc" (decodeEverySet decodeSendToHCSign)
+        |> required "call_114" (decodeEverySet decodeCall114Sign)
+        |> required "recommendation_114" (decodeEverySet decodeRecommendation114)
+        |> required "contact_hc" (decodeEverySet decodeHCContactSign)
+        |> required "recommendation_hc" (decodeEverySet decodeHCRecommendation)
 
 
 decodePrenatalDataItem : Decoder PrenatalDataItem
@@ -327,15 +316,15 @@ decodePrenatalEncounterDataItem =
                         EverySet.fromList items
                 )
             <|
-                list (decodeWithFallback NoPrenatalDiagnosis decodePrenatalDiagnosis)
+                decodeListDroppingUnknown decodePrenatalDiagnosis
     in
     succeed PrenatalEncounterDataItem
         |> required "start_date" decodeYYYYMMDD
         |> optional "encounter_type" (decodeWithFallback NurseEncounter decodePrenatalEncounterType) NurseEncounter
-        |> required "danger_signs" (decodeEverySet (decodeWithFallback NoDangerSign decodeDangerSign))
+        |> required "danger_signs" (decodeEverySet decodeDangerSign)
         |> optional "diagnoses" decodeDiagnoses (EverySet.singleton NoPrenatalDiagnosis)
         |> optional "muac" (nullable decodeFloat) Nothing
-        |> required "send_to_hc" (decodeEverySet (decodeWithFallback NoSendToHCSigns decodeSendToHCSign))
+        |> required "send_to_hc" (decodeEverySet decodeSendToHCSign)
 
 
 decodeNCDDataItem : Decoder NCDDataItem
@@ -360,13 +349,13 @@ decodeNCDEncounterDataItem =
                         EverySet.fromList items
                 )
             <|
-                list (decodeWithFallback NoNCDDiagnosis decodeNCDDiagnosis)
+                decodeListDroppingUnknown decodeNCDDiagnosis
     in
     succeed NCDEncounterDataItem
         |> required "start_date" decodeYYYYMMDD
         |> optional "diagnoses" decodeDiagnoses (EverySet.singleton NoNCDDiagnosis)
-        |> required "medical_conditions" (decodeEverySet (decodeWithFallback NoMedicalConditions decodeMedicalCondition))
-        |> required "co_morbidities" (decodeEverySet (decodeWithFallback NoMedicalConditions decodeMedicalCondition))
+        |> required "medical_conditions" (decodeEverySet decodeMedicalCondition)
+        |> required "co_morbidities" (decodeEverySet decodeMedicalCondition)
         |> optional "hiv_test_result" (nullable decodeTestResult) Nothing
         |> optional "hiv_test_execution_note" (nullable decodeTestExecutionNote) Nothing
 
@@ -402,7 +391,7 @@ decodeSPVEncounterDataItem =
                         EverySet.fromList items
                 )
             <|
-                list (decodeWithFallback NoEncounterWarnings decodeEncounterWarning)
+                decodeListDroppingUnknown decodeEncounterWarning
     in
     succeed SPVEncounterDataItem
         |> required "start_date" decodeYYYYMMDD


### PR DESCRIPTION
## What

Follow-up to #1834. Apply the same **drop-unknown** treatment to the dashboard-stats decoder (`Backend/Dashboard/Decoder.elm`), now using the canonical `decodeEverySet` / `decodeListDroppingUnknown` merged with #1830/#1834.

Closes #1835.

## Why

The dashboard decoder used the same falsifying idiom #1834 fixed in the patient-record decoders: an unrecognized clinical enum value was coerced into a "no-finding" sentinel (or, for the diagnosis/warning lists, the wrapper fell back to one). Under version skew this inserts spurious sentinels and **skews the aggregate dashboard counts**.

## How — 13 clinical list/set sites

- `decodeEverySet (decodeWithFallback <Sentinel> d)` → `decodeEverySet d` (×10): isolation, send_to_hc (×2), call_114, recommendation_114, contact_hc, recommendation_hc, danger_signs, medical_conditions, co_morbidities.
- `list (decodeWithFallback <Sentinel> d)` → `decodeListDroppingUnknown d` (×3): prenatal diagnoses, NCD diagnoses, encounter warnings — each inside the same `if empty then singleton <Sentinel> else fromList` wrapper as the patient-record decoders, so drop behaviour is identical.

Also removes the now-unused `Backend.Measurement.Model` sentinel-type import (those constructors were only referenced by the removed fallbacks).

## Out of scope (left as-is)
Scalar `encounter_type` (×2) and `sequence_number` defaults, and the `dict (decodeWithFallback (NutritionValue Neutral "X") …)` per-value placeholder — different patterns, not the list/set sentinel idiom.

## Tests
Mechanical call-site swaps onto helpers already unit-tested (merged with #1830/#1834). Local verification: `elm make src/elm/Main.elm` Success, `elm-test` **2734 passed**, `elm-format` clean, no new `elm-review` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
