### PR TITLE
Cache downloaded WellChild photos on secondary devices (#1854)

### DIFF
--- a/client/src/elm/SyncManager/Utils.elm
+++ b/client/src/elm/SyncManager/Utils.elm
@@ -1089,6 +1089,9 @@ getImageFromBackendAuthorityEntity backendAuthorityEntity =
             in
             Just url
 
+        BackendAuthorityWellChildPhoto identifier ->
+            getImageFromMeasurement identifier
+
         _ ->
             Nothing
 


### PR DESCRIPTION
## What
Caches downloaded **WellChild photos** on secondary devices, fixing a permanent broken-image bug. Closes #1854.

## Why
`getImageFromBackendAuthorityEntity` (`SyncManager/Utils.elm:1069-1092`) is the single chokepoint that schedules a downloaded entity's image for fetch into the local `"photos"` cache. It handled every photo-bearing authority type **except `BackendAuthorityWellChildPhoto`**, which fell through `_ -> Nothing`. So a WellChild photo uploaded from device A was never proactively fetched on device B, and viewing it there hit a `photos.js` 404 (no cached copy; the in-app URL carries no `access_token`). The asymmetry is provable — the upload encoder and `backendAuthorityEntityToRevision` both handle WellChildPhoto; only this download-side extraction omitted it.

## How
One branch added, reusing the existing helper exactly like the sibling photo types:
```elm
BackendAuthorityWellChildPhoto identifier ->
    getImageFromMeasurement identifier
```

## Verification
- `elm make src/elm/Main.elm` → Success; `elm-test` → **2734 passed**; `elm-format` clean. Pure case-branch addition reusing an existing helper — no import changes.

R6-3 from the rolling code-review exercise. (Download-side sibling of the upload-side photo-wiring gotcha — new photo types must be added to both dispatches.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
