### PR TITLE
B-037: count preeclampsia-in-family as a Medical History task (stop silent discard)

### DIFF
--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -3105,6 +3105,7 @@ medicalFormInputsAndTasks language form =
       , maybeToBoolTask form.physicalConditions
       , maybeToBoolTask form.infectiousDiseases
       , maybeToBoolTask form.mentalHealthIssues
+      , maybeToBoolTask form.preeclampsiaInFamily
       ]
     )
 


### PR DESCRIPTION
Closes #1890.

## Problem
`medicalFormInputsAndTasks` renders 5 medical-history questions but counts only 4 tasks (omits `form.preeclampsiaInFamily`), while `toMedicalHistoryValue`'s `Maybe.map5` requires all 5. First visit: answer the 4 counted, skip preeclampsia → 4/4 → Save → `toMedicalHistoryValue` returns `Nothing` → `saveMeasurementMsgs` = `[]` (no-op) → navigation still advances → all four answered groups silently lost, no error.

## Fix
Add `maybeToBoolTask form.preeclampsiaInFamily` as the 5th task, so Save only enables once the question is answered — aligning the completion gate with the save contract. Editing an existing record is unaffected (the decoder backfills `preeclampsiaInFamily`); only the buggy first-visit path changes.

## Relationship to #1877
Both fix the same original oversight: when `preeclampsiaInFamily` was added to Prenatal Medical History, its **encoder** (value→JSON) and its **task count** were both left unwired. #1877 (merged) fixed the encoder — the silent data loss on sync. This PR fixes the task count — the 4/4 premature-Save that silently discards the whole record on a first visit. They were caught by two different review lenses (encode/decode round-trip vs completion-count-vs-payload), which is why they landed as two focused PRs.

## Testing
- `elm make src/elm/Main.elm` → Success (548 modules).
- `elm-format --validate` clean; `elm-test` 2749 passed / 0 failed.
- No bespoke unit test: a compiler-verified 1-line list append; the count helper is an unexposed `View` function returning `Html`, so testing it needs Language+form fixtures disproportionate to a one-liner (per the R5-1/R6-1 one-line-fix precedent).

Backlog: B-037 (R10 sweep, re-confirmed R14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
