### PR TITLE
Readability: extract begin-encounter in-flight check into a let binding

### DIFF
--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4679,7 +4679,13 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostIndividualEncounterParticipant extraData session ->
-            if Dict.get session.person model.postIndividualEncounterParticipant |> Maybe.map RemoteData.isLoading |> Maybe.withDefault False then
+            let
+                alreadyInFlight =
+                    Dict.get session.person model.postIndividualEncounterParticipant
+                        |> Maybe.map RemoteData.isLoading
+                        |> Maybe.withDefault False
+            in
+            if alreadyInFlight then
                 -- A create for this person is already in flight; ignore the
                 -- duplicate, so a double-tapped "begin encounter" button can't
                 -- open two encounter participants (e.g. two open pregnancies).
@@ -5100,7 +5106,13 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostFamilyEncounterParticipant session ->
-            if Dict.get session.person model.postFamilyEncounterParticipant |> Maybe.map RemoteData.isLoading |> Maybe.withDefault False then
+            let
+                alreadyInFlight =
+                    Dict.get session.person model.postFamilyEncounterParticipant
+                        |> Maybe.map RemoteData.isLoading
+                        |> Maybe.withDefault False
+            in
+            if alreadyInFlight then
                 -- Already creating a family encounter participant for this
                 -- person; ignore the double-tap.
                 ( model, Cmd.none, [] )


### PR DESCRIPTION
Follow-up to R9-3 (#1881). The two participant-create guards used a long inline condition in the `if`:

```elm
if Dict.get session.person model.postIndividualEncounterParticipant |> Maybe.map RemoteData.isLoading |> Maybe.withDefault False then
```

Extracted into an `alreadyInFlight` `let` binding in both `PostIndividualEncounterParticipant` and `PostFamilyEncounterParticipant`. Behavior-preserving readability change.

## Verification
- `elm make src/elm/Main.elm` — Success
- `elm-test` — full suite green
- `elm-format` clean

Closes #1884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
