### PR TITLE
R7-1: Well-Child "previous head circumference" reference shows oldest, not latest

### DIFF
--- a/client/src/elm/Backend/NutritionEncounter/Test.elm
+++ b/client/src/elm/Backend/NutritionEncounter/Test.elm
@@ -13,6 +13,7 @@ import Backend.Model exposing (ModelIndexedDb, emptyModelIndexedDb)
 import Backend.NutritionEncounter.Utils
     exposing
         ( generateNutritionAssessment
+        , resolveLatestValue
         , zScoreWeightForAgeModerate
         , zScoreWeightForAgeSevere
         )
@@ -266,6 +267,63 @@ generateNutritionAssessmentSignsTest =
         ]
 
 
+
+-- PART 3 — resolveLatestValue
+--
+-- The "previous value" reference shown next to height/MUAC/weight/head-
+-- circumference inputs must be the MOST RECENT measurement before today.
+-- Selection must not depend on the input list being pre-sorted: head
+-- circumference was concatenated oldest-first, and the old `List.head`-only
+-- selection showed the oldest value. resolveLatestValue sorts internally.
+
+
+resolveLatestValueTest : Test
+resolveLatestValueTest =
+    describe "resolveLatestValue (most recent value strictly before currentDate; order-independent)"
+        [ test "picks the most recent value when the list is oldest-first (reproduces the head-circumference bug)" <|
+            \_ ->
+                resolveLatestValue currentDate
+                    [ ( Date.fromCalendarDate 2020 Time.Jan 1, 100 )
+                    , ( Date.fromCalendarDate 2020 Time.Mar 1, 200 )
+                    , ( Date.fromCalendarDate 2020 Time.May 1, 300 )
+                    ]
+                    |> Expect.equal (Just 300)
+        , test "picks the most recent value regardless of input order" <|
+            \_ ->
+                resolveLatestValue currentDate
+                    [ ( Date.fromCalendarDate 2020 Time.Mar 1, 200 )
+                    , ( Date.fromCalendarDate 2020 Time.May 1, 300 )
+                    , ( Date.fromCalendarDate 2020 Time.Jan 1, 100 )
+                    ]
+                    |> Expect.equal (Just 300)
+        , test "ignores measurements dated on or after currentDate" <|
+            \_ ->
+                resolveLatestValue currentDate
+                    [ ( Date.fromCalendarDate 2020 Time.Apr 1, 200 )
+                    , ( Date.fromCalendarDate 2020 Time.May 15, 300 )
+                    , ( Date.fromCalendarDate 2020 Time.Jun 1, 999 )
+                    , ( Date.fromCalendarDate 2020 Time.Jul 1, 888 )
+                    ]
+                    |> Expect.equal (Just 300)
+        , test "returns Nothing for an empty list" <|
+            \_ ->
+                let
+                    noMeasurements : List ( NominalDate, Int )
+                    noMeasurements =
+                        []
+                in
+                resolveLatestValue currentDate noMeasurements
+                    |> Expect.equal Nothing
+        , test "returns Nothing when every measurement is dated on or after currentDate" <|
+            \_ ->
+                resolveLatestValue currentDate
+                    [ ( Date.fromCalendarDate 2020 Time.Jun 1, 999 )
+                    , ( Date.fromCalendarDate 2020 Time.Aug 1, 888 )
+                    ]
+                    |> Expect.equal Nothing
+        ]
+
+
 all : Test
 all =
     describe "Nutrition assessment tests"
@@ -274,4 +332,5 @@ all =
         , zScoreWeightForAgeModerateSixMonthsPlusTest
         , generateNutritionAssessmentMuacTest
         , generateNutritionAssessmentSignsTest
+        , resolveLatestValueTest
         ]

--- a/client/src/elm/Backend/NutritionEncounter/Utils.elm
+++ b/client/src/elm/Backend/NutritionEncounter/Utils.elm
@@ -1,4 +1,4 @@
-module Backend.NutritionEncounter.Utils exposing (calculateZScoreWeightForAge, generateIndividualChildScoreboardMeasurementsForChild, generateNutritionAssessment, getAcuteIllnessEncountersForParticipant, getChildScoreboardEncountersForParticipant, getHIVEncountersForParticipant, getHomeVisitEncountersForParticipant, getNCDEncountersForParticipant, getNewbornExamPregnancySummary, getNutritionEncountersForParticipant, getPrenatalEncountersForParticipant, getTuberculosisEncountersForParticipant, getWellChildEncountersForParticipant, nutritionAssessmentForBackend, resolveAllWeightMeasurementsForChild, resolveNCDANeverFilled, resolveNCDANotFilledAfterAgeOfSixMonths, resolvePreviousValuesSetForChild, zScoreWeightForAgeModerate, zScoreWeightForAgeSevere)
+module Backend.NutritionEncounter.Utils exposing (calculateZScoreWeightForAge, generateIndividualChildScoreboardMeasurementsForChild, generateNutritionAssessment, getAcuteIllnessEncountersForParticipant, getChildScoreboardEncountersForParticipant, getHIVEncountersForParticipant, getHomeVisitEncountersForParticipant, getNCDEncountersForParticipant, getNewbornExamPregnancySummary, getNutritionEncountersForParticipant, getPrenatalEncountersForParticipant, getTuberculosisEncountersForParticipant, getWellChildEncountersForParticipant, nutritionAssessmentForBackend, resolveAllWeightMeasurementsForChild, resolveLatestValue, resolveNCDANeverFilled, resolveNCDANotFilledAfterAgeOfSixMonths, resolvePreviousValuesSetForChild, zScoreWeightForAgeModerate, zScoreWeightForAgeSevere)
 
 import AssocList as Dict exposing (Dict)
 import Backend.AcuteIllnessEncounter.Model exposing (AcuteIllnessEncounter)
@@ -423,9 +423,13 @@ resolvePreviousMeasurementsSetForChild childId db =
                     )
                 |> Maybe.withDefault []
     in
-    { heights = nutritionHeights ++ wellChildHeights ++ groupHeights |> List.sortWith sortTuplesByDateDesc
-    , muacs = nutritionMuacs ++ wellChildMuacs ++ groupMuacs |> List.sortWith sortTuplesByDateDesc
-    , weights = nutritionWeights ++ wellChildWeights ++ groupWeights |> List.sortWith sortTuplesByDateDesc
+    -- Ordering is applied by `resolveLatestValue` when the most recent value is
+    -- selected, so the per-source lists are concatenated here without sorting.
+    -- (Previously `headCircumferences` lacked the sort its siblings had, which
+    -- made its "previous value" reference show the oldest measurement.)
+    { heights = nutritionHeights ++ wellChildHeights ++ groupHeights
+    , muacs = nutritionMuacs ++ wellChildMuacs ++ groupMuacs
+    , weights = nutritionWeights ++ wellChildWeights ++ groupWeights
     , headCircumferences = wellChildHeadCircumferences
     }
 
@@ -521,14 +525,6 @@ resolvePreviousValuesSetForChild currentDate site childId db =
         previousMeasurementsSet =
             resolvePreviousMeasurementsSetForChild childId db
 
-        getLatestValue =
-            List.filter
-                (\( dateMeasured, _ ) ->
-                    Date.compare dateMeasured currentDate == LT
-                )
-                >> List.head
-                >> Maybe.map Tuple.second
-
         muacValueFunc =
             case site of
                 SiteBurundi ->
@@ -540,12 +536,28 @@ resolvePreviousValuesSetForChild currentDate site childId db =
                     identity
     in
     PreviousValuesSet
-        (getLatestValue previousMeasurementsSet.heights)
-        (getLatestValue previousMeasurementsSet.muacs
+        (resolveLatestValue currentDate previousMeasurementsSet.heights)
+        (resolveLatestValue currentDate previousMeasurementsSet.muacs
             |> Maybe.map muacValueFunc
         )
-        (getLatestValue previousMeasurementsSet.weights)
-        (getLatestValue previousMeasurementsSet.headCircumferences)
+        (resolveLatestValue currentDate previousMeasurementsSet.weights)
+        (resolveLatestValue currentDate previousMeasurementsSet.headCircumferences)
+
+
+{-| Select the most recently measured value dated strictly before `currentDate`.
+
+Sorts by measurement date internally, so it does not rely on the input list
+being pre-sorted. (A list that was concatenated but not sorted previously caused
+the "previous head circumference" reference to show the oldest measurement
+instead of the latest.)
+
+-}
+resolveLatestValue : NominalDate -> List ( NominalDate, a ) -> Maybe a
+resolveLatestValue currentDate =
+    List.filter (\( dateMeasured, _ ) -> Date.compare dateMeasured currentDate == LT)
+        >> List.sortWith sortTuplesByDateDesc
+        >> List.head
+        >> Maybe.map Tuple.second
 
 
 resolveAllWeightMeasurementsForChild : PersonId -> ModelIndexedDb -> List ( NominalDate, Float )


### PR DESCRIPTION
## Problem

On the Well-Child / Nutrition activity form, each anthropometric input shows the child's **previous** measured value as a reference. For **head circumference**, this showed the child's *first-ever* value instead of the **most recent** — misfiring for any child with ≥2 prior encounters that recorded head circumference. Wrong growth-trend anchor at point of care.

## Root cause

`resolvePreviousValuesSetForChild` (`client/src/elm/Backend/NutritionEncounter/Utils.elm`) picks the "previous" value via `List.head`, relying on each list being pre-sorted **descending by date** at construction. `heights`/`muacs`/`weights` were sorted with `sortTuplesByDateDesc`; `headCircumferences` was **not** — its source `resolveIndividualWellChildValues` ends in `List.reverse` over a descending input, so it comes out **ascending (oldest-first)**, and `List.head` returns the oldest.

## Fix

Centralize ordering in the selection itself: new pure `resolveLatestValue` filters to dates strictly before today, **sorts descending**, then takes the most recent. Selection no longer depends on each caller pre-sorting, eliminating the whole "forgot to sort one list" class. The now-redundant per-field sorts in `resolvePreviousMeasurementsSetForChild` are removed (that record's only consumer is this selection).

## Tests

5 new unit tests in `Backend/NutritionEncounter/Test.elm` for `resolveLatestValue` (oldest-first repro, order-independence, ignores today/future, empty, all-future). Verified they **fail** against the old non-sorting selection (3/5) and pass with the fix.

## Verification

- `elm make src/elm/Main.elm` — Success
- `elm-test` — 20/20 in the module (15 existing + 5 new); full suite green
- `elm-format` clean; no new `elm-review` findings

Closes #1860. Found via the Round-7 code-review sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)