### PR TITLE
Remove Debug.toString from production view modules (R3-5 part A) (#1839)

### DIFF
--- a/client/src/elm/Pages/Dashboard/GraphUtils.elm
+++ b/client/src/elm/Pages/Dashboard/GraphUtils.elm
@@ -26,7 +26,7 @@ import Backend.Measurement.Model exposing (FamilyPlanningSign(..))
 import Color exposing (Color)
 import Pages.Dashboard.Model exposing (FeverCause(..), allFeverCauses)
 import Scale exposing (BandScale, ContinuousScale, defaultBandConfig)
-import Time exposing (Month)
+import Time exposing (Month(..))
 import TypedSvg exposing (g, line, rect)
 import TypedSvg.Attributes as Explicit
 import TypedSvg.Attributes.InPx exposing (height, rx, ry, strokeWidth, x, x1, x2, y, y1, y2)
@@ -114,7 +114,47 @@ yScale yScaleMax =
 
 xAxis : List ( Month, Nutrition ) -> Svg msg
 xAxis data =
-    Axis.bottom [] (Scale.toRenderable Debug.toString (xScale data))
+    Axis.bottom [] (Scale.toRenderable monthToString (xScale data))
+
+
+monthToString : Month -> String
+monthToString month =
+    case month of
+        Jan ->
+            "Jan"
+
+        Feb ->
+            "Feb"
+
+        Mar ->
+            "Mar"
+
+        Apr ->
+            "Apr"
+
+        May ->
+            "May"
+
+        Jun ->
+            "Jun"
+
+        Jul ->
+            "Jul"
+
+        Aug ->
+            "Aug"
+
+        Sep ->
+            "Sep"
+
+        Oct ->
+            "Oct"
+
+        Nov ->
+            "Nov"
+
+        Dec ->
+            "Dec"
 
 
 yAxis : Float -> Svg msg

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -30,6 +30,7 @@ import Backend.Dashboard.Model
         )
 import Backend.Entities exposing (..)
 import Backend.IndividualEncounterParticipant.Model exposing (DeliveryLocation(..))
+import Backend.Measurement.Encoder exposing (encodeFamilyPlanningSignAsString)
 import Backend.Measurement.Model exposing (ChildNutritionSign(..), FamilyPlanningSign(..))
 import Backend.Model exposing (ModelIndexedDb)
 import Backend.Nurse.Model exposing (Nurse)
@@ -595,11 +596,27 @@ viewMonthCell ( month, cellData ) =
     let
         class =
             classList
-                [ ( String.toLower <| Debug.toString cellData.class, True )
+                [ ( nutritionStatusToClass cellData.class, True )
                 , ( String.fromInt month, True )
                 ]
     in
     td [ class ] [ span [] [ text cellData.value ] ]
+
+
+nutritionStatusToClass : Backend.Dashboard.Model.NutritionStatus -> String
+nutritionStatusToClass status =
+    case status of
+        Backend.Dashboard.Model.Good ->
+            "good"
+
+        Backend.Dashboard.Model.Moderate ->
+            "moderate"
+
+        Backend.Dashboard.Model.Neutral ->
+            "neutral"
+
+        Backend.Dashboard.Model.Severe ->
+            "severe"
 
 
 viewFiltersPane : Language -> DashboardPage -> ModelIndexedDb -> Model -> Html Msg
@@ -2220,7 +2237,7 @@ viewFamilyPlanningDonutChart language stats =
                 dict
                     |> Dict.toList
                     |> List.filter (\( sign, _ ) -> sign /= NoFamilyPlanning)
-                    |> List.sortBy (\( name, _ ) -> Debug.toString name)
+                    |> List.sortBy (\( name, _ ) -> encodeFamilyPlanningSignAsString name)
         in
         div [ class "content" ]
             [ viewPieChart familyPlanningSignsColors signs

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -40,7 +40,6 @@ import Backend.Utils exposing (groupEducationEnabled)
 import Backend.WellChildEncounter.Model exposing (EncounterWarning(..), WellChildEncounterType(..))
 import Color exposing (Color)
 import Date exposing (Month, Unit(..), numberToMonth)
-import Debug exposing (toString)
 import EverySet exposing (EverySet)
 import Gizra.Html exposing (emptyNode, showIf, showMaybe)
 import Gizra.NominalDate exposing (NominalDate, formatDDMMYYYY, isDiffTruthy, toLastDayOfMonth)
@@ -2323,7 +2322,7 @@ viewPieChartLegend language translateFunc colorFunc signs =
                             "1"
 
                         else
-                            toString percentage
+                            String.fromInt percentage
                 in
                 div [ class "legend-item" ]
                     [ svg [ Svg.Attributes.width "12", Svg.Attributes.height "12", viewBox 0 0 100 100 ]

--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -4347,11 +4347,11 @@ viewUltrasoundContent language currentDate assembled data =
 
 viewNumberInput :
     Language
-    -> Maybe a
+    -> Maybe Int
     -> (String -> msg)
     -> String
     -> TranslationId
-    -> Maybe ( List (List (a -> Bool)), List (List (a -> Bool)) )
+    -> Maybe ( List (List (Int -> Bool)), List (List (Int -> Bool)) )
     -> Html msg
 viewNumberInput language maybeCurrentValue setMsg inputClass labelTranslationId maybeAlertConditions =
     let
@@ -4359,7 +4359,7 @@ viewNumberInput language maybeCurrentValue setMsg inputClass labelTranslationId 
             maybeCurrentValue
                 |> unwrap
                     ""
-                    Debug.toString
+                    String.fromInt
 
         ( labelWidth, inputWidth, alert ) =
             maybeAlertConditions

--- a/client/src/elm/SyncManager/View.elm
+++ b/client/src/elm/SyncManager/View.elm
@@ -211,7 +211,7 @@ viewSyncDownloadGeneral model webData =
                     ]
 
             RemoteData.Failure error ->
-                text <| Debug.toString error
+                text <| Utils.WebData.viewErrorForRollbar error
 
             RemoteData.Loading ->
                 spinner
@@ -299,7 +299,7 @@ viewSyncDownloadAuthority db model webData =
                             ]
 
                     RemoteData.Failure error ->
-                        text <| Debug.toString error
+                        text <| Utils.WebData.viewErrorForRollbar error
 
                     RemoteData.Loading ->
                         spinner
@@ -1008,7 +1008,7 @@ viewSyncStatus db model =
         , class "segment ui"
         ]
         [ summary [] [ text "Sync Status" ]
-        , div [] [ text <| "Sync status: " ++ Debug.toString model.syncStatus ]
+        , div [] [ text <| "Sync status: " ++ syncStatusToString model.syncStatus ]
         , case model.syncStatus of
             SyncDownloadGeneral webData ->
                 viewSyncDownloadGeneral model webData
@@ -1019,3 +1019,37 @@ viewSyncStatus db model =
             _ ->
                 emptyNode
         ]
+
+
+syncStatusToString : SyncStatus -> String
+syncStatusToString status =
+    case status of
+        SyncIdle ->
+            "SyncIdle"
+
+        SyncUploadPhoto _ _ ->
+            "SyncUploadPhoto"
+
+        SyncUploadScreenshot _ _ ->
+            "SyncUploadScreenshot"
+
+        SyncUploadGeneral _ ->
+            "SyncUploadGeneral"
+
+        SyncUploadWhatsApp _ ->
+            "SyncUploadWhatsApp"
+
+        SyncUploadAuthority _ ->
+            "SyncUploadAuthority"
+
+        SyncDownloadGeneral _ ->
+            "SyncDownloadGeneral"
+
+        SyncDownloadAuthority _ ->
+            "SyncDownloadAuthority"
+
+        SyncDownloadAuthorityDashboardStats _ ->
+            "SyncDownloadAuthorityDashboardStats"
+
+        SyncReportIncident _ ->
+            "SyncReportIncident"


### PR DESCRIPTION
## What

Replace the 5 `Debug.toString` calls in the four production view modules with explicit formatters.

Closes #1839.

## Why

`Debug.toString` runs reflection-based stringification at runtime (one is inside a **per-cell dashboard render loop**), violates the CLAUDE.md "no Debug in committed Elm" convention, and is a gate to ever enabling `elm make --optimize`.

This is **Part A** of R3-5 — it does **not** enable `--optimize` yet (that also needs the `Debug.todo` removed from `Utils/AllDict.elm` and the gulp publish build wired, a separate/riskier follow-up).

## How

| Site | Replacement |
|---|---|
| `Dashboard/View.elm` cell class (`NutritionStatus`) | new `nutritionStatusToClass` (Good→`"good"`, …) |
| `Dashboard/View.elm` family-planning sort key (`FamilyPlanningSign`) | reuse `encodeFamilyPlanningSignAsString` |
| `Dashboard/GraphUtils.elm` x-axis tick labels (`BandScale Month`) | new `monthToString` (preserves "Jan".."Dec") |
| `Prenatal/Activity/View.elm` `viewNumberInput` value | specialize the polymorphic `Maybe a` → `Maybe Int` (all callers pass `Int`) + `String.fromInt` |
| `SyncManager/View.elm` errors (×2, `Http.Error`) | reuse `Utils.WebData.viewErrorForRollbar` |
| `SyncManager/View.elm` `SyncStatus` line | new `syncStatusToString` (variant names; dev view) |

All behavior-preserving (or, for the dev sync view, equivalent human-readable output).

## Verification

- No `Debug.*` remain in the four modules.
- `elm make src/elm/Main.elm` → Success.
- **`elm make --optimize` now blocks only on `Utils.AllDict`** — confirming the four view modules are cleared (the remaining `Debug.todo` in `AllDict` is Part B).
- `elm-test` → **2734 passed**; `elm-format` clean; no new `elm-review` findings.

## Follow-ups (not in this PR)
- **Part B**: remove `Debug.todo` from `Utils/AllDict.elm` (red-black-tree guards).
- **Part C**: enable `--optimize` for the gulp publish build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
