### PR TITLE
R8-4: reset the relationship form on nav entry (stop stale-pair leak)

### DIFF
--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -1153,19 +1153,41 @@ update msg model =
                         DevicePage ->
                             [ MsgSyncManager SyncManager.Model.TrySyncing ]
 
-                        -- When navigating to relationship page in group encounter context,
-                        -- we automaticaly select the clinic, to which the session belongs.
-                        UserPage (RelationshipPage id1 id2 (GroupEncounterOrigin sessionId)) ->
-                            getSession sessionId model.indexedDb
-                                |> Maybe.map
-                                    (.clinicId
-                                        >> fromEntityUuid
-                                        >> Pages.Relationship.Model.AssignToClinicId
-                                        >> MsgPageRelationship id1 id2
-                                        >> MsgLoggedIn
-                                        >> List.singleton
-                                    )
-                                |> Maybe.withDefault []
+                        -- Clear the (per-pair) relationship form on genuine entry, so a
+                        -- previously abandoned, unsaved selection can't be shown as the
+                        -- current value and re-saved for the same pair (the view lets an
+                        -- unsaved relatedBy win over the DB value). In group encounter
+                        -- context we then re-select the clinic the session belongs to.
+                        UserPage (RelationshipPage id1 id2 initiator) ->
+                            let
+                                resetMsgs =
+                                    if model.activePage == page then
+                                        []
+
+                                    else
+                                        [ Pages.Relationship.Model.Reset initiator
+                                            |> MsgPageRelationship id1 id2
+                                            |> MsgLoggedIn
+                                        ]
+
+                                clinicMsgs =
+                                    case initiator of
+                                        GroupEncounterOrigin sessionId ->
+                                            getSession sessionId model.indexedDb
+                                                |> Maybe.map
+                                                    (.clinicId
+                                                        >> fromEntityUuid
+                                                        >> Pages.Relationship.Model.AssignToClinicId
+                                                        >> MsgPageRelationship id1 id2
+                                                        >> MsgLoggedIn
+                                                        >> List.singleton
+                                                    )
+                                                |> Maybe.withDefault []
+
+                                        _ ->
+                                            []
+                            in
+                            resetMsgs ++ clinicMsgs
 
                         -- When navigating to Acute Illness participant page, set initial view mode.
                         UserPage (AcuteIllnessParticipantPage _ participantId) ->


### PR DESCRIPTION
## Problem
The Relationship page (link A↔B: `relatedBy` = Parent/Child/Caregiver + group/clinic) keeps abandoned, never-saved selections and re-shows them the next time the **same pair** is related, where a nurse can save the wrong linkage. Structural twin of the create/edit-person form leak fixed in #1838.

## Root cause
`relationshipPages : Dict (PersonId, PersonId) …` (`App/Model.elm`) is a singleton reset only on **POST-success** (`HandlePostedRelationship` dispatches `Reset` inside `data |> RemoteData.map (...)`, i.e. `Success`-only) and at login. `SetActivePage` has **no entry reset** (its only `RelationshipPage` case auto-assigns the clinic for group encounters). The view lets the unsaved value win — `viewedRelationship = model.relatedBy |> Maybe.Extra.orElse savedRelationship` — which drives both the checked radio and `Save`.

## Fix
Mirror #1838: dispatch `Pages.Relationship.Model.Reset initiator` on genuine entry (`model.activePage == page` guard) for `RelationshipPage`, folded with the existing group-context clinic auto-assign so the order is **reset → then AssignToClinicId**.

## Verification
- `elm make src/elm/Main.elm` — Success
- `elm-test` — full suite 2744
- `elm-format` clean

No unit test — `SetActivePage` extraMsg wiring (needs a full `App.Model` fixture), same as #1838; verified by compile + the traced mechanism.

Closes #1872. Found via the Round-8 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)