### PR TITLE
R9-4: set the dirty flag on numeric lab Set handlers (clear no longer reverts)

### DIFF
--- a/client/src/elm/Pages/NCD/Activity/Update.elm
+++ b/client/src/elm/Pages/NCD/Activity/Update.elm
@@ -1741,7 +1741,7 @@ update currentDate id db msg model =
                     model.laboratoryData.hba1cTestForm
 
                 updatedForm =
-                    { form | hba1cResult = String.toFloat value }
+                    { form | hba1cResult = String.toFloat value, hba1cResultDirty = True }
 
                 updatedData =
                     model.laboratoryData

--- a/client/src/elm/Pages/NCD/RecurrentActivity/Update.elm
+++ b/client/src/elm/Pages/NCD/RecurrentActivity/Update.elm
@@ -273,7 +273,7 @@ update currentDate id db msg model =
                     model.labResultsData.randomBloodSugarTestForm
 
                 updatedForm =
-                    { form | sugarCount = String.toFloat value }
+                    { form | sugarCount = String.toFloat value, sugarCountDirty = True }
 
                 updatedData =
                     model.labResultsData

--- a/client/src/elm/Pages/Prenatal/RecurrentActivity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/RecurrentActivity/Update.elm
@@ -604,7 +604,7 @@ update id isLabTech db msg model =
                     model.labResultsData.hemoglobinTestForm
 
                 updatedForm =
-                    { form | hemoglobinCount = String.toFloat value }
+                    { form | hemoglobinCount = String.toFloat value, hemoglobinCountDirty = True }
 
                 updatedData =
                     model.labResultsData
@@ -666,7 +666,7 @@ update id isLabTech db msg model =
                     model.labResultsData.randomBloodSugarTestForm
 
                 updatedForm =
-                    { form | sugarCount = String.toFloat value }
+                    { form | sugarCount = String.toFloat value, sugarCountDirty = True }
 
                 updatedData =
                     model.labResultsData
@@ -752,7 +752,7 @@ update id isLabTech db msg model =
                     model.labResultsData.hivPCRTestForm
 
                 updatedForm =
-                    { form | hivViralLoad = String.toFloat value }
+                    { form | hivViralLoad = String.toFloat value, hivViralLoadDirty = True }
 
                 updatedData =
                     model.labResultsData
@@ -1538,7 +1538,7 @@ updateLabsHistory originEncounterId labEncounterId isLabTech db msg data =
                     data.hemoglobinTestForm
 
                 updatedForm =
-                    { form | hemoglobinCount = String.toFloat value }
+                    { form | hemoglobinCount = String.toFloat value, hemoglobinCountDirty = True }
             in
             ( { data | hemoglobinTestForm = updatedForm }
             , Cmd.none
@@ -1575,7 +1575,7 @@ updateLabsHistory originEncounterId labEncounterId isLabTech db msg data =
                     data.randomBloodSugarTestForm
 
                 updatedForm =
-                    { form | sugarCount = String.toFloat value }
+                    { form | sugarCount = String.toFloat value, sugarCountDirty = True }
             in
             ( { data | randomBloodSugarTestForm = updatedForm }
             , Cmd.none
@@ -1635,7 +1635,7 @@ updateLabsHistory originEncounterId labEncounterId isLabTech db msg data =
                     data.hivPCRTestForm
 
                 updatedForm =
-                    { form | hivViralLoad = String.toFloat value }
+                    { form | hivViralLoad = String.toFloat value, hivViralLoadDirty = True }
             in
             ( { data | hivPCRTestForm = updatedForm }
             , Cmd.none


### PR DESCRIPTION
## Problem
Several recurrent/NCD numeric lab `Set` handlers updated the value but omitted the `…Dirty = True` flag. Because `maybeValueConsideringIsDirtyField isDirty form saved = if isDirty then form else or form saved`, the flag only matters when the field is `Nothing` (cleared) — so **clearing a previously-saved value** falls back to the saved one and the blank is discarded. The Activity-side handlers set the flag; the recurrent/NCD ones didn't (the A/B tell).

Handlers fixed: `hemoglobinCount` (Prenatal recurrent ×2), `sugarCount` (Prenatal recurrent ×2 + NCD recurrent), `hivViralLoad` (Prenatal recurrent ×2), `hba1cResult` (NCD activity).

Narrow harm: only the *clear-to-blank* action is lost; changing to another number is preserved via `or`.

## Fix
Add `…Dirty = True` to each handler, matching the Activity-side twins.

## Verification
- `elm make src/elm/Main.elm` — Success
- `elm-test` — full suite 2744

No unit test — compiler-checked one-field additions (the dirty fields already exist and are read by the `…WithDefault` functions); consistent with the mechanical field fixes.

Closes #1882. Found via the Round-9 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)