### PR TITLE
R8-5: site-adjust the NCDA MUAC field at Burundi (input + display)

### DIFF
--- a/client/src/elm/Measurement/Test.elm
+++ b/client/src/elm/Measurement/Test.elm
@@ -4,11 +4,14 @@ import AssocList as Dict
 import Backend.Measurement.Model
     exposing
         ( ColorAlertIndication(..)
+        , MuacInCm(..)
         , VaccineDose(..)
         , WellChildVaccineType(..)
         )
 import Date exposing (Unit(..))
 import Expect
+import Measurement.Model exposing (MsgChild(..), emptyModelChild)
+import Measurement.Update exposing (updateChild)
 import Measurement.Utils
     exposing
         ( getAllDosesForVaccine
@@ -242,6 +245,31 @@ initialVaccinationDateByBirthDateTest =
         ]
 
 
+updateChildSetMuacTest : Test
+updateChildSetMuacTest =
+    -- The NCDA MUAC field stores cm. At Burundi the nurse enters mm, so the
+    -- group-session input handler must divide by 10 (like every other MUAC
+    -- field) rather than store the typed value verbatim.
+    describe "updateChild SetMuac (group NCDA MUAC input is site-aware)"
+        [ test "Burundi: entering 125 (mm) stores 12.5 cm" <|
+            \_ ->
+                let
+                    ( model, _, _ ) =
+                        updateChild SiteBurundi (SetMuac "125") emptyModelChild
+                in
+                model.ncdaData.form.muac
+                    |> Expect.equal (Just (MuacInCm 12.5))
+        , test "Rwanda: entering 12.5 (cm) stores 12.5 cm unchanged" <|
+            \_ ->
+                let
+                    ( model, _, _ ) =
+                        updateChild SiteRwanda (SetMuac "12.5") emptyModelChild
+                in
+                model.ncdaData.form.muac
+                    |> Expect.equal (Just (MuacInCm 12.5))
+        ]
+
+
 all : Test
 all =
     describe "Measurement of children: form tests"
@@ -251,4 +279,5 @@ all =
         , getIntervalForVaccineTest
         , getAllDosesForVaccineTest
         , initialVaccinationDateByBirthDateTest
+        , updateChildSetMuacTest
         ]

--- a/client/src/elm/Measurement/Update.elm
+++ b/client/src/elm/Measurement/Update.elm
@@ -18,7 +18,8 @@ import Backend.Measurement.Model
 import Backend.Measurement.Utils exposing (currentValues, mapMeasurementData)
 import EverySet
 import Measurement.Model exposing (ModelChild, ModelMother, MsgChild(..), MsgMother(..), OutMsgChild(..), OutMsgMother(..), emptyParticipantFormProgress)
-import Pages.Utils exposing (setMultiSelectInputValue)
+import Pages.Utils exposing (setMuacValueForSite, setMultiSelectInputValue)
+import SyncManager.Model exposing (Site)
 
 
 {-| The strategy used here, for the moment, is that the `model` tracks the UI,
@@ -28,8 +29,8 @@ which we can change **directly** here is our own model. If we want to change
 the "real" data, we have to return an `OutMsg` to be processed elsehwere (for
 instance, by actually writing the data to local storage).
 -}
-updateChild : MsgChild -> ModelChild -> ( ModelChild, Cmd MsgChild, Maybe OutMsgChild )
-updateChild msg model =
+updateChild : Site -> MsgChild -> ModelChild -> ( ModelChild, Cmd MsgChild, Maybe OutMsgChild )
+updateChild site msg model =
     case msg of
         UpdateHeight val ->
             ( { model | height = val }
@@ -401,7 +402,7 @@ updateChild msg model =
                     model.ncdaData.form
                         |> (\form ->
                                 { form
-                                    | muac = String.toFloat string |> Maybe.map MuacInCm
+                                    | muac = setMuacValueForSite site string |> Maybe.map MuacInCm
                                 }
                            )
 

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -3324,8 +3324,17 @@ ncdaFormInputsAndTasks language currentDate site personId person config form cur
                                             else
                                                 let
                                                     muacAsFloat =
-                                                        Maybe.map (\(MuacInCm muac) -> muac)
+                                                        -- MUAC is stored in cm; show it in mm at Burundi.
+                                                        Maybe.map (\(MuacInCm muac) -> muacValueForSite site muac)
                                                             form.muac
+
+                                                    unitTransId =
+                                                        case site of
+                                                            SiteBurundi ->
+                                                                Translate.UnitMillimeter
+
+                                                            _ ->
+                                                                Translate.UnitCentimeter
                                                 in
                                                 [ div [ class "ui grid" ]
                                                     [ div [ class "eleven wide column" ]
@@ -3334,7 +3343,7 @@ ncdaFormInputsAndTasks language currentDate site personId person config form cur
                                                             muacAsFloat
                                                             config.setMuacMsg
                                                             "muac"
-                                                            Translate.UnitCentimeter
+                                                            unitTransId
                                                         ]
                                                     , div
                                                         [ class "five wide column" ]

--- a/client/src/elm/Pages/Activity/Update.elm
+++ b/client/src/elm/Pages/Activity/Update.elm
@@ -17,7 +17,7 @@ import Measurement.Update
 import Pages.Activity.Model exposing (ChildUpdateReturns, Model, MotherUpdateReturns, Msg(..), Tab(..))
 import Pages.Page exposing (Page(..), SessionPage(..), UserPage(..))
 import Pages.Utils exposing (matchFilter, normalizeFilter)
-import SyncManager.Model exposing (SiteFeature)
+import SyncManager.Model exposing (Site, SiteFeature)
 import ZScore.Model
 
 
@@ -29,6 +29,7 @@ updateChild :
     NominalDate
     -> ZScore.Model.Model
     -> EverySet SiteFeature
+    -> Site
     -> Msg PersonId Measurement.Model.MsgChild
     -> Model PersonId
     -> EditableSession
@@ -36,7 +37,7 @@ updateChild :
     -> Maybe Measurement.Model.ModelChild
     -> ModelIndexedDb
     -> ChildUpdateReturns
-updateChild currentDate zscores features msg model session activity childForm db =
+updateChild currentDate zscores features site msg model session activity childForm db =
     case msg of
         GoBackToActivitiesPage sessionId ->
             ChildUpdateReturns
@@ -52,7 +53,7 @@ updateChild currentDate zscores features msg model session activity childForm db
                     (\form ->
                         let
                             ( subModel, subCmd, outMsg ) =
-                                Measurement.Update.updateChild subMsg form
+                                Measurement.Update.updateChild site subMsg form
                         in
                         ChildUpdateReturns
                             model

--- a/client/src/elm/Pages/Participant/Update.elm
+++ b/client/src/elm/Pages/Participant/Update.elm
@@ -7,6 +7,7 @@ import EverySet
 import Measurement.Model
 import Measurement.Update
 import Pages.Participant.Model exposing (ChildUpdateReturns, Model, MotherUpdateReturns, Msg(..), Tab(..))
+import SyncManager.Model exposing (Site)
 
 
 {-| This is a bit of a variation on the usual `update` function.
@@ -27,16 +28,17 @@ And, we return a possible redirect.
 
 -}
 updateChild :
-    Msg ChildActivity Measurement.Model.MsgChild
+    Site
+    -> Msg ChildActivity Measurement.Model.MsgChild
     -> Model ChildActivity
     -> Measurement.Model.ModelChild
     -> ChildUpdateReturns
-updateChild msg model childForm =
+updateChild site msg model childForm =
     case msg of
         MsgMeasurement subMsg ->
             let
                 ( subModel, subCmd, outMsg ) =
-                    Measurement.Update.updateChild subMsg childForm
+                    Measurement.Update.updateChild site subMsg childForm
             in
             ChildUpdateReturns
                 model

--- a/client/src/elm/Pages/Session/Update.elm
+++ b/client/src/elm/Pages/Session/Update.elm
@@ -105,6 +105,7 @@ updateFoundSession currentDate zscores site features sessionId session db msg mo
                     Pages.Activity.Update.updateChild currentDate
                         zscores
                         features
+                        site
                         subMsg
                         activityPage
                         session
@@ -204,7 +205,7 @@ updateFoundSession currentDate zscores site features sessionId session db msg mo
                         |> Maybe.withDefault Pages.Participant.Model.emptyModel
 
                 updateReturns =
-                    Pages.Participant.Update.updateChild subMsg childPage childForm
+                    Pages.Participant.Update.updateChild site subMsg childPage childForm
 
                 sessionMsgs =
                     List.map (App.Model.MsgIndexedDb << Backend.Model.MsgSession sessionId)


### PR DESCRIPTION
Stacked on #1867 (uses the `muacValueForSite` / `setMuacValueForSite` helpers from it). Base auto-retargets to `develop` once #1867 merges.

## Problem
Every MUAC field at Burundi is mm (stored cm) — except the NCDA questionnaire field:
1. **Group-session input (clinical):** `Measurement.Update.updateChild`'s `SetMuac` stored the typed value verbatim, so at Burundi `125` (mm) → **125 cm** → wrong `muacIndicationForChild` classification. (`updateChild` had no `site`; the individual WellChild/Nutrition/ChildScoreboard handlers already convert.)
2. **Shared display (UX):** `ncdaFormInputsAndTasks` hard-labeled `UnitCentimeter` and never ×10'd, so the field showed cm even where input was mm.

## Fix
- Threaded `site` through the group update stack (`Pages.Session.Update` → `Pages.Activity.Update.updateChild` / `Pages.Participant.Update.updateChild` → `Measurement.Update.updateChild`) and used `setMuacValueForSite site` in `SetMuac`.
- Made the shared NCDA display site-aware (`muacValueForSite site` + `UnitMillimeter` at Burundi).

`muacIndicationForChild` reads the stored `MuacInCm`, so classification is unaffected by the display change; the input fix makes the stored value correct.

## Tests
`Measurement/Test.elm`: group `SetMuac "125"` at Burundi stores `MuacInCm 12.5`; Rwanda `"12.5"` stores `12.5`. Verified the Burundi test **fails** (stores `125`) without the fix.

## Verification
- `elm make src/elm/Main.elm` — Success
- `elm-test` — full suite 2739
- `elm-format` clean; no Site/unused-import elm-review findings on touched files

Closes #1868. Found via the Round-8 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)