### PR TITLE
Fix clinical dosing/regimen translation errors (patient safety) (#1846)

### DIFF
--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -4354,21 +4354,21 @@ translationSet trans =
         ByMouthDailyForXDays days ->
             { english = "by mouth daily x " ++ String.fromInt days ++ " days"
             , kinyarwanda = Just <| "ku munsi / mu  minsi " ++ String.fromInt days
-            , kirundi = Just <| "Gucisha mu kanwa buri munsi mu iminsi " ++ String.fromInt days
+            , kirundi = Just <| "gucisha mu kanwa buri munsi mu iminsi " ++ String.fromInt days
             , somali = Just <| "Afka maalinki x " ++ String.fromInt days ++ " maalin"
             }
 
         ByMouthTwiceADayForXDays days ->
             { english = "by mouth twice per day x " ++ String.fromInt days ++ " days"
             , kinyarwanda = Just <| "inshuro ebyiri ku munsi/ mu minsi " ++ String.fromInt days
-            , kirundi = Just <| "Gucisha mu kanwa incuro 2 k'umunsi mu iminsi " ++ String.fromInt days
+            , kirundi = Just <| "gucisha mu kanwa incuro 2 k'umunsi mu iminsi " ++ String.fromInt days
             , somali = Just <| "afka laba jeer maalinki x " ++ String.fromInt days ++ " maalin"
             }
 
         ByMouthThreeTimesADayForXDays days ->
             { english = "by mouth three times per day x " ++ String.fromInt days ++ " days"
             , kinyarwanda = Just <| "inshuro 3 ku munsi/ mu minsi " ++ String.fromInt days
-            , kirundi = Just <| "Kumira incuro 3 k'umunsi mu iminsi " ++ String.fromInt days
+            , kirundi = Just <| "kumira incuro 3 k'umunsi mu iminsi " ++ String.fromInt days
             , somali = Just <| "afka 3 jeer maalinki x " ++ String.fromInt days ++ " maalin"
             }
 

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -4367,8 +4367,8 @@ translationSet trans =
 
         ByMouthThreeTimesADayForXDays days ->
             { english = "by mouth three times per day x " ++ String.fromInt days ++ " days"
-            , kinyarwanda = Just <| "inshuro ebyiri ku munsi/ mu minsi " ++ String.fromInt days
-            , kirundi = Just "Kumira incuro 3 k'umunsi mu kiringo (Igitigiri) iminsi"
+            , kinyarwanda = Just <| "inshuro 3 ku munsi/ mu minsi " ++ String.fromInt days
+            , kirundi = Just <| "Kumira incuro 3 k'umunsi mu iminsi " ++ String.fromInt days
             , somali = Just <| "afka 3 jeer maalinki x " ++ String.fromInt days ++ " maalin"
             }
 
@@ -12564,7 +12564,7 @@ translationSet trans =
             { english = "Ciprofloxacin (1000mg): by mouth as a single dose"
             , kinyarwanda = Just "Kunywa ikinini cya Ciplofoloxacine (1000mg) inshuro imwe"
             , kirundi = Just "Ciprofloxacine (1000 mg) : Kumira igipimo kimwe/idozi imwe"
-            , somali = Just "Ciprofloxacin (100mg): afka hal doos "
+            , somali = Just "Ciprofloxacin (1000mg): afka hal doos "
             }
 
         MedicationDistributionNoticeGonorrheaPartnerMed2 ->
@@ -26601,7 +26601,7 @@ translationSet trans =
 
             else if arvs then
                 { english = "At the previous visit you were given TDF + 3TC (1 tablet), to be taken by mouth 1x a day."
-                , kinyarwanda = Just "Mu isura riheruka wahawe ikinini cya Tenofoviri na Lamividine na Dulutogaraviri (50mg), ikinini kimwe ku munsi."
+                , kinyarwanda = Just "Mu isura riheruka wahawe ikinini cya Tenofoviri na Lamividine, ikinini kimwe ku munsi."
                 , kirundi = Just "Aho uherukira kuza, wahawe FTD + 3TC (ikinini 1), umuti/ikinini wo/co gufata (kumira) rimwe (1) ku munsi."
                 , somali = Nothing
                 }


### PR DESCRIPTION
## What
Fixes four **patient-safety** dosing/regimen translation errors in `Translate.elm`. Closes #1846.

## The errors (all objective — provable without language fluency)
| # | Where | Bug | Fix |
|---|---|---|---|
| 1 | `:12567` Ciprofloxacin (Somali) | `100mg` vs EN/RW/RN `1000mg` — **10× under-dose** | `100mg`→`1000mg` (pure digit) |
| 2 | `:26604` HIV `arvs` (Kinyarwanda) | "TDF + 3TC" wrongly appends `na Dulutogaraviri (50mg)` (pasted from the adjacent dolutegravir entry; EN + Kirundi omit it) | remove the contaminant |
| 3 | `:4370` 3×/day (Kinyarwanda) | verbatim copy of the *twice* entry's `inshuro ebyiri` (two) | `ebyiri`→`3` (form used at `:3317/:19419/:20433`) |
| 4 | `:4371` 3×/day (Kirundi) | garbled `(Igitigiri)` placeholder, missing `× N days` | reuse the well-formed twice-entry tail + `++ String.fromInt days` |

The correct **twice-a-day** entry is left untouched (its "ebyiri"/"incuro 2" are right for twice).

## Reviewer note
#1 is a pure digit. #2 removes a confirmed contaminant; #3/#4 propagate an existing in-table form (only the number differs). A native Kinyarwanda/Kirundi reviewer is welcome to confirm #2–#4 wording, but each is a strict improvement over a dangerous current state.

## Verification
- `elm make src/elm/Main.elm` → Success; `elm-test` → **2734 passed**; `elm-format` clean.

R5-1 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
