### PR TITLE
Toolchain: upgrade Elm 0.19.1 → 0.19.2

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -147,7 +147,7 @@ These are the most common mistakes when writing E-Heza E2E tests. Violating any 
 When you can't reliably target an element (duplicate labels, ambiguous structure, no distinguishing class), **add a CSS class in the Elm source** to serve as a test identifier. Never weaken assertions or use fragile index-based selectors as a workaround. The Elm codebase is under our control — adding a class like `class "encounter-row-ai-hc"` is cheap and makes tests robust.
 
 ### 1. No `name` Attributes on Form Inputs
-Elm's `etaque/elm-form` does NOT set HTML `name` attributes. Locate inputs by label text:
+Elm's `Gizra/elm-form` does NOT set HTML `name` attributes. Locate inputs by label text:
 ```typescript
 page.locator('.ui.grid').filter({ hasText: 'Label Text:' }).locator('input').first()
 ```

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -34,16 +34,24 @@ RUN if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then \
     fi
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
-# Elm - directly downloading the binary.
-RUN wget https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz
-RUN gunzip binary-for-linux-64-bit.gz
-RUN mv binary-for-linux-64-bit /usr/bin/elm
-RUN chmod +x /usr/bin/elm
+# Elm - directly downloading the binary. Since 0.19.2 the release ships one
+# asset per architecture, so pick the one matching the container.
+RUN set -eux; \
+    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then \
+      ELM_ARCH=arm; \
+    else \
+      ELM_ARCH=x64; \
+    fi; \
+    wget -q "https://github.com/elm/compiler/releases/download/0.19.2/elm-0.19.2-linux-${ELM_ARCH}.gz" -O /tmp/elm.gz; \
+    gunzip -c /tmp/elm.gz > /usr/bin/elm; \
+    rm /tmp/elm.gz; \
+    chmod +x /usr/bin/elm; \
+    elm --version
 # gulp for the client compilation.
 RUN npm install -g gulp-cli
 # For Elm Unit tests
 ENV NPM_CONFIG_UNSAFE_PERM=true
-RUN npm install -g elm-test@0.19.1-revision6
+RUN npm install -g elm-test@0.19.2-0
 # Install svg2elm.
 RUN npm install -g svg2elm
 # Downgrade terminus.

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
   - name: Terminal
     init: |
       npm install -g elm-format
-      npm install -g elm@latest-0.19.1
+      npm install -g elm@latest-0.19.2
       export DDEV_NONINTERACTIVE=true
       cp .ddev/config.local.yaml.example .ddev/config.local.yaml
       ddev start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 E-Heza is a digital health data capture app for frontline health workers (maternal/child health). It's an offline-first PWA that syncs with a Drupal backend.
 
-- **Frontend:** Elm 0.19.1 (`client/`)
+- **Frontend:** Elm 0.19.2 (`client/`)
 - **Backend:** Drupal 7 with custom "Hedley" install profile (`server/hedley/`)
 - **Database:** MariaDB 10.5
 - **Dev environment:** DDEV (Docker-based)

--- a/ci-scripts/install_client.sh
+++ b/ci-scripts/install_client.sh
@@ -10,8 +10,8 @@ set -e
 echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 
 # Install global packages.
-npm install -g elm@latest-0.19.1
-npm install -g elm-test@0.19.1-revision6
+npm install -g elm@latest-0.19.2
+npm install -g elm-test@0.19.2-0
 npm install --global gulp-cli
 npm install -g bower
 

--- a/ci-scripts/install_elm_review.sh
+++ b/ci-scripts/install_elm_review.sh
@@ -9,9 +9,10 @@ set -e
 
 # Install Elm compiler (required by elm-review)
 # Using the official binary release for Linux x64
-wget -q https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz
-gunzip binary-for-linux-64-bit.gz
-chmod +x binary-for-linux-64-bit
-sudo mv binary-for-linux-64-bit /usr/local/bin/elm
+ELM_VERSION=0.19.2
+wget -q "https://github.com/elm/compiler/releases/download/${ELM_VERSION}/elm-${ELM_VERSION}-linux-x64.gz"
+gunzip "elm-${ELM_VERSION}-linux-x64.gz"
+chmod +x "elm-${ELM_VERSION}-linux-x64"
+sudo mv "elm-${ELM_VERSION}-linux-x64" /usr/local/bin/elm
 
 echo "Elm compiler installed successfully"

--- a/ci-scripts/test_elm.sh
+++ b/ci-scripts/test_elm.sh
@@ -14,8 +14,8 @@
 set -e
 
 # Install the Elm toolchain (same versions as ci-scripts/install_client.sh).
-npm install -g elm@latest-0.19.1
-npm install -g elm-test@0.19.1-revision6
+npm install -g elm@latest-0.19.2
+npm install -g elm-test@0.19.2-0
 npm install --global gulp-cli
 
 cd "$CIRCLE_WORKING_DIRECTORY"/client

--- a/client/e2e/helpers/common.ts
+++ b/client/e2e/helpers/common.ts
@@ -402,7 +402,7 @@ export async function saveSubTask(page: Page): Promise<void> {
 
 /**
  * Locate a form input by its label text (grid row pattern).
- * Elm's etaque/elm-form does NOT set HTML name attributes on inputs,
+ * Elm's Gizra/elm-form does NOT set HTML name attributes on inputs,
  * so we locate by label text in the .ui.grid layout.
  */
 export function formInput(page: Page, labelText: string) {

--- a/client/elm.json
+++ b/client/elm.json
@@ -4,11 +4,12 @@
         "src/elm",
         "src/generated"
     ],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.2",
     "dependencies": {
         "direct": {
             "Gizra/elm-all-set": "1.0.1",
             "Gizra/elm-debouncer": "2.0.0",
+            "Gizra/elm-form": "1.0.0",
             "NoRedInk/elm-json-decode-pipeline": "1.0.1",
             "avh4/elm-color": "1.0.0",
             "ccapndave/elm-update-extra": "4.0.0",
@@ -26,8 +27,7 @@
             "elm-community/maybe-extra": "5.3.0",
             "elm-community/string-extra": "4.0.1",
             "elm-community/typed-svg": "7.0.0",
-            "elm-explorations/test": "1.2.2",
-            "etaque/elm-form": "4.0.0",
+            "elm-explorations/test": "2.2.1",
             "folkertdev/one-true-path-experiment": "6.0.0",
             "gampleman/elm-visualization": "2.4.1",
             "hecrj/html-parser": "2.4.0",
@@ -43,6 +43,7 @@
             "wernerdegroot/listzipper": "4.0.0"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/virtual-dom": "1.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "csv-parse": "^4.4.1",
     "del": "^4.1.1",
     "elm-review": "^2.13.5",
-    "elm-test": "^0.19.1-revision6",
+    "elm-test": "^0.19.2-0",
     "git-rev": "^0.2.1",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^6.1.0",

--- a/client/review/elm.json
+++ b/client/review/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.2",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -30775,7 +30775,7 @@ translateFormError error =
             translateValidationError e
 
 
-{-| This one is hampered by the fact that the field names in etaque/elm-form
+{-| This one is hampered by the fact that the field names in Gizra/elm-form
 are untyped strings, but we do our best.
 -}
 translateFormField : String -> TranslationSet String

--- a/server/elm/elm.json
+++ b/server/elm/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.2",
     "dependencies": {
         "direct": {
             "Gizra/elm-all-set": "1.0.1",

--- a/server/elm/review/elm.json
+++ b/server/elm/review/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.2",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",


### PR DESCRIPTION
Tracking issue: #1913

## Summary

Upgrades the Elm compiler to [0.19.2](https://github.com/elm/compiler/releases/tag/0.19.2) (released 2026-07-06). It is a **performance-only patch release — no language changes**.

## Measured impact

Benchmarked on this repo: identical sources, identical dependency set (only `elm-version` + the binary differ), warm package cache, cold `elm-stuff`, runs interleaved to cancel drift. 16-core host.

| Scenario | 0.19.1 | 0.19.2 | Median Δ |
|---|---|---|---|
| Full build (n=5, median) | 44.62s | **35.52s** | **−20%** |
| Full build (n=5, mean) | 44.64s | 36.80s | −18% |
| Incremental, touch `Translate.elm` (n=5) | 2.78s | **2.45s** | −12% |
| Incremental, touch a leaf module (n=5) | 0.26s | **0.23s** | −12% |
| Full build pinned to 4 cores, ≈CI (n=2) | 72–74s | **62–63s** | −15% |
| Peak RSS, full build (median) | 13.0 GB | **11.6 GB** | −11% |

Two honest caveats:

- 0.19.1 is very consistent (44.0–45.5s); **0.19.2 is bimodal** — 3 of 5 runs finished in ~35.2s at 11.6 GB peak RSS, the other 2 took ~39s at 13.0 GB. Time and peak memory correlate exactly, which matches what the release notes actually claim (*"20% lower copying in GC"*): the win is reduced allocation pressure, and it evaporates on runs where the heap grows anyway. The worst 0.19.2 run still beat the best 0.19.1 run.
- **The 4 GB swap workaround in `ci-scripts/install_client.sh` is still required.** Pinned to 4 cores (modelling CircleCI) peak RSS is ~10.4–11.3 GB for *both* compilers — the memory win did not reproduce at low core counts.

## ⚠️ This is a lockstep upgrade

The compiler requires `elm.json`'s `elm-version` to match its own version **exactly** — 0.19.1 refuses `"0.19.2"` *and* 0.19.2 refuses `"0.19.1"`, both with `ELM VERSION MISMATCH`. Every install site is therefore bumped in this PR.

**After merging:** reinstall Elm (`npm i -g elm@latest-0.19.2`), and DDEV users must `ddev restart` to rebuild the web image.

## Why `etaque/elm-form` → `Gizra/elm-form`

This is the non-obvious part. The chain:

1. Compiler 0.19.2 forces **elm-test 0.19.2-0** — earlier elm-test releases hardcode `'elm-version': '0.19.1'` into the project they generate (`Generate.js`), so they cannot drive a 0.19.2 compiler.
2. elm-test 0.19.2-0 **requires `elm-explorations/test` 2.x**.
3. **`etaque/elm-form@4.0.0` declares `elm-explorations/test` as a _runtime_ dependency**, pinned to `1.0.0 <= v < 2.0.0` (it ships the `Form.Test` helpers as public API). That makes `test` 2.x unsatisfiable — plain `elm make` fails with `INCOMPATIBLE DEPENDENCIES`.
4. 4.0.0 is the latest release, and [upstream has been archived since 2021](https://github.com/etaque/elm-form). It cannot be fixed there.

[`Gizra/elm-form@1.0.0`](https://package.elm-lang.org/packages/Gizra/elm-form/1.0.0/) ([repo](https://github.com/Gizra/elm-form)) is a fork of `etaque/elm-form@4.0.0` that moves the `Form.Test` helpers from `src/` into `tests/`, so `elm-explorations/test` becomes a **test-only** dependency and consumers pick their own version.

- The **six exposed modules are unchanged, byte for byte** (verified by `diff` against the registry's published 4.0.0).
- **Zero application code changes** — module names are identical, so the 22 `import Form.*` lines are untouched.
- BSD-3-Clause license and attribution retained; the fork's own 27 tests pass.

Considered and rejected: vendoring the source in-repo (1.4k LOC of third-party code to own); `scrive`/`kutyel` forks (their `Form.elm`, `Form/Init.elm`, `Form/Input.elm`, `Form/Validate.elm` **diverge** from upstream — behaviour changes); `enbala/elm-form` (byte-identical, but a 0-star repo untouched since 2022 — and since Elm refetches from GitHub on every CI run, two sibling forks have already 404'd this way).

## What changes in the generated JavaScript

I diffed the emitted `Main.js` from both compilers (same sources). Line count is identical (301,586). All differences fall into three buckets:

1. **String-literal escaping style** — 0.19.2 emits `\u000A` where 0.19.1 emitted `\n`, `\u0027` for `\'`, `\u0022` for `"`, `\u005C` for `\\`; and conversely `\r`/`\f` where 0.19.1 emitted `\u000D`/`\^L`. Same string values — semantically identical.
2. **Order of independent `var x = _v0.field;` record reads** is reversed. Pure property reads, no side effects — semantically identical.
3. **`Debug.todo` source regions are now 0-based** (see below).

Net effect on the shipped asset is nil: raw dev bundle +10,349 bytes (+0.09%, purely the longer `\uXXXX` escapes), but **after terser −8 bytes, and gzipped +21 bytes (+0.003%)**.

### 🐛 Upstream bug found: `Debug.todo` reports the wrong line

0.19.2 embeds **0-based** source regions where 0.19.1 embedded 1-based ones. Reproduced on a 17-line program depending only on `elm/core`:

```elm
boom : ()
boom =
    Debug.todo "boom"   -- line 17, column 5
```

| | emitted region | runtime crash message |
|---|---|---|
| 0.19.1 | `{line: 17, column: 5}` | ``TODO in module `Main` on line 17`` ✅ |
| 0.19.2 | `{line: 16, column: 4}` | ``TODO in module `Main` on line 16`` ❌ |

Relevance here: `client/src/elm/Utils/AllDict.elm` contains 7 `Debug.todo` calls (lines 182, 195, 448, 464, 482, 512, 659) for unreachable red-black-tree states. If one ever fires, the reported line will be off by one. **Diagnostic only — no behavioural change.** Worth reporting to `elm/compiler`.

### Side finding: this project cannot use `elm make --optimize`

Those same 7 `Debug.todo` calls make `--optimize` fail outright (`There are uses of the Debug module`). `gulpfile.js` accordingly runs `gulp-elm` with `{debug: false, warn: false}` and no `optimize` flag; minification is left entirely to terser. Removing those `Debug.todo` calls would unlock Elm's own optimizations (record-field shortening, constructor unboxing) — a worthwhile follow-up, out of scope here.

## Toolchain changes

- 0.19.2 **renamed its release assets** (`binary-for-linux-64-bit.gz` → `elm-0.19.2-linux-{x64,arm}.gz`), so the download URLs are rewritten, not merely version-bumped. A naive version bump 404s.
- 0.19.2 is the **first release with a native `linux-arm` (aarch64) binary**. The DDEV Dockerfile previously installed the x64 binary unconditionally despite branching on `uname -m` for arm64 elsewhere; it now selects the matching asset and smoke-tests it (`elm --version`) at build time.
- `client/package-lock.json` is intentionally untouched: it is gitignored, `skip-worktree`-flagged, and already stale (its `elm-review` entry predates `package.json`). CI runs `npm install`, which resolves `elm-test@0.19.2-0` from the new `^0.19.2-0` range — verified.

## Verification (all run locally against the 0.19.2 toolchain)

- ✅ `client`: `elm make src/elm/Main.elm` → **548 modules**
- ✅ `client`: `elm-test "src/elm/**/Test.elm"` → **2761 passed, 0 failed**
- ✅ `server/elm`: `elm make src/Main.elm` → **84 modules**
- ✅ `elm-review` → *"I found no errors!"* on both the client and server apps
- ✅ `elm-format --validate` → clean across all 572 tracked `.elm` sources
- ✅ `shellcheck` (dockerized `koalaman/shellcheck:v0.4.6`, CI's exclusions) → clean on all three changed `ci-scripts/`

> **Note:** committed with `[ci skip]` per the repo convention in `CLAUDE.md`. Because this PR changes the DDEV image and the CI scripts themselves, it's worth letting CI actually run before merge — the `e2e_playwright_*` and `test_simpletest_linux` jobs exercise the rebuilt image and `install_client.sh`, which I could not verify locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

