### PR TITLE
Fix dashboard wasting/stunting counts to test z-score < -2, not < 2

### DIFF
--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -3051,7 +3051,7 @@ viewChildWellnessNutritionPage language dateLastDayOfSelectedMonth assembled =
         -- at encounter during selected month or previously, and did not have
         -- an encounter afterwards that indicated that condition was resolved.
         totalBeneficiariesWasting =
-            countCurrentlyDiagnosedByValue .zscoreWasting (\zscore -> zscore < 2)
+            countCurrentlyDiagnosedByValue .zscoreWasting (\zscore -> zscore < -2)
 
         -- Number of children who are had firs diagnosis of wasting during
         -- selected month.
@@ -3083,7 +3083,7 @@ viewChildWellnessNutritionPage language dateLastDayOfSelectedMonth assembled =
         -- encounter during selected month or previously, and did not have an
         -- encounter afterwards that indicated that condition was resolved.
         numberOfStunting =
-            countCurrentlyDiagnosedByValue .zscoreStunting (\zscore -> zscore < 2)
+            countCurrentlyDiagnosedByValue .zscoreStunting (\zscore -> zscore < -2)
 
         -- Number of Children who had either micro or macrocephaly diagnosed at
         -- encounter during selected month or previously, and did not have an


### PR DESCRIPTION
Fixes #1894.

## What

Two-character fix in `Pages/Dashboard/View.elm`: the `totalBeneficiariesWasting` and `numberOfStunting` predicates now test `zscore < -2` instead of `zscore < 2`.

## Why

Malnutrition is a z-score below −2 SD. Testing `< 2` counts every child below +2 SD — about 98% of a normal cohort — so the Dashboard → Child Wellness → Nutrition "Total Beneficiaries Wasting" and "# of Stunting" cards grossly over-counted. This is a definitive typo, not a convention: the same fields are tested `< -2` (`incidentsOfWasting`) and `>= -2` (`isGoodNutritionEncounter`) elsewhere in the same file, and the backend stores raw signed z-scores. Present since `a818e8069` (2024-01-04).

## Verification

- `elm make src/elm/Main.elm` — Success, 548 modules.
- `elm-format --validate` clean.
- `elm-test` — 2749 passed.
- Per project convention for mechanical sign-flip fixes, no bespoke unit test (the count helpers are unexposed view-level functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)