### PR TITLE
Remove hardcoded deleted:false overriding the real flag in 3 measurement encoders

### DIFF
--- a/client/src/elm/Backend/Measurement/Encoder.elm
+++ b/client/src/elm/Backend/Measurement/Encoder.elm
@@ -877,7 +877,6 @@ encodeUltrasoundValue value =
     , ( "edd_weeks", int value.eddWeeks )
     , ( "edd_days", int value.eddDays )
     , ( "expected_date_concluded", Gizra.NominalDate.encodeYYYYMMDD value.eddDate )
-    , ( "deleted", bool False )
     , ( "type", string "prenatal_ultrasound" )
     ]
 
@@ -1430,7 +1429,6 @@ encodeMedicalHistoryValue value =
     , ( "infectious_disease_history", encodeEverySet encodeMedicalHistoryInfectiousDisease value.infectiousDiseases )
     , ( "mental_health_issues", encodeEverySet encodeMedicalHistoryMentalHealthIssue value.mentalHealthIssues )
     , ( "preeclampsia_in_family", encodeOccursInFamilySign value.preeclampsiaInFamily )
-    , ( "deleted", bool False )
     , ( "type", string "medical_history" )
     ]
 
@@ -2005,7 +2003,6 @@ encodeSymptomsRespiratoryValue signs =
     , ( "sore_throat_period", int soreThroat )
     , ( "loss_of_smell_period", int lossOfSmell )
     , ( "stabbing_chest_pain_period", int stabbingChestPain )
-    , ( "deleted", bool False )
     , ( "type", string "symptoms_respiratory" )
     ]
 


### PR DESCRIPTION
Fixes #1900.

## What

Deletes three hardcoded `("deleted", bool False)` lines from `Backend/Measurement/Encoder.elm` — in `encodeUltrasoundValue`, `encodeMedicalHistoryValue`, and `encodeSymptomsRespiratoryValue`.

## Why

The shared `encodeMeasurement` emits the real flag (`("deleted", bool measurement.deleted)`) and then appends the value encoder's fields via `List.concat` — so the hardcoded `False`, coming last, is what `Json.Encode.object` keeps (duplicate keys: last wins). Syncing a soft-deleted `prenatal_ultrasound` / `medical_history` / `symptoms_respiratory` measurement therefore uploaded `deleted: false`, resurrecting the record on the backend. Every other measurement type already relies solely on the shared flag; these three were the only duplicates (grep-verified — exactly one `"deleted"` key remains in the file after the change).

## Verification

- `elm make src/elm/Main.elm` — Success, 548 modules.
- `elm-format --validate` clean.
- `elm-test` — 2752 passed.
- Mechanical line-deletion per the established convention (the duplicate-key last-wins mechanism was verified empirically when this was first recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)