### PR TITLE
R7-5: fix objective i18n wrong-text errors

### DIFF
--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -468,7 +468,7 @@ viewPregnancyDatingContent language currentDate assembled data =
                                     prePregnancyWeight =
                                         Maybe.map (\(WeightInKg weight) -> String.fromFloat weight ++ "kg")
                                             value.prePregnancyWeight
-                                            |> Maybe.withDefault "Not Set"
+                                            |> Maybe.withDefault (translate language Translate.NotAvailable)
                                 in
                                 [ viewCustomLabel language Translate.LmpDateConfirmationLabel "." "label"
                                 , viewLabel language Translate.LmpLabel

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -6251,7 +6251,7 @@ translationSet trans =
 
                 UseMediumPhrases ->
                     { english = "Does the child use 4-5 word sentences"
-                    , kinyarwanda = Just "Umwana ashobora gukora interuro zigizwe n'amagambo 2 kugera kuri 4"
+                    , kinyarwanda = Just "Umwana ashobora gukora interuro zigizwe n'amagambo 4 kugera kuri 5"
                     , kirundi = Just "Mbega umwana arakoresha amungane 4-5"
                     , somali = Nothing
                     }
@@ -11489,7 +11489,7 @@ translationSet trans =
 
         Low ->
             { english = "Low"
-            , kinyarwanda = Just "Kwemeza amakosa"
+            , kinyarwanda = Nothing
             , kirundi = Nothing
             , somali = Just "Hoose"
             }
@@ -14955,7 +14955,7 @@ translationSet trans =
 
         NotFollowingRecommendationQuestion ->
             { english = "Why recommendations were not followed"
-            , kinyarwanda = Just "Nta bipimo byafashwe"
+            , kinyarwanda = Nothing
             , kirundi = Just "Kubera iki ivyifuzo bitakurikijwe"
             , somali = Just "Talooyinka maxaa loo raaci waayay"
             }
@@ -30496,7 +30496,7 @@ translateMonth month short =
         Nov ->
             if short then
                 { english = "Nov"
-                , kinyarwanda = Just "Ukw"
+                , kinyarwanda = Just "Ugu"
                 , kirundi = Just "Muny"
                 , somali = Nothing
                 }


### PR DESCRIPTION
Five objective i18n errors (wrong string vs. the English/sibling-language values — not translation-quality judgments). All in `Translate.elm` except (5).

| # | Key / location | Was | Now |
|---|---|---|---|
| 1 | ECD `UseMediumPhrases` (english "4-5 word sentences") | Kinyarwanda "amagambo **2 kugera kuri 4**" (copy of the 2-4 milestone) | "amagambo **4 kugera kuri 5**" |
| 2 | `NotFollowingRecommendationQuestion` ("Why recommendations were not followed") | Kinyarwanda "Nta bipimo byafashwe" (= "no measurements taken") | `Nothing` (English fallback) |
| 3 | `Low` (severity) | Kinyarwanda "Kwemeza amakosa" (≈ "confirm errors") | `Nothing` (English fallback) |
| 4 | Month short `Nov` | Kinyarwanda "Ukw" (October's, from *Ukwakira*) | "Ugu" (*Ugushyingo*) |
| 5 | `Pages/Prenatal/Activity/View.elm:471` pre-pregnancy weight fallback | hardcoded English "Not Set" | `translate language Translate.NotAvailable` |

(1) and (4) are fixed to the correct value (digit / month abbreviation). (2) and (3) are set to English fallback rather than a guess — the correct Kinyarwanda isn't recoverable here, and the fallback is strictly better than the actively-wrong string; **a native Kinyarwanda speaker should supply the proper translations**. (5) uses the existing `NotAvailable` id (translated in all four languages).

## Verification
- `elm make src/elm/Main.elm` — Success
- `elm-test` — 2734/2734
- `elm-format` clean

Closes #1864. Found via the Round-7 sweep (promoted Round-5 runner-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)