### PR TITLE
R8-2: recalc Statistical-Queries report on edit/soft-delete of any content

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -342,7 +342,12 @@ function hedley_reports_trigger_recalculation_for_edited_person($node) {
   $birth_date = $wrapper->field_birth_date->value();
   $birth_date_orig = $wrapper_orig->field_birth_date->value();
 
-  if ($birth_date == $birth_date_orig) {
+  $gender = $wrapper->field_gender->value();
+  $gender_orig = $wrapper_orig->field_gender->value();
+
+  // Birth date and gender both feed the person's aggregated nutrition data
+  // (z-scores are gender-derived), so a change to either must recalculate.
+  if ($birth_date == $birth_date_orig && $gender == $gender_orig) {
     return;
   }
 
@@ -408,28 +413,25 @@ function hedley_reports_trigger_recalculation_by_new_content($node) {
  * @throws EntityMetadataWrapperException
  */
 function hedley_reports_trigger_recalculation_by_edited_content($node) {
-  switch ($node->type) {
-    case HEDLEY_ACTIVITY_PRENATAL_ENCOUNTER_CONTENT_TYPE:
-      $participant_id = $node->field_individual_participant[LANGUAGE_NONE][0]['target_id'];
-      break;
+  // The antenatal participant node itself is a special case: it is neither a
+  // triggering encounter nor a triggering measurement, but editing it must
+  // still refresh the pregnancy's report data.
+  if ($node->type == HEDLEY_ACTIVITY_INDIVIDUAL_PARTICIPANT_CONTENT_TYPE) {
+    if ($node->field_encounter_type[LANGUAGE_NONE][0]['value'] == 'antenatal') {
+      $wrapper = entity_metadata_wrapper('node', $node);
+      $person_id = $wrapper->field_person->value(['identifier' => TRUE]);
+      hedley_general_add_task_to_advanced_queue_by_id(HEDLEY_REPORTS_CALCULATE_AGGREGATED_DATA, $person_id, [
+        'person_id' => $person_id,
+      ]);
+    }
 
-    case HEDLEY_ACTIVITY_INDIVIDUAL_PARTICIPANT_CONTENT_TYPE:
-      if ($node->field_encounter_type[LANGUAGE_NONE][0]['value'] == 'antenatal') {
-        $participant_id = $node->nid;
-      }
-      break;
-  }
-
-  if (empty($participant_id)) {
-    // Can't resolve to which participant encounter belongs.
     return;
   }
-  $wrapper = entity_metadata_wrapper('node', $participant_id);
-  $person_id = $wrapper->field_person->value(['identifier' => TRUE]);
-  // Trigger recalculation using AQ.
-  hedley_general_add_task_to_advanced_queue_by_id(HEDLEY_REPORTS_CALCULATE_AGGREGATED_DATA, $person_id, [
-    'person_id' => $person_id,
-  ]);
+
+  // For every other edited measurement or encounter, mirror the insert path,
+  // so value corrections and soft-deletes (which both arrive as node updates)
+  // refresh the report - not just prenatal content.
+  hedley_reports_trigger_recalculation_by_new_content($node);
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -327,7 +327,7 @@ function hedley_reports_trigger_recalculation_for_created_person($node) {
 /**
  * Triggers recalculation of person's Reports data, when edited.
  *
- * Recalculation is required only when birthdate is edited.
+ * Recalculation is required when birthdate or gender is edited.
  * Note: Currently, editing geo fields of person is not allowed.
  *
  * @param object $node
@@ -417,7 +417,10 @@ function hedley_reports_trigger_recalculation_by_edited_content($node) {
   // triggering encounter nor a triggering measurement, but editing it must
   // still refresh the pregnancy's report data.
   if ($node->type == HEDLEY_ACTIVITY_INDIVIDUAL_PARTICIPANT_CONTENT_TYPE) {
-    if ($node->field_encounter_type[LANGUAGE_NONE][0]['value'] == 'antenatal') {
+    $encounter_type = !empty($node->field_encounter_type[LANGUAGE_NONE][0]['value'])
+      ? $node->field_encounter_type[LANGUAGE_NONE][0]['value']
+      : '';
+    if ($encounter_type == 'antenatal') {
       $wrapper = entity_metadata_wrapper('node', $node);
       $person_id = $wrapper->field_person->value(['identifier' => TRUE]);
       hedley_general_add_task_to_advanced_queue_by_id(HEDLEY_REPORTS_CALCULATE_AGGREGATED_DATA, $person_id, [


### PR DESCRIPTION
## Problem
The per-person Statistical-Queries data (`field_reports_data`) was **not refreshed** when a non-prenatal measurement/encounter was **edited or soft-deleted**, so the report kept counting deleted measurements and stale values. (No hard delete exists — a soft-delete is a `node_update` setting `field_deleted=TRUE`; corrections are also `node_update`s.)

## Root cause
`hedley_reports_node_update` → `trigger_recalculation_by_edited_content` was a `switch` with only two cases (prenatal encounter, antenatal participant); everything else fell through (`$participant_id` empty) and returned without enqueuing. The **insert** path (`by_new_content`) already handles the full triggering set (10 encounter types + height/weight/MUAC/nutrition/immunisation bundles). Siblings NCDA and hedley_stats route *every* update through one comprehensive trigger — reports was the lone divergence. Self-heals on the person's next triggering insert, so the window is edit/delete → next new measurement.

## Companion
`trigger_recalculation_for_edited_person` gated on `field_birth_date` only — correcting `field_gender` left stale gender-derived z-scores. Now recalcs on either.

## Fix
- `by_edited_content`: keep the antenatal-participant special case; delegate everything else to `by_new_content` (same person resolution as insert, no-ops on non-triggering types).
- `for_edited_person`: also recalc on `field_gender` change.

## Verification
- `php -l` clean
- phpcs Drupal + DrupalPractice clean (full CI extension list)

Closes #1870. Found via the Round-8 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)