### PR TITLE
Sync: guarantee a port reply on upload-handler rejection (was a silent sync wedge)

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -948,7 +948,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         };
 
         return sendIndexedDbFetchResult(queryType, resultToSend);
-      })().catch(() => sendIndexedDbFetchResult(queryType, {entities: [], remaining: 0}));
+      })().catch((e) => sendIndexedDbFetchResult(queryType, {'entities': [], 'remaining': 0, 'error': String(e)}));
       break;
 
     case 'IndexDbQueryUploadWhatsApp':
@@ -983,7 +983,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         };
 
         return sendIndexedDbFetchResult(queryType, resultToSend);
-      })().catch(() => sendIndexedDbFetchResult(queryType, {entities: [], remaining: 0}));
+      })().catch((e) => sendIndexedDbFetchResult(queryType, {'entities': [], 'remaining': 0, 'error': String(e)}));
       break;
 
     case 'IndexDbQueryUploadAuthority':
@@ -1045,7 +1045,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         }
 
         return sendIndexedDbFetchResult(queryType, resultToSend);
-      })().catch(() => sendIndexedDbFetchResult(queryType, {entities: [], remaining: 0}));
+      })().catch((e) => sendIndexedDbFetchResult(queryType, {'entities': [], 'remaining': 0, 'error': String(e)}));
       break;
 
     case 'IndexDbQueryDeferredPhoto':

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -733,7 +733,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
 
         const cache = await caches.open(photosUploadCache);
 
-        result.forEach(async function(row, index) {
+        await Promise.all(result.map(async function(row, index) {
             const cachedResponse = await cache.match(row.photo);
 
             if (cachedResponse) {
@@ -813,7 +813,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
             }
 
             return sendIndexedDbFetchResult(queryType, {tag: 'Success', result: row});
-        });
+        }));
       })().catch((e) => sendIndexedDbFetchResult(queryType, {tag: 'Error', error: 'UploadError', reason: String(e)}));
       break;
 
@@ -837,7 +837,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         const screenshotsUploadCache = "screenshots-upload";
         const cache = await caches.open(screenshotsUploadCache);
 
-        result.forEach(async function(row, index) {
+        await Promise.all(result.map(async function(row, index) {
             const cachedResponse = await cache.match(row.screenshot);
 
             if (cachedResponse) {
@@ -910,7 +910,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
             }
 
             return sendIndexedDbFetchResult(queryType, {tag: 'Success', result: row});
-        });
+        }));
       })().catch((e) => sendIndexedDbFetchResult(queryType, {tag: 'Error', error: 'UploadError', reason: String(e)}));
       break;
 

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -814,7 +814,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
 
             return sendIndexedDbFetchResult(queryType, {tag: 'Success', result: row});
         });
-      })();
+      })().catch((e) => sendIndexedDbFetchResult(queryType, {tag: 'Error', error: 'UploadError', reason: String(e)}));
       break;
 
     case 'IndexDbQueryUploadScreenshot':
@@ -911,7 +911,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
 
             return sendIndexedDbFetchResult(queryType, {tag: 'Success', result: row});
         });
-      })();
+      })().catch((e) => sendIndexedDbFetchResult(queryType, {tag: 'Error', error: 'UploadError', reason: String(e)}));
       break;
 
     case 'IndexDbQueryUploadGeneral':
@@ -948,7 +948,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         };
 
         return sendIndexedDbFetchResult(queryType, resultToSend);
-      })();
+      })().catch(() => sendIndexedDbFetchResult(queryType, {entities: [], remaining: 0}));
       break;
 
     case 'IndexDbQueryUploadWhatsApp':
@@ -983,7 +983,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         };
 
         return sendIndexedDbFetchResult(queryType, resultToSend);
-      })();
+      })().catch(() => sendIndexedDbFetchResult(queryType, {entities: [], remaining: 0}));
       break;
 
     case 'IndexDbQueryUploadAuthority':
@@ -1045,7 +1045,7 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         }
 
         return sendIndexedDbFetchResult(queryType, resultToSend);
-      })();
+      })().catch(() => sendIndexedDbFetchResult(queryType, {entities: [], remaining: 0}));
       break;
 
     case 'IndexDbQueryDeferredPhoto':


### PR DESCRIPTION
Closes #1888.

## Problem
The five `IndexDbQueryUpload*` handlers in `client/src/js/app.js` are bare `async` IIFEs whose `try/catch` only wraps `fetch()`/`response.json()`. Any other rejection — most realistically the post-upload `.modify()` Dexie write failing on `QuotaExceededError`, which happens *after* a successful upload — dies as an unhandled rejection and **never replies to the `getFromIndexDb` port**. The Elm upload lanes have no timeout (the download lanes do), so the lane stays `Loading` forever and the whole sync cycle (uploads **and** downloads) silently wedges until a page reload.

## Fix
Append a `.catch` to each upload IIFE that always sends a reply. The existing `return sendIndexedDbFetchResult(...)` success/error paths resolve the promise normally, so `.catch` only fires on an otherwise-unhandled rejection (no double-reply):
- **Photo / Screenshot** → `{tag:'Error', error:'UploadError', reason}` — the shape their decoder already accepts (`decodeIndexDbQueryUpload{Photo,Screenshot}ResultRecordRemoteData`), feeding the existing errorsCount/threshold retry.
- **General / WhatsApp / Authority** → `{entities:[], remaining:0}` — an already-handled 'nothing to upload this cycle' shape, so the lane advances and re-reads the still-unsynced entities next cycle (self-healing) rather than wedging.

## Testing
- `node --check client/src/js/app.js` clean.
- Forced-throw discrimination check (no JS unit framework in this repo): simulated the post-upload-reject wedge — old behavior = 0 replies (wedge), new = exactly 1 decodable `Error` reply; happy path still sends exactly one reply (no double-reply).

Backlog: B-025 (R10 sweep). JS-only; no Elm change (decoders already accept both reply shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)