### PR TITLE
Fix inverted date filter in default ECD milestone status (+ test) (#1858)

### DIFF
--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -1,0 +1,43 @@
+module Pages.WellChild.Activity.Test exposing (all)
+
+import Date
+import Expect
+import Pages.WellChild.Activity.Utils exposing (resolveFirstEncounterDateAfterMilestone)
+import Test exposing (Test, describe, test)
+import Time
+
+
+all : Test
+all =
+    describe "Pages.WellChild.Activity.Utils.resolveFirstEncounterDateAfterMilestone"
+        [ test "picks the earliest encounter strictly AFTER the milestone, not an earlier one before it" <|
+            \_ ->
+                let
+                    milestone =
+                        Date.fromCalendarDate 2024 Time.Jul 1
+                in
+                resolveFirstEncounterDateAfterMilestone milestone
+                    [ Date.fromCalendarDate 2024 Time.Apr 1
+                    , Date.fromCalendarDate 2024 Time.Jun 20
+                    , Date.fromCalendarDate 2024 Time.Jul 15
+                    , Date.fromCalendarDate 2024 Time.Sep 1
+                    ]
+                    |> Expect.equal (Just (Date.fromCalendarDate 2024 Time.Jul 15))
+        , test "returns Nothing when every encounter is on or before the milestone" <|
+            \_ ->
+                let
+                    milestone =
+                        Date.fromCalendarDate 2024 Time.Jul 1
+                in
+                resolveFirstEncounterDateAfterMilestone milestone
+                    [ Date.fromCalendarDate 2024 Time.Apr 1
+                    , Date.fromCalendarDate 2024 Time.Jun 20
+                    , Date.fromCalendarDate 2024 Time.Jul 1
+                    ]
+                    |> Expect.equal Nothing
+        , test "treats an encounter exactly on the milestone date as not after it" <|
+            \_ ->
+                resolveFirstEncounterDateAfterMilestone (Date.fromCalendarDate 2024 Time.Jul 1)
+                    [ Date.fromCalendarDate 2024 Time.Jul 1 ]
+                    |> Expect.equal Nothing
+        ]

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.WellChild.Activity.Utils exposing (activityCompleted, albendazoleAdministrationFormConfig, dangerSignsTasksCompletedFromTotal, ecdSigns6To12MonthsMajors, ecdSignsFrom13Weeks, ecdSignsFrom5Weeks, expectActivity, expectImmunisationTask, expectMedicationTask, expectNextStepsTask, expectNutritionAssessmentTask, expectedECDSignsOnMilestone, generateASAPImmunisationDate, generateCompletedECDSigns, generateNextDateForImmunisationVisit, generateNextVisitDates, generateNutritionAssessment, generateRemianingECDSignsAfterCurrentEncounter, generateRemianingECDSignsBeforeCurrentEncounter, generateVitalsFormConfig, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, headCircumferenceFormAndTasks, headCircumferenceFormWithDefault, immunisationTasks, immunisationTasksCompletedFromTotal, mandatoryDangerSignsTasksCompleted, mandatoryNutritionAssessmentTasksCompleted, mebendezoleAdministrationFormConfig, medicationTasksCompletedFromTotal, nextStepsTasks, nextStepsTasksCompletedFromTotal, nextVisitFormWithDefault, nutritionAssessmentTaskCompleted, nutritionAssessmentTasksCompletedFromTotal, pregnancySummaryFormWithDefault, resolveNutritionAssessmentTasks, symptomsReviewFormInputsAndTasks, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType, vaccinationFormDynamicContentAndTasks, vitaminAAdministrationFormConfig, wellChildECDFormWithDefault)
+module Pages.WellChild.Activity.Utils exposing (activityCompleted, albendazoleAdministrationFormConfig, dangerSignsTasksCompletedFromTotal, ecdSigns6To12MonthsMajors, ecdSignsFrom13Weeks, ecdSignsFrom5Weeks, expectActivity, expectImmunisationTask, expectMedicationTask, expectNextStepsTask, expectNutritionAssessmentTask, expectedECDSignsOnMilestone, generateASAPImmunisationDate, generateCompletedECDSigns, generateNextDateForImmunisationVisit, generateNextVisitDates, generateNutritionAssessment, generateRemianingECDSignsAfterCurrentEncounter, generateRemianingECDSignsBeforeCurrentEncounter, generateVitalsFormConfig, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, headCircumferenceFormAndTasks, headCircumferenceFormWithDefault, immunisationTasks, immunisationTasksCompletedFromTotal, mandatoryDangerSignsTasksCompleted, mandatoryNutritionAssessmentTasksCompleted, mebendezoleAdministrationFormConfig, medicationTasksCompletedFromTotal, nextStepsTasks, nextStepsTasksCompletedFromTotal, nextVisitFormWithDefault, nutritionAssessmentTaskCompleted, nutritionAssessmentTasksCompletedFromTotal, pregnancySummaryFormWithDefault, resolveFirstEncounterDateAfterMilestone, resolveNutritionAssessmentTasks, symptomsReviewFormInputsAndTasks, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType, vaccinationFormDynamicContentAndTasks, vitaminAAdministrationFormConfig, wellChildECDFormWithDefault)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Measurement.Model exposing (..)
@@ -1020,6 +1020,18 @@ expectedECDSignsByAge currentDate assembled =
                 ecdSignsFromGroupedSignsByAge ageWeeks ageMonths groupedSigns
             )
         |> Maybe.withDefault []
+
+
+{-| The earliest WellChild encounter date strictly after the given milestone
+date. Used to bound the ECD assessment window (measurements up to and including
+that encounter). Nothing if no encounter falls after the milestone.
+-}
+resolveFirstEncounterDateAfterMilestone : NominalDate -> List NominalDate -> Maybe NominalDate
+resolveFirstEncounterDateAfterMilestone milestoneDate encounterDates =
+    encounterDates
+        |> List.filter (\date -> Date.compare milestoneDate date == LT)
+        |> List.sortWith Date.compare
+        |> List.head
 
 
 expectedECDSignsOnMilestone : NominalDate -> NominalDate -> Maybe NominalDate -> List ECDSign

--- a/client/src/elm/Pages/WellChild/ProgressReport/View.elm
+++ b/client/src/elm/Pages/WellChild/ProgressReport/View.elm
@@ -82,6 +82,7 @@ import Pages.WellChild.Activity.Utils
         ( expectedECDSignsOnMilestone
         , generateCompletedECDSigns
         , mandatoryNutritionAssessmentTasksCompleted
+        , resolveFirstEncounterDateAfterMilestone
         )
 import Pages.WellChild.Activity.View exposing (viewVaccinationOverview)
 import Pages.WellChild.Encounter.Model exposing (AssembledData)
@@ -1125,17 +1126,8 @@ genrateDefaultECDStatus birthDate milestone individualWellChildMeasurementsWithD
             resolveDateForPediatricCareMilestone birthDate milestone
 
         firstEncounterDateAfterMilestone =
-            List.filterMap
-                (\( date, _ ) ->
-                    if not <| Date.compare milestoneDate date == LT then
-                        Just date
-
-                    else
-                        Nothing
-                )
-                individualWellChildMeasurementsWithDates
-                |> List.sortWith Date.compare
-                |> List.head
+            resolveFirstEncounterDateAfterMilestone milestoneDate
+                (List.map Tuple.first individualWellChildMeasurementsWithDates)
 
         -- Take all measurements that were taken before the milestone,
         -- and, these of first encounter after milestone.


### PR DESCRIPTION
## What
Fixes an inverted date filter that made the **default ECD milestone status** on the Well-Child progress report compute from the wrong assessment window (a child could show off-track when on-track, or vice-versa). Closes #1858.

## Why
`genrateDefaultECDStatus` (`ProgressReport/View.elm`) resolved `firstEncounterDateAfterMilestone` with `if not <| Date.compare milestoneDate date == LT` — but `Date.compare milestoneDate date == LT` is true iff the encounter is *after* the milestone, so the `not` keeps encounters **on/before** it and takes the earliest. That's the opposite of the binding's name **and** the adjacent comment, and it corrupts *both* inputs to the decision: the assessment window (`measurementsForPeriod` → completed signs) and `expectedECDSignsOnMilestone` (→ expected signs). Reached via the default path for milestones with no explicit recorded status. No test covered it.

## How
- Extracted the date resolution into a pure helper `resolveFirstEncounterDateAfterMilestone` in `WellChild/Activity/Utils.elm` (where the sibling ECD helpers live), filtering **strictly after** the milestone (the `not` dropped); `View.elm` calls it. Behaviour-preserving apart from the corrected filter.
- New `Pages/WellChild/Activity/Test.elm` unit-tests it (earliest-after / Nothing-when-all-before / on-milestone-is-not-after).

## Verification
- `elm make src/elm/Main.elm` → Success; `elm-format` clean; no new `elm-review` findings.
- **`elm-test` → 2737 passed** (3 new). The new tests were verified to **fail on the original buggy logic (3/3) and pass on the fix** — a genuine regression guard.

## Note
No clinical sign-off needed for the *direction* (name + comment + downstream semantics all agree the window runs through the first encounter after the milestone), but this does change which children show on-track for default-path milestones.

R6-4 from the rolling code-review exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
