### PR TITLE
Fix NCD Social History encoding the wrong field for difficulty sign (#1850)

### DIFF
--- a/client/src/elm/Pages/NCD/Activity/Utils.elm
+++ b/client/src/elm/Pages/NCD/Activity/Utils.elm
@@ -480,7 +480,7 @@ toSocialHistoryValue form =
             [ Maybe.map (ifTrue SignDrinkAlcohol) form.alcohol
             , Maybe.map (ifTrue SignSmokeCigarettes) form.cigarettes
             , Maybe.map (ifTrue SignConsumeSalt) form.salt
-            , Maybe.map (ifTrue SignDifficult4TimesAYear) form.salt
+            , Maybe.map (ifTrue SignDifficult4TimesAYear) form.difficult4Times
             , Maybe.map (ifTrue SignHelpWithTreatmentAtHome) form.helpAtHome
             ]
                 |> Maybe.Extra.combine


### PR DESCRIPTION
## What
Fixes the NCD **Social History** activity discarding the nurse's "difficulty affording treatment 4×/year" answer and saving the salt answer in its place. Closes #1850.

## Why
`toSocialHistoryValue` (`Pages/NCD/Activity/Utils.elm:483`) encoded `SignDifficult4TimesAYear` from `form.salt` — a copy-paste of the `SignConsumeSalt` line above it — instead of the dedicated `form.difficult4Times` field. That field is correctly wired into the decoder (`:459`), the rendered question (`:702/704/707`), and the completion-task counter (`:725`); only the encoder read the wrong field. So the nurse must answer the difficulty question to complete the activity, but the answer never reached the saved measurement — it was overwritten by the salt answer on every encounter where the two differ. Introduced in `dabd0eafe`.

## How
One-line change: `form.salt` → `form.difficult4Times` on line 483.

## Verification
- `elm make src/elm/Main.elm` → Success; `elm-test` → **2734 passed**; `elm-format` clean.

R6-1 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
