### PR TITLE
R8-3: exclude soft-deleted records in geo/resilience/education searches

### DIFF
--- a/client/src/js/nodes.js
+++ b/client/src/js/nodes.js
@@ -1001,7 +1001,11 @@
                             criteria.sector = fields[2];
                             criteria.cell = fields[3];
                             criteria.village = fields[4];
-                            query = table.where(criteria);
+                            // Exclude soft-deleted people, matching the other
+                            // person-search branches (name/national id).
+                            query = table.where(criteria).and(function (person) {
+                                return person.deleted !== true;
+                            });
 
                             countQuery = query.clone();
 
@@ -1161,7 +1165,10 @@
                   if (nurseId) {
                     modifyQuery = modifyQuery.then(function () {
                         criteria.nurse = nurseId;
-                        query = table.where(criteria);
+                        // Exclude soft-deleted records, as the other branches do.
+                        query = table.where(criteria).and(function (item) {
+                            return item.deleted !== true;
+                        });
 
                         countQuery = query.clone();
 
@@ -1177,7 +1184,10 @@
                   if (personId) {
                     modifyQuery = modifyQuery.then(function () {
                         criteria.participating_patients = personId;
-                        query = table.where(criteria);
+                        // Exclude soft-deleted records, as the other branches do.
+                        query = table.where(criteria).and(function (item) {
+                            return item.deleted !== true;
+                        });
 
                         countQuery = query.clone();
 


### PR DESCRIPTION
## Problem
`client/src/js/nodes.js` `index()` reassigns `query = table.where(criteria)` + `countQuery = query.clone()` in three branches **without** the soft-deleted filter every sibling branch applies:
- **`geo_fields`** (geographic/admin-area participant search) → soft-deleted/merged **people reappear in the directory** (data *and* count)
- **`resilience_survey`** (by nurse)
- **`education_session`** (by participant)

Siblings (name_contains, national_id_contains, `[type+person]`, encounters, `[type+clinic]`, pmtct session) all chain `.and(... deleted ...)`; only these three forgot it.

## Fix
Append `.and(item => item.deleted !== true)` to the reassigned `query` in each branch (the `countQuery = query.clone()` inherits it). `!== true` matches the person-search siblings (exclude only explicitly-deleted).

## Verification
- `node --check` — clean
- No unit test: the JS layer has no unit-test framework; the person-search paths are exercised by the Playwright e2e suite (`e2e_playwright_*` in CI).

Closes #1874. Found via the Round-8 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)