### PR TITLE
Dashboard stats: exclude soft-deleted measurements

### DIFF
--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -975,7 +975,12 @@ function hedley_stats_get_acute_illness_data($health_center_id) {
   $query->condition('field_individual_participant.field_individual_participant_target_id', $individual_participants, 'IN');
 
   // Join with AI Encounter table, through which we can join measurements data.
-  $query->leftJoin('field_data_field_acute_illness_encounter', 'ai_encounter', 'ai_encounter.field_acute_illness_encounter_target_id = node.nid');
+  // Soft-deleted measurements are excluded via the ON clause, so their values
+  // are not pulled into the aggregates below.
+  $query->leftJoin('field_data_field_acute_illness_encounter', 'ai_encounter', hedley_stats_exclude_deleted_from_join(
+    'ai_encounter.field_acute_illness_encounter_target_id = node.nid',
+    'ai_encounter.entity_id'
+  ));
 
   // Pull data of health center referrals.
   $query->leftJoin('field_data_field_send_to_hc', 'send_to_hc', 'send_to_hc.entity_id = ai_encounter.entity_id');
@@ -1153,7 +1158,12 @@ function hedley_stats_get_prenatal_data($health_center_id) {
 
   // Join with Prenatal Encounter table,
   // through which we can join measurements data.
-  $query->leftJoin('field_data_field_prenatal_encounter', 'prenatal_encounter', 'prenatal_encounter.field_prenatal_encounter_target_id = node.nid');
+  // Soft-deleted measurements are excluded via the ON clause, so their values
+  // are not pulled into the aggregates below.
+  $query->leftJoin('field_data_field_prenatal_encounter', 'prenatal_encounter', hedley_stats_exclude_deleted_from_join(
+    'prenatal_encounter.field_prenatal_encounter_target_id = node.nid',
+    'prenatal_encounter.entity_id'
+  ));
 
   // Pull data of danger signs that were recorded during encounter.
   $query->leftJoin('field_data_field_danger_signs', 'danger_signs', 'danger_signs.entity_id = prenatal_encounter.entity_id');
@@ -1302,7 +1312,13 @@ function hedley_stats_get_ncd_data($health_center_id) {
   }
   $base_query->condition('field_individual_participant.field_individual_participant_target_id', $individual_participants, 'IN');
   // Join with NCD Encounter table, through which we can join measurements data.
-  $base_query->leftJoin('field_data_field_ncd_encounter', 'ncd_encounter', 'ncd_encounter.field_ncd_encounter_target_id = node.nid');
+  // Soft-deleted measurements are excluded via the ON clause, so their values
+  // are not pulled into the aggregates below (this base query is cloned into
+  // the measurement queries that follow).
+  $base_query->leftJoin('field_data_field_ncd_encounter', 'ncd_encounter', hedley_stats_exclude_deleted_from_join(
+    'ncd_encounter.field_ncd_encounter_target_id = node.nid',
+    'ncd_encounter.entity_id'
+  ));
 
   $query = clone $base_query;
   // Pull data of prenatal_diagnoses that were recorded during encounter.
@@ -1582,7 +1598,13 @@ function hedley_stats_get_spv_data($health_center_id) {
 
   // Join with Well Child Encounter table, through which
   // we can join measurements data.
-  $base_query->leftJoin('field_data_field_well_child_encounter', 'well_child_encounter', 'well_child_encounter.field_well_child_encounter_target_id = node.nid');
+  // Soft-deleted measurements are excluded via the ON clause, so their values
+  // are not pulled into the aggregates below (this base query is cloned into
+  // the measurement queries that follow).
+  $base_query->leftJoin('field_data_field_well_child_encounter', 'well_child_encounter', hedley_stats_exclude_deleted_from_join(
+    'well_child_encounter.field_well_child_encounter_target_id = node.nid',
+    'well_child_encounter.entity_id'
+  ));
 
   $query = clone $base_query;
 
@@ -1774,7 +1796,13 @@ function hedley_stats_get_child_scorecard_data($health_center_id) {
 
   // Join with Well Child Encounter table, through which
   // we can join measurements data.
-  $base_query->leftJoin('field_data_field_child_scoreboard_encounter', 'child_scoreboard_encounter', 'child_scoreboard_encounter.field_child_scoreboard_encounter_target_id = node.nid');
+  // Soft-deleted measurements are excluded via the ON clause, so their values
+  // are not pulled into the aggregates below (this base query is cloned into
+  // the measurement queries that follow).
+  $base_query->leftJoin('field_data_field_child_scoreboard_encounter', 'child_scoreboard_encounter', hedley_stats_exclude_deleted_from_join(
+    'child_scoreboard_encounter.field_child_scoreboard_encounter_target_id = node.nid',
+    'child_scoreboard_encounter.entity_id'
+  ));
 
   $query = clone $base_query;
 
@@ -2005,7 +2033,13 @@ function hedley_stats_get_nutrition_individual_data($health_center_id) {
 
   // Join with Nutrition Encounter table, through which we can
   // join measurements data.
-  $base_query->leftJoin('field_data_field_nutrition_encounter', 'nutrition_encounter', 'nutrition_encounter.field_nutrition_encounter_target_id = node.nid');
+  // Soft-deleted measurements are excluded via the ON clause, so their values
+  // are not pulled into the aggregates below (this base query is cloned into
+  // the measurement queries that follow).
+  $base_query->leftJoin('field_data_field_nutrition_encounter', 'nutrition_encounter', hedley_stats_exclude_deleted_from_join(
+    'nutrition_encounter.field_nutrition_encounter_target_id = node.nid',
+    'nutrition_encounter.entity_id'
+  ));
 
   $query = clone $base_query;
 
@@ -3463,6 +3497,35 @@ function hedley_stats_run_node_query_in_batches(SelectQuery $query, $batch = 100
   }
 
   return $result;
+}
+
+/**
+ * Adds a soft-delete exclusion to a measurement JOIN's ON condition.
+ *
+ * The dashboard statistics builders reach measurement values by joining the
+ * field_<program>_encounter table (whose entity_id is the measurement node ID)
+ * and then joining each value field off that alias. Soft-deleting a measurement
+ * only sets its field_deleted flag; the node and its field rows remain, so
+ * the measurement's values would otherwise keep being pulled into the
+ * aggregates on every stats recalculation.
+ *
+ * The exclusion is folded into the JOIN's ON clause (rather than added as a
+ * WHERE condition) so that a soft-deleted measurement is treated as absent from
+ * the LEFT JOIN - its values simply do not appear - without dropping the
+ * encounter row. A WHERE filter on a fanned-in measurement would instead drop
+ * the whole encounter when all of its measurements are deleted.
+ *
+ * @param string $on_condition
+ *   The original ON condition of the measurement join.
+ * @param string $measurement_entity_id
+ *   SQL reference to the measurement node ID within that join, e.g.
+ *   "ai_encounter.entity_id".
+ *
+ * @return string
+ *   The ON condition extended with the soft-delete exclusion.
+ */
+function hedley_stats_exclude_deleted_from_join($on_condition, $measurement_entity_id) {
+  return "$on_condition AND NOT EXISTS (SELECT 1 FROM {field_data_field_deleted} hsd WHERE hsd.entity_id = $measurement_entity_id AND hsd.field_deleted_value = 1)";
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -3525,7 +3525,7 @@ function hedley_stats_run_node_query_in_batches(SelectQuery $query, $batch = 100
  *   The ON condition extended with the soft-delete exclusion.
  */
 function hedley_stats_exclude_deleted_from_join($on_condition, $measurement_entity_id) {
-  return "$on_condition AND NOT EXISTS (SELECT 1 FROM {field_data_field_deleted} hsd WHERE hsd.entity_id = $measurement_entity_id AND hsd.field_deleted_value = 1)";
+  return "($on_condition) AND NOT EXISTS (SELECT 1 FROM {field_data_field_deleted} hsd WHERE hsd.entity_id = $measurement_entity_id AND hsd.field_deleted_value = 1)";
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -305,7 +305,7 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
    */
   protected function extractFirstStatsEncounter(array $data) {
     $participant = reset($data);
-    if (empty($participant['encounters'])) {
+    if (empty($participant) || empty($participant['encounters'])) {
       return [];
     }
 

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -82,6 +82,7 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
    *   2. Case management aggregation across moderate/severe branches.
    *   3. Session attendance (smoke check that the function runs).
    *   4. Stats-blob sync with cache-hash invalidation.
+   *   5. Soft-deleted measurements are excluded from stats aggregates (B-032).
    */
   public function testStatsCalculations() {
     // 1. Total encounters.
@@ -258,6 +259,57 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
 
     // Check that we got the stats.
     $this->assertTrue(is_array($stats4));
+
+    // 5. Soft-deleted measurements are excluded from stats aggregates (B-032).
+    //
+    // An admin can soft-delete an individual measurement (field_deleted = TRUE)
+    // while its encounter stays live (VBO mark-as-deleted action, or the
+    // delete-duplicate-measurements script). The dashboard builders join
+    // measurement values off the field_<program>_encounter fan, which had no
+    // deleted filter, so the removed values kept feeding the dashboards on
+    // every recalculation. This scenario exercises the shared
+    // hedley_stats_exclude_deleted_from_join() helper through the nutrition
+    // individual builder as a representative of the six builders that use it.
+    $this->resetHealthCenter();
+    $created = $this->createIndividualNutritionEncounterData('-7 days', 11, 'edema');
+
+    // Baseline: the MUAC measurement is present in the stats.
+    hedley_stats_handle_cache(HEDLEY_STATS_CACHE_CLEAR, HEDLEY_STATS_SYNC_NUTRITION_INDIVIDUAL_DATA, $this->healthCenterId);
+    $encounter_before = $this->extractFirstStatsEncounter(hedley_stats_get_nutrition_individual_data($this->healthCenterId));
+    $this->assertFalse(empty($encounter_before['muac']), 'MUAC measurement is present before deletion.');
+
+    // Soft-delete the MUAC measurement, leaving its encounter live.
+    $muac_wrapper = entity_metadata_wrapper('node', $created['muac']);
+    $muac_wrapper->field_deleted->set(TRUE);
+    $muac_wrapper->save();
+
+    // Recalculate: the deleted MUAC must be gone, while the encounter and its
+    // still-live nutrition sign must remain. Before the fix, the deleted MUAC
+    // value would still be pulled in here.
+    hedley_stats_handle_cache(HEDLEY_STATS_CACHE_CLEAR, HEDLEY_STATS_SYNC_NUTRITION_INDIVIDUAL_DATA, $this->healthCenterId);
+    $encounter_after = $this->extractFirstStatsEncounter(hedley_stats_get_nutrition_individual_data($this->healthCenterId));
+    $this->assertFalse(empty($encounter_after), 'Encounter is retained after its measurement is soft-deleted.');
+    $this->assertTrue(empty($encounter_after['muac']), 'Soft-deleted MUAC is excluded from stats after recalculation.');
+    $this->assertEqual(['edema'], $encounter_after['nutrition_signs'], 'Live nutrition sign is retained.');
+  }
+
+  /**
+   * Return the first encounter from a program *_data stats structure.
+   *
+   * @param array $data
+   *   A stats builder result: a list of participant items, each with an
+   *   'encounters' list.
+   *
+   * @return array
+   *   The first participant's first encounter, or an empty array if none.
+   */
+  protected function extractFirstStatsEncounter(array $data) {
+    $participant = reset($data);
+    if (empty($participant['encounters'])) {
+      return [];
+    }
+
+    return reset($participant['encounters']);
   }
 
   /**
@@ -406,6 +458,10 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
    *   Nutrition sign value to record.
    * @param float $weight_value
    *   Weight value to record.
+   *
+   * @return array
+   *   The created node IDs, keyed by 'encounter', 'muac', 'height', 'weight'
+   *   and 'nutrition'.
    */
   protected function createIndividualNutritionEncounterData($timestamp = '-7 days', $muac_value = 11, $nutrition_sign = 'edema', $weight_value = 9) {
     $date = strtotime($timestamp);
@@ -441,10 +497,13 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     ];
     node_save($encounter);
 
-    $this->createMuac('nutrition_muac', $encounter->nid, $child_id, $muac_value, $date);
-    $this->createHeight('nutrition_height', $encounter->nid, $child_id, 68, $date);
-    $this->createWeight('nutrition_weight', $encounter->nid, $child_id, $weight_value, $date);
-    $this->createNutrition('nutrition_nutrition', $encounter->nid, $child_id, $nutrition_sign, $date);
+    return [
+      'encounter' => $encounter->nid,
+      'muac' => $this->createMuac('nutrition_muac', $encounter->nid, $child_id, $muac_value, $date),
+      'height' => $this->createHeight('nutrition_height', $encounter->nid, $child_id, 68, $date),
+      'weight' => $this->createWeight('nutrition_weight', $encounter->nid, $child_id, $weight_value, $date),
+      'nutrition' => $this->createNutrition('nutrition_nutrition', $encounter->nid, $child_id, $nutrition_sign, $date),
+    ];
   }
 
   /**


### PR DESCRIPTION
## Summary

The `hedley_stats` dashboard builders excluded soft-deleted **encounters** (primary node via `hedley_stats_get_base_query`) but joined measurement values off the `field_<program>_encounter` fan with **no deleted filter** — module-wide `grep -c field_data_field_deleted hedley_stats.module` = `0`. Soft-deleting a measurement only sets its `field_deleted` flag; the node and field rows remain, so the measurement kept fanning in and its value flowed into the aggregate, re-entering the cache on every stats recalculation.

Reachable in production via the VBO `hedley_admin_mark_as_deleted_action` (`'triggers' => ['any']`) and the bulk `delete-duplicate-measurements.php` script.

## Fix

A shared helper folds a "measurement is not soft-deleted" check into each measurement JOIN's **ON clause** (not a `WHERE` condition), so a deleted measurement is treated as absent from the LEFT JOIN — its values simply don't appear — without dropping the encounter row (a `WHERE` filter would drop the whole encounter when all of its measurements are deleted):

```php
function hedley_stats_exclude_deleted_from_join($on_condition, $measurement_entity_id) {
  return "$on_condition AND NOT EXISTS (SELECT 1 FROM {field_data_field_deleted} hsd WHERE hsd.entity_id = $measurement_entity_id AND hsd.field_deleted_value = 1)";
}
```

Applied to the 6 measurement-encounter fan joins: **acute illness, prenatal, NCD, SPV/well-child, child scoreboard, nutrition individual**. For NCD/SPV/scoreboard/nutrition the fan lives in a `$base_query` cloned into follow-up measurement queries, so filtering the fan once covers the clones.

Out of scope (already correct): encounter-level fields on `node.nid` (`prenatal_diagnoses`, `ncd_diagnoses`, `encounter_warnings`) are covered by the base query's encounter filter; nutrition-**group** / case-management / family-planning / attendance query the measurement bundle directly (node = measurement, base-query filtered); person fields and group-education participants are person-side (separate finding).

## Verification

- `php -l` + phpcs (Drupal + DrupalPractice): clean.
- **SQL-level discrimination** against the real `field_data_*` tables (rolled-back transaction): old ON clause pulls a soft-deleted MUAC into the aggregate (`muac=11`); new ON clause excludes it (`muac=NULL`) while retaining the live sibling (`nutrition_signs=edema`) and preserving the encounter row even when all its measurements are deleted.
- **New SimpleTest scenario** in `HedleyStatsCalculation`: soft-deletes a MUAC measurement under a live nutrition encounter, recalculates, and asserts the deleted value is gone while the encounter and its live nutrition sign remain. Exercises the shared helper through the nutrition-individual builder (representative of all six).

Fixes #1908

🤖 Generated with [Claude Code](https://claude.com/claude-code)