### PR TITLE
Fix inverted resolved-follow-up filter keeping resolved, dropping open

### DIFF
--- a/client/src/elm/Pages/GlobalCaseManagement/Test.elm
+++ b/client/src/elm/Pages/GlobalCaseManagement/Test.elm
@@ -1,0 +1,46 @@
+module Pages.GlobalCaseManagement.Test exposing (all)
+
+import Date
+import Expect
+import Pages.GlobalCaseManagement.Utils exposing (filterResolvedFollowUps)
+import Test exposing (Test, describe, test)
+import Time
+
+
+all : Test
+all =
+    describe "Pages.GlobalCaseManagement"
+        [ filterResolvedFollowUpsTests ]
+
+
+{-| filterResolvedFollowUps is the keep-predicate for pending follow-ups:
+an item resolved ON or BEFORE the limit date is resolved as of that date
+and must be dropped; an item resolved AFTER the limit date (or not at
+all) was still open and must be kept. The server stamps resolution dates
+at resolution time, so for the case-management view (limit = today)
+every resolved item must be dropped.
+-}
+filterResolvedFollowUpsTests : Test
+filterResolvedFollowUpsTests =
+    let
+        limitDate =
+            Date.fromCalendarDate 2026 Time.Jun 15
+    in
+    describe "filterResolvedFollowUps"
+        [ test "drops a follow up resolved before the limit date" <|
+            \_ ->
+                filterResolvedFollowUps limitDate (Just <| Date.fromCalendarDate 2026 Time.Jun 10)
+                    |> Expect.equal False
+        , test "drops a follow up resolved on the limit date" <|
+            \_ ->
+                filterResolvedFollowUps limitDate (Just <| Date.fromCalendarDate 2026 Time.Jun 15)
+                    |> Expect.equal False
+        , test "keeps a follow up resolved after the limit date" <|
+            \_ ->
+                filterResolvedFollowUps limitDate (Just <| Date.fromCalendarDate 2026 Time.Jun 20)
+                    |> Expect.equal True
+        , test "keeps a follow up with no resolution date" <|
+            \_ ->
+                filterResolvedFollowUps limitDate Nothing
+                    |> Expect.equal True
+        ]

--- a/client/src/elm/Pages/GlobalCaseManagement/Utils.elm
+++ b/client/src/elm/Pages/GlobalCaseManagement/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.GlobalCaseManagement.Utils exposing (calculateDueDate, chwFilters, fillPersonName, filterFollowUpsOfResidents, followUpDueOptionByDate, generateAcuteIllnessEncounters, generateAcuteIllnessFollowUps, generateAcuteIllnessParticipants, generateHIVFollowUps, generateHIVParticipants, generateImmunizationFollowUps, generateNutritionFollowUps, generatePrenatalEncounters, generatePrenatalFollowUps, generatePrenatalParticipants, generateTuberculosisEncounters, generateTuberculosisFollowUps, generateTuberculosisParticipants, labTechFilters, labsResultsTestData, nurseFilters, resolveUniquePatientsFromFollowUps)
+module Pages.GlobalCaseManagement.Utils exposing (calculateDueDate, chwFilters, fillPersonName, filterFollowUpsOfResidents, filterResolvedFollowUps, followUpDueOptionByDate, generateAcuteIllnessEncounters, generateAcuteIllnessFollowUps, generateAcuteIllnessParticipants, generateHIVFollowUps, generateHIVParticipants, generateImmunizationFollowUps, generateNutritionFollowUps, generatePrenatalEncounters, generatePrenatalFollowUps, generatePrenatalParticipants, generateTuberculosisEncounters, generateTuberculosisFollowUps, generateTuberculosisParticipants, labTechFilters, labsResultsTestData, nurseFilters, resolveUniquePatientsFromFollowUps)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Entities exposing (..)
@@ -463,8 +463,9 @@ filterResolvedFollowUps : NominalDate -> Maybe NominalDate -> Bool
 filterResolvedFollowUps limitDate resolutionDate =
     Maybe.map
         (\date ->
-            -- Resolution date was on limit date, or before that.
-            not <| Date.compare limitDate date == LT
+            -- Keep the follow up only if it was resolved AFTER the limit
+            -- date, meaning it was still open as of that date.
+            Date.compare limitDate date == LT
         )
         resolutionDate
         |> -- Do not filter follow up if resolution date is not set.


### PR DESCRIPTION
Fixes #1904.

## What

One-expression fix in `Pages/GlobalCaseManagement/Utils.elm`: `filterResolvedFollowUps` drops the `not`, so the keep-predicate is now `Date.compare limitDate date == LT` — keep only follow-ups resolved strictly AFTER the limit date (still open as of that date), or never resolved. The inline comment is rewritten to state the keep-semantics. The function is newly exposed for tests. The similar-looking due-date guard in `generateImmunizationFollowUps` (same expression shape on `dueDate`) is intentionally untouched — "keep items already due" is correct there.

## Why

All 10 call sites use this as the "filter out resolved follow ups" predicate for pending-follow-up lists. The inverted comparison kept already-resolved items and dropped still-open ones. Real-world effect is bounded by the service worker's pre-filter (resolved items are mostly dropped before Elm), EXCEPT the five follow-up types deliberately retained ≤6 months for Dashboard statistics — so resolved nutrition/TB items lingered as OverDue in case management, and dashboard month-window totals (`getFollowUpsTotals`) were wrong in both directions (open-during-month dropped, resolved-before-month kept).

## Expected behavior change

- Case management: recently-resolved nutrition/TB follow-ups disappear from the pending lists (correct; fewer items, no flood).
- Dashboard follow-up totals: gain items that were open during the month but resolved later; lose items resolved before the month end.

## Verification

- New `Pages/GlobalCaseManagement/Test.elm` with 4 boundary tests (resolved before / on / after limit, no resolution date).
- Discrimination verified: against the pre-fix logic, exactly the 3 behavior-pinning tests fail (before/on limit must drop; after limit must keep); the `Nothing` case passes on both.
- `elm make src/elm/Main.elm` — Success, 548 modules; `elm-format --validate` clean; `elm-review` clean; `elm-test` — 2756 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)