### PR TITLE
Fix dashboard underweight z-score populated with stunting value (#1844)

### DIFF
--- a/client/src/elm/Backend/Dashboard/Encoder.elm
+++ b/client/src/elm/Backend/Dashboard/Encoder.elm
@@ -419,7 +419,7 @@ encodeSPVEncounterDataItem item =
 
         zscoreUnderweight =
             Maybe.map (\value -> [ ( "zscore_underweight", float value ) ])
-                item.zscoreStunting
+                item.zscoreUnderweight
                 |> Maybe.withDefault []
 
         zscoreWasting =
@@ -507,7 +507,7 @@ encodeNutritionIndividualEncounterDataItem item =
 
         zscoreUnderweight =
             Maybe.map (\value -> [ ( "zscore_underweight", float value ) ])
-                item.zscoreStunting
+                item.zscoreUnderweight
                 |> Maybe.withDefault []
 
         zscoreWasting =
@@ -553,7 +553,7 @@ encodeNutritionGroupEncounterDataItem item =
 
         zscoreUnderweight =
             Maybe.map (\value -> [ ( "zscore_underweight", float value ) ])
-                item.zscoreStunting
+                item.zscoreUnderweight
                 |> Maybe.withDefault []
 
         zscoreWasting =


### PR DESCRIPTION
## What
Fixes the statistics dashboard's **underweight** nutrition metric, which was silently populated with the **stunting** z-score.

Closes #1844.

## Why
In `Backend/Dashboard/Encoder.elm`, all three encoder functions built the `zscore_underweight` JSON key from `item.zscoreStunting` instead of `item.zscoreUnderweight` (lines 422 / 510 / 556). The `zscore_stunting` key was already correct, and the Model + decoder keep the two fields distinct — so `zscore_underweight` was serialized with the stunting value and overwrote the real underweight z-score on decode. The output also feeds the cached dashboard stats (`SyncManager/Utils.elm` → `Pages/Dashboard/View.elm`), so the corrupted value reached the display. Present since `5d4600e6c` (2023-12-31).

## How
Swapped the three `zscore_underweight` reads to `item.zscoreUnderweight` (one site per encounter type: SPV, nutrition-individual, nutrition-group).

## Verification
- `elm make src/elm/Main.elm` → Success.
- `elm-test` → **2734 passed**; `elm-format` clean. Pure field-reference swap (same record, no import changes).

R4-3 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
