### PR TITLE
Fix WhatsApp batch scripts skipping records via unordered pagination (#1856)

### DIFF
--- a/server/hedley/modules/custom/hedley_whatsapp/scripts/delete-processed.php
+++ b/server/hedley/modules/custom/hedley_whatsapp/scripts/delete-processed.php
@@ -42,6 +42,7 @@ $or = db_or();
 $or->isNotNull('dc.field_date_concluded_value');
 $or->condition('da.field_delivery_attempts_value', $delivery_attempts, '>=');
 $base_query->condition($or);
+$base_query->orderBy('n.nid');
 
 $count_query = clone $base_query;
 if ($nid) {

--- a/server/hedley/modules/custom/hedley_whatsapp/scripts/delete-public-files.php
+++ b/server/hedley/modules/custom/hedley_whatsapp/scripts/delete-public-files.php
@@ -31,10 +31,11 @@ $base_query = db_select('file_managed', 'fm');
 $base_query->addField('fm', 'fid');
 $base_query->condition('fm.uri', 'public://whatsapp-upload%', 'LIKE');
 $base_query->condition('fm.timestamp', $hour_ago, '<');
+$base_query->orderBy('fm.fid');
 
 $count_query = clone $base_query;
 if ($fid) {
-  $count_query->condition('n.fid', $fid, '>');
+  $count_query->condition('fid', $fid, '>');
 }
 $executed = $count_query->execute();
 $total = $executed->rowCount();

--- a/server/hedley/modules/custom/hedley_whatsapp/scripts/send-messages.php
+++ b/server/hedley/modules/custom/hedley_whatsapp/scripts/send-messages.php
@@ -56,6 +56,7 @@ $base_query->leftJoin('field_data_field_date_concluded', 'dc', 'n.nid = dc.entit
 $base_query->isNull('dc.field_date_concluded_value');
 $base_query->leftJoin('field_data_field_delivery_attempts', 'da', 'n.nid = da.entity_id');
 $base_query->condition('da.field_delivery_attempts_value', $delivery_attempts, '<');
+$base_query->orderBy('n.nid');
 
 $count_query = clone $base_query;
 if ($nid) {


### PR DESCRIPTION
## What
Fixes the live `report_to_whatsapp` batch scripts skipping records due to unordered keyset pagination, plus a fatal alias on one script's resume path. Closes #1856.

## Why
All three scripts paginate with `condition(id, $cursor, '>')->range(0,$batch)` then `$cursor = end($ids)` — correct only if rows are **ordered by the cursor column**, but none called `orderBy`. Without it, MariaDB's arbitrary `LIMIT` order means `end($ids)` isn't the batch max, so the next iteration's `> $cursor` filter jumps past unprocessed rows while `$processed` still reaches `$total`.

- `send-messages.php` (by `n.nid`) — patients' progress reports skipped (self-heals next run).
- `delete-processed.php` (by `n.nid`) — skipped records keep their 1 MB+ screenshots (storage leak).
- `delete-public-files.php` (by `fm.fid`) — same skip, **and** the count-query resume guard referenced `n.fid` while the only table is aliased `fm` → `PDOException` on the documented `--fid=N` resume path (first run is fine, `$fid=0` skips it).

Matches the project's own convention (`update-creation-date.php` / `graduate-participants.php` order by nid so `end()` is the max).

## How
- `orderBy('n.nid')` on the two `whatsapp_record` base queries; `orderBy('fm.fid')` on the file query.
- `delete-public-files.php` count guard `n.fid` → `fid`.

## Verification
- `php -l` clean ×3; **phpcs Drupal + DrupalPractice both pass** (exit 0, full CI extensions). Confirmed each script's `$cursor = end($ids)` advance, so the ordering is load-bearing.

R6-5 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
