### PR TITLE
Fix nutrition report month-overflow on month-end run-dates (#1848)

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -2548,6 +2548,21 @@ function hedley_reports_nutrition_metrics_to_table_data($type, array $metrics) {
 }
 
 /**
+ * Resolves the timestamp of the first day of the current month.
+ *
+ * Report period stepping uses relative "-N month" arithmetic, which overflows
+ * on month-end run-dates (e.g. from the 31st, "-1 month" skips to the following
+ * month, dropping and duplicating months). Anchoring to the first of the month
+ * - which exists in every month - avoids that overflow.
+ *
+ * @return int
+ *   Unix timestamp for the first day of the current month.
+ */
+function hedley_reports_current_month_start() {
+  return strtotime(date('Y-m-01'));
+}
+
+/**
  * Generates monthly prevalence data from encounters metrics grouped by month.
  *
  * @param array $encounters_by_month
@@ -2558,7 +2573,7 @@ function hedley_reports_nutrition_metrics_to_table_data($type, array $metrics) {
  */
 function hedley_reports_generate_monthly_prevalence_data(array $encounters_by_month) {
   $result = [];
-  $current_timestamp = time();
+  $current_timestamp = hedley_reports_current_month_start();
   for ($index = 1; $index <= 12; $index++) {
     $target_timestamp = strtotime("-$index month", $current_timestamp);
     $target_date_year = date('Y', $target_timestamp);
@@ -2582,7 +2597,7 @@ function hedley_reports_generate_monthly_prevalence_data(array $encounters_by_mo
  */
 function hedley_reports_generate_monthly_incidence_data(array $encounters_by_month) {
   $result = [];
-  $current_timestamp = time();
+  $current_timestamp = hedley_reports_current_month_start();
 
   for ($index = 1; $index <= 12; $index++) {
     $target_timestamp = strtotime("-$index month", $current_timestamp);
@@ -2626,7 +2641,7 @@ function hedley_reports_generate_quarterly_incidence_data(array $encounters_by_m
   }
 
   $result = [];
-  $current_timestamp = time();
+  $current_timestamp = hedley_reports_current_month_start();
   // Showing data of the previous 4 quarters.
   for ($index = 1; $index <= 4; $index++) {
     $selected_date = strtotime("-" . (3 * $index) . " months", $current_timestamp);
@@ -2841,7 +2856,8 @@ function hedley_reports_resolve_data_set_for_year($year_index, array $encounters
  */
 function hedley_reports_resolve_data_set_for_quarter($quarter_index, array $encounters_by_month) {
   // Calculate the selected date by subtracting months.
-  $selected_date = strtotime("-" . (3 * ($quarter_index - 1)) . " months", time());
+  $anchor = hedley_reports_current_month_start();
+  $selected_date = strtotime("-" . (3 * ($quarter_index - 1)) . " months", $anchor);
 
   [$year, $quarter] = hedley_reports_resolve_quarter_date_info($selected_date);
 


### PR DESCRIPTION
## What
Fixes the nutrition statistical report silently **dropping and duplicating months/quarters** when generated on the 29th–31st. Closes #1848.

## Why
The period steppers anchor to `time()` and use `strtotime("-N month", …)`, which overflows the short target month forward on month-end dates (e.g. May 31 `−1 month` → May 1, not April). Months get skipped (their real data omitted), keys duplicate, and the incidence baseline window is computed off the overflowed target. The quarterly path can overflow across a **quarter** boundary (Dec 31 `−3 months` → Oct = Q4 not Q3), so `resolve_data_set_for_quarter` sums the wrong quarter's data. It's a *run-date* bug (~10% of days), silent because the numbers stay plausible.

## How
- New helper `hedley_reports_current_month_start()` returns the first day of the current month (which exists in every month, so `"-N month"` can't overflow).
- Anchored the four affected steppers to it: `generate_monthly_prevalence_data`, `generate_monthly_incidence_data`, `generate_quarterly_incidence_data`, `resolve_data_set_for_quarter`.
- The **yearly** functions only extract `date('Y')` (robust to day overflow) → left unchanged.
- Behavior-preserving on the other ~90% of run-dates (same 12 months / 4 quarters, just anchored to day 1).

## Scope
`hedley_reports.module` only. The drush script `generate-nutrition-report.php` has the same pattern but is **not in use**, so it's intentionally left.

## Verification
- `php -l` clean; **phpcs Drupal + DrupalPractice both pass** (exit 0).
- Mechanism reproduced in PHP (May 31 → April & February dropped, May & March duplicated).

R5-3 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
