### PR TITLE
Sync: guarantee a port reply when the bulk-photo fetch fails mid-batch

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -596,7 +596,10 @@ elmApp.ports.sendSyncSpeed.subscribe(function(syncSpeed) {
  * whole-batch error) goes back via the bulkPhotoFetchHandle port.
  */
 elmApp.ports.bulkPhotoFetch.subscribe(async function(params) {
-  const outcome = await self.bulkPhotos.handleBulkPhotoFetch(params);
+  // Belt and braces: the handler guards its own failure paths, but a reply
+  // must reach Elm on every exit, or the photos lane stays Loading forever.
+  const outcome = await self.bulkPhotos.handleBulkPhotoFetch(params)
+    .catch((e) => ({ 'batchError': 0, 'error': String(e) }));
   elmApp.ports.bulkPhotoFetchHandle.send(outcome);
 });
 

--- a/client/src/js/bulkPhotos.js
+++ b/client/src/js/bulkPhotos.js
@@ -46,7 +46,14 @@ self.bulkPhotos.handleBulkPhotoFetch = async function (params) {
     return { batchError: response.status };
   }
 
-  var buf = await response.arrayBuffer();
+  var buf;
+  try {
+    buf = await response.arrayBuffer();
+  } catch (e) {
+    // Connection dropped while the (multi-MB) body was streaming —
+    // routine on rural networks. Transient: retry on the next cycle.
+    return { batchError: 0, error: String(e) };
+  }
   if (buf.byteLength < 8) {
     return { batchError: 0 };
   }
@@ -67,7 +74,13 @@ self.bulkPhotos.handleBulkPhotoFetch = async function (params) {
   }
 
   var binStart = 8 + manifestLen;
-  var cache = await caches.open(self.photoCache.cacheName);
+  var cache;
+  try {
+    cache = await caches.open(self.photoCache.cacheName);
+  } catch (e) {
+    // Cache Storage unavailable (quota pressure, storage eviction).
+    return { batchError: 0, error: String(e) };
+  }
   var results = [];
 
   for (var i = 0; i < manifest.items.length; i++) {

--- a/client/src/js/bulkPhotos.js
+++ b/client/src/js/bulkPhotos.js
@@ -14,7 +14,8 @@
  * handleBulkPhotoFetch returns either:
  *   { results: [{url, ok, terminal}, ...] } on success, or
  *   { batchError: <http status or 0 for network/parse failure> } on
- *   whole-batch failure.
+ *   whole-batch failure, optionally carrying a diagnostic `error` string
+ *   (ignored by the Elm decoder, visible in port traffic).
  *
  * NOTE: depends on self.photoCache.stripAccessToken — photoCache.js must
  * load before this file (handled by index.html script order).


### PR DESCRIPTION
Fixes #1898.

## What

- `bulkPhotos.js`: the two previously-unguarded awaits — `response.arrayBuffer()` (connection drop while the multi-MB batch body streams) and `caches.open` (storage pressure) — now return the documented whole-batch shape `{batchError: 0}` with the caught error forwarded as a diagnostic `error` field (ignored by the Elm decoder, visible in port traffic).
- `app.js`: the `bulkPhotoFetch` subscriber gained a belt-and-braces `.catch` so any rejection inside the handler still sends a decodable reply.

## Why

The Elm deferred-photos lane (`DownloadPhotosBatch`/`DownloadPhotosAll`) has no timeout — `if isLoading then noChange`. A handler rejection skipped the subscriber's `send`, so one mid-batch network drop (routine on rural networks) wedged photo downloading in `Loading` until page reload. `{batchError: 0}` decodes as retryable (`decodeBulkPhotoFetchHandle` → `Err 0`), so the lane now cleanly retries next cycle. Same failure-path class as #1888/#1889 (upload lanes).

## Verification

- `node --check` clean on both files.
- Discrimination harness driving the real `handleBulkPhotoFetch` with stubbed `fetch`/`caches`:
  - OLD, mid-body drop → unhandled rejection, no reply (the wedge); NEW → `{"batchError":0,"error":"TypeError: network error..."}`
  - OLD, `caches.open` failure → unhandled rejection; NEW → `{"batchError":0,"error":"QuotaExceededError..."}`
  - Happy path identical before/after (`{"results":[]}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)