### PR TITLE
Sync: leftJoin file_managed in photo/signature sync plugins

### DIFF
--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/family-nutrition/HedleyRestfulFamilyNutritionPhoto.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/family-nutrition/HedleyRestfulFamilyNutritionPhoto.class.php
@@ -44,7 +44,7 @@ class HedleyRestfulFamilyNutritionPhoto extends HedleyRestfulFamilyNutritionActi
 
     // For the Photo, get to the `file`. We'll convert the `uri`
     // to `field_photo`.
-    $query->innerJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
+    $query->leftJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
     $query->addField('f', 'uri');
   }
 

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/group-session/HedleyRestfulPhotos.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/group-session/HedleyRestfulPhotos.class.php
@@ -37,7 +37,7 @@ class HedleyRestfulPhotos extends HedleyRestfulGroupActivityBase {
 
     // For the Photo, get to the `file`. We'll convert the `uri`
     // to `field_photo`.
-    $query->innerJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
+    $query->leftJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
     $query->addField('f', 'uri');
   }
 

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/nutrition/HedleyRestfulNutritionPhotos.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/nutrition/HedleyRestfulNutritionPhotos.class.php
@@ -44,7 +44,7 @@ class HedleyRestfulNutritionPhotos extends HedleyRestfulNutritionActivityBase {
 
     // For the Photo, get to the `file`. We'll convert the `uri`
     // to `field_photo`.
-    $query->innerJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
+    $query->leftJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
     $query->addField('f', 'uri');
   }
 

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/prenatal/HedleyRestfulPrenatalPhotos.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/prenatal/HedleyRestfulPrenatalPhotos.class.php
@@ -44,7 +44,7 @@ class HedleyRestfulPrenatalPhotos extends HedleyRestfulPrenatalActivityBase {
 
     // For the Photo, get to the `file`. We'll convert the `uri`
     // to `field_photo`.
-    $query->innerJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
+    $query->leftJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
     $query->addField('f', 'uri');
   }
 

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/well-child/HedleyRestfulWellChildPhoto.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/activity/well-child/HedleyRestfulWellChildPhoto.class.php
@@ -44,7 +44,7 @@ class HedleyRestfulWellChildPhoto extends HedleyRestfulWellChildActivityBase {
 
     // For the Photo, get to the `file`. We'll convert the `uri`
     // to `field_photo`.
-    $query->innerJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
+    $query->leftJoin('file_managed', 'f', 'f.fid = field_photo.field_photo_fid');
     $query->addField('f', 'uri');
   }
 

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/misc/HedleyRestfulStockUpdate.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/misc/HedleyRestfulStockUpdate.class.php
@@ -121,7 +121,7 @@ class HedleyRestfulStockUpdate extends HedleyRestfulSyncBase {
 
     // For the Signature, get to the `file`. We'll convert the `uri`
     // to `field_signature`.
-    $query->innerJoin('file_managed', 'f', 'f.fid = field_signature.field_signature_fid');
+    $query->leftJoin('file_managed', 'f', 'f.fid = field_signature.field_signature_fid');
     $query->addField('f', 'uri');
 
     return $query;


### PR DESCRIPTION
## Summary

Six RESTful sync plugins `innerJoin` `file_managed` on a photo/signature fid. If the fid is NULL or **dangling** (the `file_managed` row was deleted — admin deletion, managed-file cleanup, bad clone/migration), the inner join matches nothing and the measurement is **silently dropped from the shard sync feed**, while still counted in the revision count → phantom "remaining"; the newest-revision case stalls the shard.

The correct sibling `HedleyRestfulPeople:120` already uses `leftJoin` for exactly this reason.

## Change

`innerJoin → leftJoin` in all six (one word each):

- `HedleyRestfulPhotos`, `HedleyRestfulNutritionPhotos`, `HedleyRestfulPrenatalPhotos`, `HedleyRestfulWellChildPhoto`, `HedleyRestfulFamilyNutritionPhoto` (on `field_photo`)
- `HedleyRestfulStockUpdate` (on `field_signature`)

Safe with no other change:
- Post-processing already null-guards (`if (!empty($item->photo) && !empty($item->uri))`; StockUpdate null-checks too).
- Client `decodePhoto` = `field "photo" (decodeStringWithDefault "")`, photo dict `optional` → a null/absent photo decodes cleanly (no batch poison).

So a measurement whose file was deleted still syncs (empty/broken photo URL) instead of vanishing and stalling the shard.

## Reachability

Latent — the app always attaches a photo/signature, so it needs a dangling fid (file deletion/cleanup/migration) or a non-app writer. No known incident, but the failure mode (stuck shard feed) is disproportionate to the cause.

## Verification

- `php -l` + phpcs (Drupal + DrupalPractice): clean on all six files.
- SQL demo on real tables (rolled-back txn): a `nutrition_photo` node with a dangling fid is dropped by `innerJoin`, retained by `leftJoin`; a valid-fid node is returned by both.
- No new test: one-word change per file with a living reference (`HedleyRestfulPeople`), already-null-tolerant post-processing, and a null-tolerant client decoder.

Fixes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)