### PR TITLE
Fix NCDA low-birth-weight flag dropped on questionnaire birth weight (#1852)

### DIFF
--- a/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
+++ b/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
@@ -520,10 +520,10 @@ function hedley_ncda_calculate_aggregated_data_for_person($person, $birth_date_f
   // we try to resolve from NCDA questionnaires.
   if (empty($birth_weight)) {
     foreach ($ncdas as $ncda) {
-      if (!empty($ncda->field_birth_weight) && !empty($ncda->field_weight[LANGUAGE_NONE][0]['value'])) {
+      if (!empty($ncda->field_birth_weight[LANGUAGE_NONE][0]['value'])) {
         $birth_weight = $ncda->field_birth_weight[LANGUAGE_NONE][0]['value'];
+        break;
       }
-      break;
     }
   }
   if ($birth_weight) {


### PR DESCRIPTION
## What
Fixes the NCDA / Child Scorecard silently dropping the **low-birth-weight** indicator for children whose birth weight was recorded on an NCDA questionnaire. Closes #1852.

## Why
In `hedley_ncda_calculate_aggregated_data_for_person` (reached from the registered advanced-queue worker), the questionnaire birth-weight fallback (`hedley_ncda.module:521-528`) had two compounding defects:
1. **Wrong-field guard** — it required the NCDA's `field_weight` (current weight) to be non-empty before reading `field_birth_weight`. They're independent, separately-optional fields, so a questionnaire with a birth weight but no current weight never resolved.
2. **Misplaced `break`** — outside the `if`, so only the first NCDA node was ever examined.

So `$data['low_birth_weight']` (`$birth_weight < 2000`) was never set for those children, and the indicator vanished from their scorecard. (The pregnancy-summary path above correctly reads `field_weight` because that bundle stores birth weight there; only the questionnaire path uses the dedicated `field_birth_weight`.)

## How
Guard on the `field_birth_weight` value and move the `break` inside the `if`:
```php
foreach ($ncdas as $ncda) {
  if (!empty($ncda->field_birth_weight[LANGUAGE_NONE][0]['value'])) {
    $birth_weight = $ncda->field_birth_weight[LANGUAGE_NONE][0]['value'];
    break;
  }
}
```

## Verification
- `php -l` clean; **phpcs Drupal + DrupalPractice both pass** (exit 0, full CI extensions).

R6-2 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
