### PR TITLE
Readability: extract long inline if-conditions into lets / a helper

### DIFF
--- a/client/src/elm/Backend/Measurement/Utils.elm
+++ b/client/src/elm/Backend/Measurement/Utils.elm
@@ -63,7 +63,12 @@ muacIndicationForChild (MuacInCm value) =
 
 muacIndicationForPerson : NominalDate -> Person -> MuacInCm -> ColorAlertIndication
 muacIndicationForPerson currentDate person muac =
-    if isPersonAnAdult currentDate person |> Maybe.withDefault False then
+    let
+        isAdult =
+            isPersonAnAdult currentDate person
+                |> Maybe.withDefault False
+    in
+    if isAdult then
         muacIndicationForAdult muac
 
     else

--- a/client/src/elm/Pages/Dashboard/Utils.elm
+++ b/client/src/elm/Pages/Dashboard/Utils.elm
@@ -789,10 +789,12 @@ filterNewlyDiagnosesCasesForSelectedMonth dateLastDayOfSelectedMonth diagnoses =
                 matchDates =
                     List.filterMap
                         (\encounter ->
-                            if
-                                EverySet.toList encounter.diagnoses
-                                    |> List.any (\diagnosis -> List.member diagnosis diagnoses)
-                            then
+                            let
+                                hasMatchingDiagnosis =
+                                    EverySet.toList encounter.diagnoses
+                                        |> List.any (\diagnosis -> List.member diagnosis diagnoses)
+                            in
+                            if hasMatchingDiagnosis then
                                 Just encounter.startDate
 
                             else

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -18,7 +18,7 @@ import Json.Encode
 import List.Zipper as Zipper
 import Maybe.Extra
 import Pages.Page exposing (Page)
-import RemoteData
+import RemoteData exposing (RemoteData)
 import Restful.Endpoint exposing (fromEntityUuid, toEntityUuid)
 import SyncManager.Decoder exposing (decodeDownloadSyncResponseAuthority, decodeDownloadSyncResponseAuthorityStats, decodeDownloadSyncResponseGeneral)
 import SyncManager.Encoder
@@ -41,7 +41,7 @@ import Version
 {-| True when either the local IndexedDB write or the backend request of a sync
 record is still in progress. Used to avoid re-issuing a step already running.
 -}
-isRecordLoading : { a | indexDbRemoteData : RemoteData.RemoteData e1 v1, backendRemoteData : RemoteData.RemoteData e2 v2 } -> Bool
+isRecordLoading : { a | indexDbRemoteData : RemoteData e1 v1, backendRemoteData : RemoteData e2 v2 } -> Bool
 isRecordLoading record =
     RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData
 

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -38,6 +38,14 @@ import Utils.WebData
 import Version
 
 
+{-| True when either the local IndexedDB write or the backend request of a sync
+record is still in progress. Used to avoid re-issuing a step already running.
+-}
+isRecordLoading : { a | indexDbRemoteData : RemoteData.RemoteData e1 v1, backendRemoteData : RemoteData.RemoteData e2 v2 } -> Bool
+isRecordLoading record =
+    RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData
+
+
 update : Time.Posix -> Page -> Int -> Device -> Msg -> Model -> SubModelReturn Model Msg
 update currentTime activePage dbVersion device msg model =
     let
@@ -933,7 +941,7 @@ update currentTime activePage dbVersion device msg model =
                     noChange
 
                 DownloadPhotosInProcess (DownloadPhotosBatch record) ->
-                    if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then
+                    if isRecordLoading record then
                         -- We are already loading.
                         noChange
 
@@ -954,7 +962,7 @@ update currentTime activePage dbVersion device msg model =
                             { model | downloadPhotosStatus = DownloadPhotosInProcess (DownloadPhotosBatch recordUpdated) }
 
                 DownloadPhotosInProcess (DownloadPhotosAll record) ->
-                    if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then
+                    if isRecordLoading record then
                         -- We are already loading.
                         noChange
 
@@ -986,7 +994,7 @@ update currentTime activePage dbVersion device msg model =
                     noChange
 
                 DownloadPhotosInProcess (DownloadPhotosBatch record) ->
-                    if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then
+                    if isRecordLoading record then
                         noChange
 
                     else
@@ -1006,7 +1014,7 @@ update currentTime activePage dbVersion device msg model =
                             { model | downloadPhotosStatus = DownloadPhotosInProcess (DownloadPhotosBatch recordUpdated) }
 
                 DownloadPhotosInProcess (DownloadPhotosAll record) ->
-                    if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then
+                    if isRecordLoading record then
                         noChange
 
                     else
@@ -1032,7 +1040,7 @@ update currentTime activePage dbVersion device msg model =
             -- Get a entities for upload from IndexDB.
             case model.syncStatus of
                 SyncUploadGeneral record ->
-                    if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then
+                    if isRecordLoading record then
                         -- We are already loading.
                         noChange
 
@@ -1089,7 +1097,7 @@ update currentTime activePage dbVersion device msg model =
             -- Get a entities for upload from IndexDB.
             case model.syncStatus of
                 SyncUploadAuthority record ->
-                    if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then
+                    if isRecordLoading record then
                         -- We are already loading.
                         noChange
 

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -1067,10 +1067,7 @@ update currentTime activePage dbVersion device msg model =
             -- Get a entities for upload from IndexDB.
             case model.syncStatus of
                 SyncUploadWhatsApp record ->
-                    if
-                        RemoteData.isLoading record.indexDbRemoteData
-                            || RemoteData.isLoading record.backendRemoteData
-                    then
+                    if isRecordLoading record then
                         -- We are already loading.
                         noChange
 


### PR DESCRIPTION
Follow-up readability cleanup (audit off the R9-3 pattern), covering 3 sites:

1. **`SyncManager/Update.elm`** — the 6×-repeated `if RemoteData.isLoading record.indexDbRemoteData || RemoteData.isLoading record.backendRemoteData then` is replaced with a shared `isRecordLoading record` helper.
2. **`Backend/Measurement/Utils.elm`** — `muacIndicationForPerson` now binds `isAdult` in a `let`.
3. **`Pages/Dashboard/Utils.elm`** — the wrapped diagnosis-match condition binds `hasMatchingDiagnosis` in a `let`.

All behavior-preserving.

## Verification
- `elm make src/elm/Main.elm` — Success (the structural `isRecordLoading` annotation type-checks across all 6 sites)
- `elm-test` — full suite 2749
- `elm-format` clean

Closes #1886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)