### PR TITLE
Fix dead HIV/Partner-HIV/Malaria result entry on Prenatal Labs-History (#1842)

### DIFF
--- a/client/src/elm/Pages/Prenatal/RecurrentActivity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/RecurrentActivity/Update.elm
@@ -1666,6 +1666,178 @@ updateLabsHistory originEncounterId labEncounterId isLabTech db msg data =
             )
                 |> sequenceExtra (updateLabsHistory originEncounterId labEncounterId isLabTech db) extraMsgs
 
-        -- Other messages are not related to Labs History, and will not be sent.
+        SetHIVTestResult value ->
+            let
+                form =
+                    data.hivTestForm
+
+                updatedForm =
+                    { form
+                        | testResult = testResultFromString value
+                        , hivProgramHC = Nothing
+                        , hivProgramHCDirty = True
+                        , partnerHIVPositive = Nothing
+                        , partnerHIVPositiveDirty = True
+                        , partnerTakingARV = Nothing
+                        , partnerTakingARVDirty = True
+                        , partnerSurpressedViralLoad = Nothing
+                        , partnerSurpressedViralLoadDirty = True
+                    }
+            in
+            ( { data | hivTestForm = updatedForm }
+            , Cmd.none
+            , []
+            )
+
+        SetHIVTestFormBoolInput formUpdateFunc value ->
+            let
+                form =
+                    data.hivTestForm
+
+                updatedForm =
+                    formUpdateFunc value form
+            in
+            ( { data | hivTestForm = updatedForm }
+            , Cmd.none
+            , []
+            )
+
+        SaveHIVResult personId saved _ ->
+            let
+                measurementId =
+                    Maybe.map Tuple.first saved
+
+                measurement =
+                    getMeasurementValueFunc saved
+
+                form =
+                    data.hivTestForm
+
+                appMsgs =
+                    toHIVResultValueWithDefault isLabTech measurement form
+                        |> Maybe.map
+                            (Backend.PrenatalEncounter.Model.SaveHIVTest personId measurementId
+                                >> Backend.Model.MsgPrenatalEncounter labEncounterId
+                                >> App.Model.MsgIndexedDb
+                                >> List.singleton
+                            )
+                        |> Maybe.withDefault []
+            in
+            ( data
+            , Cmd.none
+            , appMsgs
+            )
+                |> sequenceExtra (updateLabsHistory originEncounterId labEncounterId isLabTech db) extraMsgs
+
+        SetPartnerHIVTestResult value ->
+            let
+                form =
+                    data.partnerHIVTestForm
+
+                updatedForm =
+                    { form | testResult = testResultFromString value }
+            in
+            ( { data | partnerHIVTestForm = updatedForm }
+            , Cmd.none
+            , []
+            )
+
+        SetPartnerHIVTestFormBoolInput formUpdateFunc value ->
+            let
+                form =
+                    data.partnerHIVTestForm
+
+                updatedForm =
+                    formUpdateFunc value form
+            in
+            ( { data | partnerHIVTestForm = updatedForm }
+            , Cmd.none
+            , []
+            )
+
+        SavePartnerHIVResult personId saved _ ->
+            let
+                measurementId =
+                    Maybe.map Tuple.first saved
+
+                measurement =
+                    getMeasurementValueFunc saved
+
+                form =
+                    data.partnerHIVTestForm
+
+                appMsgs =
+                    toPartnerHIVResultValueWithDefault isLabTech measurement form
+                        |> Maybe.map
+                            (Backend.PrenatalEncounter.Model.SavePartnerHIVTest personId measurementId
+                                >> Backend.Model.MsgPrenatalEncounter labEncounterId
+                                >> App.Model.MsgIndexedDb
+                                >> List.singleton
+                            )
+                        |> Maybe.withDefault []
+            in
+            ( data
+            , Cmd.none
+            , appMsgs
+            )
+                |> sequenceExtra (updateLabsHistory originEncounterId labEncounterId isLabTech db) extraMsgs
+
+        SetMalariaTestResult value ->
+            let
+                form =
+                    data.malariaTestForm
+
+                updatedForm =
+                    { form | testResult = testResultFromString value }
+            in
+            ( { data | malariaTestForm = updatedForm }
+            , Cmd.none
+            , []
+            )
+
+        SetBloodSmearResult value ->
+            let
+                form =
+                    data.malariaTestForm
+
+                updatedForm =
+                    { form | bloodSmearResult = bloodSmearResultFromString value }
+            in
+            ( { data | malariaTestForm = updatedForm }
+            , Cmd.none
+            , []
+            )
+
+        SaveMalariaResult personId saved _ ->
+            let
+                measurementId =
+                    Maybe.map Tuple.first saved
+
+                measurement =
+                    getMeasurementValueFunc saved
+
+                form =
+                    data.malariaTestForm
+
+                appMsgs =
+                    toMalariaResultValueWithDefault measurement form
+                        |> Maybe.map
+                            (Backend.PrenatalEncounter.Model.SaveMalariaTest personId measurementId
+                                >> Backend.Model.MsgPrenatalEncounter labEncounterId
+                                >> App.Model.MsgIndexedDb
+                                >> List.singleton
+                            )
+                        |> Maybe.withDefault []
+            in
+            ( data
+            , Cmd.none
+            , appMsgs
+            )
+                |> sequenceExtra (updateLabsHistory originEncounterId labEncounterId isLabTech db) extraMsgs
+
+        -- Any other message is not related to Labs History. NOTE: every lab test
+        -- form rendered on this page MUST have its Set/Save branches handled above;
+        -- otherwise its input is silently dropped here (this is what broke
+        -- HIV/Partner-HIV/Malaria result entry until these branches were added).
         _ ->
             ( data, Cmd.none, [] )


### PR DESCRIPTION
## What
Adds the missing HIV / Partner-HIV / Malaria `Set`/`Save` handlers to `updateLabsHistory`, fixing silently-dead deferred-result entry on the Prenatal **Labs-History** screen.

Closes #1842.

## Why
The Labs-History page routes exclusively to `updateLabsHistory`, which had branches for every prenatal lab **except** these three. Their `Set*`/`Save*` messages (which the shared `viewLab` emits, and which the regular `update` *does* handle) fell through the silent `_ -> ( data, Cmd.none, [] )` catch-all. So a nurse entering a deferred HIV/Partner-HIV/Malaria result got: inputs dropped, Save a no-op, no navigation — the pending result could never be completed. All three are deferrable via the recording form's `immediateResult` ("RDT now vs done-at-lab") toggle, so they genuinely reach this screen.

## How
Nine new branches in `updateLabsHistory`, grouped by test, mirroring the existing Syphilis branches and the regular `update` handlers:

| Test | Branches |
|---|---|
| HIV | `SetHIVTestResult`, `SetHIVTestFormBoolInput`, `SaveHIVResult` |
| Partner-HIV | `SetPartnerHIVTestResult`, `SetPartnerHIVTestFormBoolInput`, `SavePartnerHIVResult` |
| Malaria | `SetMalariaTestResult`, `SetBloodSmearResult`, `SaveMalariaResult` |

- `Set*` update `data.<x>TestForm` directly (the labs-history `data` *is* the `LabResultsData`).
- `Save*` build the value with `to<X>ResultValueWithDefault` and dispatch `Save<X>Test personId measurementId` (updating the existing pending measurement by id), then `sequenceExtra … extraMsgs` to redirect back to the Laboratory page — same shape as the Syphilis branch. (These forms have no `originatingEncounter` field — matching the regular `update`; Malaria's value-fn takes no `isLabTech`.)
- Tightened the catch-all comment to warn that every lab form rendered on this page must have explicit branches above — the silent `_ ->` is what hid this bug.

## Verification
- `elm make src/elm/Main.elm` → Success.
- `elm-test` → **2734 passed**; `elm-format` clean; no new `elm-review` findings (the `Backend.Entities` hit is pre-existing develop noise).

R4-1 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
