### PR TITLE
Reset create & edit person forms on entry to stop stale-data leaks (#1837)

### DIFF
--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -1174,6 +1174,20 @@ update msg model =
                                 |> MsgLoggedIn
                                 |> List.singleton
 
+                        -- When starting a new person registration, clear the (singleton)
+                        -- create form, so a previous patient's abandoned entry can't
+                        -- pre-fill the next person's form. Only on a genuine page change,
+                        -- not when already on the page.
+                        UserPage (CreatePersonPage _ _) ->
+                            if model.activePage == page then
+                                []
+
+                            else
+                                Pages.Person.Model.ResetCreateForm
+                                    |> MsgPageCreatePerson
+                                    |> MsgLoggedIn
+                                    |> List.singleton
+
                         _ ->
                             []
             in

--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -1188,6 +1188,20 @@ update msg model =
                                     |> MsgLoggedIn
                                     |> List.singleton
 
+                        -- Likewise clear the (per-person) edit form on entry, so a
+                        -- previously abandoned, unsaved edit isn't shown as the current
+                        -- value and can't clobber a value synced from another device --
+                        -- with the form empty, the view re-seeds it from the DB.
+                        UserPage (EditPersonPage id) ->
+                            if model.activePage == page then
+                                []
+
+                            else
+                                Pages.Person.Model.ResetEditForm
+                                    |> MsgPageEditPerson id
+                                    |> MsgLoggedIn
+                                    |> List.singleton
+
                         _ ->
                             []
             in


### PR DESCRIPTION
## What

Reset the create- and edit-person forms on **entry** to their pages, so neither retains a previous patient's data across navigation.

Closes #1837.

## Why

Both forms are reset only on a successful save and never on navigation, and `applyDefaultValuesForPerson` is fill-if-empty:

- **Create (singleton → cross-patient leak):** enter A's name/DOB/national-ID, navigate away without saving, "Register new person" for B → B's form is pre-filled with **A's** data → B can be saved with A's demographics.
- **Edit (`Dict PersonId` → stale + lost update):** edit X, navigate away without saving → the unsaved form persists, is shown as the current value on re-open, and blocks the DB refresh. On multi-device sync this **silently clobbers** a correction synced from another device.

## How

Two cases added to `App/Update.elm`'s `SetActivePage` `extraMsgs`, mirroring the existing `AcuteIllnessParticipantPage → SetViewMode` reset:

```elm
UserPage (CreatePersonPage _ _) ->
    if model.activePage == page then [] else [ ResetCreateForm |> MsgPageCreatePerson |> MsgLoggedIn ]

UserPage (EditPersonPage id) ->
    if model.activePage == page then [] else [ ResetEditForm |> MsgPageEditPerson id |> MsgLoggedIn ]
```

- `ResetCreateForm` / `ResetEditForm` already exist (`Pages/Person/Update.elm:191,198` → `emptyCreateModel` / `emptyEditModel`).
- **Guarded** on `model.activePage /= page`, so they fire only on a genuine page change, never mid-edit.
- After reset, the view's `applyDefaultValuesForPerson` re-derives the contextual defaults (create) / re-seeds from the DB (edit), so legitimate presets and current values are preserved — only abandoned leftovers are cleared.

Scoped to `SetActivePage` (the entry point for both pages); on an internal click `activePage` is already pre-set by `SetActivePage`, and browser-back into a stale form isn't a start-fresh path.

## Verification
`elm make src/elm/Main.elm` Success, `elm-test` **2734 passed**, `elm-format` clean, no new `elm-review` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
