### PR TITLE
Dashboard stats: fix follow-up setMonth under-counting

### DIFF
--- a/client/src/js/nodes.js
+++ b/client/src/js/nodes.js
@@ -654,7 +654,7 @@
                     if (node.date_concluded != undefined && typeof node.date_concluded != 'undefined') {
                         var resolutionDate = new Date(node.date_concluded);
                         if (followUpMeasurementsTypesUsedByDashboard.includes(node.type)) {
-                          resolutionDate.setMonth(today.getMonth() + 6);
+                          resolutionDate.setMonth(resolutionDate.getMonth() + 6);
                         }
 
                         if (resolutionDate < today) {


### PR DESCRIPTION
## Summary

`viewFollowUpMeasurements` in `client/src/js/nodes.js` under-counted Dashboard follow-up statistics for part of the calendar year.

The 6-month "resolved recently, keep it" cutoff was computed as:

```js
resolutionDate.setMonth(today.getMonth() + 6);
```

which overwrites the resolution month with *today's* month + 6 while keeping the conclusion date's **year and day** — a meaningless comparison date. The fix adds 6 months to the resolution date itself:

```diff
- resolutionDate.setMonth(today.getMonth() + 6);
+ resolutionDate.setMonth(resolutionDate.getMonth() + 6);
```

## Impact

Silent under-counting of Dashboard follow-up / case-management counts for the 5 dashboard follow-up types (`acute_illness_follow_up`, `follow_up`, `nutrition_follow_up`, `prenatal_follow_up`, `well_child_follow_up`). Example: with `today = 2026-02-10`, a follow-up concluded `2025-11-15` (~3 months ago, should be counted) was dropped because the buggy code compared against `2025-08-15`. Read-path aggregation only — no data loss.

## Verification

- `node --check client/src/js/nodes.js` — clean.
- Discrimination harness reproducing the exact keep/drop block: pre-fix drops a within-window follow-up; post-fix keeps it and still correctly drops genuinely-expired (>6-month-old) follow-ups.

Fixes #1906

🤖 Generated with [Claude Code](https://claude.com/claude-code)