### PR TITLE
R9-3: guard double-tap begin-encounter from opening two episodes

### DIFF
--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4679,11 +4679,18 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostIndividualEncounterParticipant extraData session ->
-            ( { model | postIndividualEncounterParticipant = Dict.insert session.person Loading model.postIndividualEncounterParticipant }
-            , sw.post individualEncounterParticipantEndpoint session
-                |> toCmd (RemoteData.fromResult >> HandlePostedIndividualEncounterParticipant session.person session.encounterType extraData)
-            , []
-            )
+            if Dict.get session.person model.postIndividualEncounterParticipant |> Maybe.map RemoteData.isLoading |> Maybe.withDefault False then
+                -- A create for this person is already in flight; ignore the
+                -- duplicate, so a double-tapped "begin encounter" button can't
+                -- open two encounter participants (e.g. two open pregnancies).
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postIndividualEncounterParticipant = Dict.insert session.person Loading model.postIndividualEncounterParticipant }
+                , sw.post individualEncounterParticipantEndpoint session
+                    |> toCmd (RemoteData.fromResult >> HandlePostedIndividualEncounterParticipant session.person session.encounterType extraData)
+                , []
+                )
 
         HandlePostedIndividualEncounterParticipant personId encounterType extraData data ->
             let
@@ -5093,11 +5100,17 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostFamilyEncounterParticipant session ->
-            ( { model | postFamilyEncounterParticipant = Dict.insert session.person Loading model.postFamilyEncounterParticipant }
-            , sw.post familyEncounterParticipantEndpoint session
-                |> toCmd (RemoteData.fromResult >> HandlePostedFamilyEncounterParticipant session.person session.encounterType)
-            , []
-            )
+            if Dict.get session.person model.postFamilyEncounterParticipant |> Maybe.map RemoteData.isLoading |> Maybe.withDefault False then
+                -- Already creating a family encounter participant for this
+                -- person; ignore the double-tap.
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postFamilyEncounterParticipant = Dict.insert session.person Loading model.postFamilyEncounterParticipant }
+                , sw.post familyEncounterParticipantEndpoint session
+                    |> toCmd (RemoteData.fromResult >> HandlePostedFamilyEncounterParticipant session.person session.encounterType)
+                , []
+                )
 
         HandlePostedFamilyEncounterParticipant personId encounterType data ->
             let


### PR DESCRIPTION
## Problem
The individual-participant begin-encounter buttons wire `onClick PostIndividualEncounterParticipant` with only a CSS `disabled` class (`encounterWasCompletedToday`) and no in-flight guard. `maybeSessionId` comes from `db.individualParticipantsByPerson`, not updated until the POST returns — so a **double-tap on a fresh patient posts two participants → two encounter episodes**. For Prenatal that's **two open pregnancies**, the state the app's `LabelOnePregnancyEpisodeOpen` warning exists to prevent.

## Fix
In `Backend/Update.elm`, guard the two participant creates — `PostIndividualEncounterParticipant` and `PostFamilyEncounterParticipant` (both keyed by `session.person`): if a create for that person is already `Loading`, ignore the duplicate dispatch. One view-independent guard for every program.

**Scope:** fixes the high-severity duplicate-**participant/episode** case. Double-tapping *subsequent*-encounter buttons can still duplicate an encounter within one episode (lower severity); the same pattern extends to the per-program `Post*Encounter` handlers if desired.

## Verification
- `elm make src/elm/Main.elm` — Success
- `elm-test` — full suite 2744

No unit test — `update` guard with `Cmd`/`sw` dependencies (like the R3-2/R8-4 `SetActivePage` guards); verified by compile + the traced mechanism.

Closes #1880. Found via the Round-9 sweep (promoted R4 runner-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)