### PR TITLE
Clone the base query for the HIV execution-note stats query

### DIFF
--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -1381,6 +1381,8 @@ function hedley_stats_get_ncd_data($health_center_id) {
     $items[$row->field_individual_participant]['encounters'][$row->nid]['hiv_test_result'] = $row->test_result;
   }
 
+  $query = clone $base_query;
+
   // Run dedicated query to pull data of HIV test execution note recorded
   // at NCD HIV Test activity.
   // Dedicated query is mandatory since multiple bundles hold same field.


### PR DESCRIPTION
Fixes #1892.

## What

One-line fix in `hedley_stats_get_ncd_data()`: add `$query = clone $base_query;` before the HIV test-execution-note joins, so the block runs as the dedicated query its own comment says is mandatory.

## Why

The block previously reused the already-executed test-result query. Its `condition('test_execution_note.bundle', 'ncd_hiv_test')` combined with the inherited `condition('test_result.bundle', 'ncd_hiv_test')` meant the second run only returned encounters that have **both** a test result and an execution note. Known-as-positive patients record an execution note without a test result, so they were silently dropped — undercounting the Dashboard HIV "HIV Cases" / "Managed by PMTCT" metrics for exactly the known-positive cohort. The reuse also stacked a duplicate `GROUP_CONCAT` expression and `groupBy` onto the second run.

## Verification

- `php -l` clean.
- phpcs Drupal + DrupalPractice (full CI extension list) clean.
- The fix mirrors the `$query = clone $base_query;` pattern used by the sibling diagnoses and test-result blocks directly above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)