### PR TITLE
R9-2: strip the |<amount> distribution tail in the district Nutrition report

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -2417,7 +2417,10 @@ function hedley_reports_generate_nutrition_report_data(array $data) {
       }
 
       $start_date_month = $start_date->format('m');
-      $encounter_fields = explode(',', $parts[1]);
+      // The wire may carry a "|<amount>" distribution tail (FBF) after the
+      // anthropometry CSV; strip it before parsing, matching the Elm decoder.
+      $anthropometry = explode('|', $parts[1])[0];
+      $encounter_fields = explode(',', $anthropometry);
       $nutrition_data = [
         'stunting' => (!isset($encounter_fields[0]) || $encounter_fields[0] === '') ? NULL : (float) $encounter_fields[0],
         'underweight' => (!isset($encounter_fields[1]) || $encounter_fields[1] === '') ? NULL : (float) $encounter_fields[1],
@@ -2449,7 +2452,10 @@ function hedley_reports_generate_nutrition_report_data(array $data) {
       }
 
       $start_date_month = $start_date->format('m');
-      $muac_value = isset($parts[1]) && $parts[1] !== '' ? (float) $parts[1] : NULL;
+      // Strip the "|<distribution-amount>" tail (AHEZA) before reading MUAC, so
+      // an amount-only wire ("|500") is treated as no-MUAC rather than 0.0.
+      $muac_raw = isset($parts[1]) ? explode('|', $parts[1])[0] : '';
+      $muac_value = $muac_raw !== '' ? (float) $muac_raw : NULL;
       $family_data = [
         'stunting' => NULL,
         'underweight' => NULL,


### PR DESCRIPTION
## Problem
The large-scope (district-aggregated) Nutrition report `hedley_reports_generate_nutrition_report_data` never strips the `|<distribution-amount>` tail the encoder appends (and the Elm decoder strips):
1. **Edema discarded → SAM undercounted:** FBF wire `"date s,w,u,m,e|amount"` → `explode(',', …)` → `$encounter_fields[4] = "1|500"` → `=== '1'` always false → kwashiorkor (edema, normal MUAC) bucketed normal not SAM.
2. **AHEZA-only visit → false SAM:** `"date |amount"` → `(float) "|500"` = `0.0` → `0.0 < 11.5` → counted as severe acute malnutrition.

The Elm small-scope path splits on `|` first, so small-scope vs large-scope dashboards disagree.

## Fix
Strip the tail (`explode('|', $parts[1])[0]`) before the CSV split (encounters loop) and before the `(float)` MUAC read (family loop) — an amount-only wire becomes no-MUAC rather than `0.0`.

## Verification
- `php -l` clean
- phpcs Drupal + DrupalPractice clean (full CI extension list)

Closes #1878. Found via the Round-9 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)