### PR TITLE
Authorization: enforce CHW village authorization on every page, not just PinCode

### DIFF
--- a/client/src/elm/App/View.elm
+++ b/client/src/elm/App/View.elm
@@ -4,7 +4,7 @@ import App.Model exposing (ConfiguredModel, Model, Msg(..), MsgLoggedIn(..), Sto
 import App.Utils exposing (getLoggedInData)
 import AssocList as Dict
 import Backend.NCDEncounter.Types exposing (NCDProgressReportInitiator(..))
-import Backend.Nurse.Utils exposing (isCommunityHealthWorker, isLabTechnician)
+import Backend.Nurse.Utils exposing (isCommunityHealthWorker, isLabTechnician, nurseAuthorizedForLocation)
 import Backend.Person.Model exposing (Initiator(..), ParticipantDirectoryOperation(..))
 import Browser
 import Config.Model
@@ -409,21 +409,25 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
     case getLoggedInData model of
         Just ( healthCenterId, loggedInModel ) ->
             let
-                selectedAuthorizedHealthCenter =
+                loggedInNurse =
                     Tuple.second loggedInModel.nurse
-                        |> .healthCenters
-                        |> EverySet.member healthCenterId
+
+                -- Authorize per village for a CHW, per health center otherwise -
+                -- the same gate the PinCode screen applies. Without this, a
+                -- synced nurse revision that drops the selected village leaves a
+                -- CHW silently working under a location they no longer belong to
+                -- (their parent health center still passes a health-center-only
+                -- check); now they fall through to the PinCode screen instead.
+                selectedAuthorizedLocation =
+                    nurseAuthorizedForLocation model.villageId (Just healthCenterId) loggedInNurse
             in
-            if selectedAuthorizedHealthCenter then
+            if selectedAuthorizedLocation then
                 let
                     currentDate =
                         fromLocalDateTime model.zone model.currentTime
 
                     ( isChw, isLabTech ) =
-                        Tuple.second loggedInModel.nurse
-                            |> (\nurse ->
-                                    ( isCommunityHealthWorker nurse, isLabTechnician nurse )
-                               )
+                        ( isCommunityHealthWorker loggedInNurse, isLabTechnician loggedInNurse )
                 in
                 case page of
                     MyAccountPage ->

--- a/client/src/elm/Backend/Nurse/Test.elm
+++ b/client/src/elm/Backend/Nurse/Test.elm
@@ -1,0 +1,78 @@
+module Backend.Nurse.Test exposing (all)
+
+import AssocList as Dict
+import Backend.Nurse.Model exposing (Nurse, Role(..))
+import Backend.Nurse.Utils exposing (nurseAuthorizedForLocation)
+import EverySet
+import Expect
+import Restful.Endpoint exposing (toEntityUuid)
+import Test exposing (Test, describe, test)
+
+
+{-| A minimal nurse carrying the given health-center and village assignments and
+roles; the resilience fields are irrelevant to authorization.
+-}
+nurseWith : List String -> List String -> List Role -> Nurse
+nurseWith healthCenterIds villageIds roles =
+    { name = "Test Nurse"
+    , healthCenters = EverySet.fromList (List.map toEntityUuid healthCenterIds)
+    , villages = EverySet.fromList (List.map toEntityUuid villageIds)
+    , roles = EverySet.fromList roles
+    , email = Nothing
+    , pinCode = "1234"
+    , resilienceProgramEnabled = False
+    , resilienceProgramStartDate = Nothing
+    , resilienceRole = Nothing
+    , resilienceBirthDate = Nothing
+    , resilienceGender = Nothing
+    , resilienceEducationLevel = Nothing
+    , resilienceUbudehe = Nothing
+    , resilienceMaritalStatus = Nothing
+    , resilienceNextReminder = Nothing
+    , resilienceMessages = Dict.empty
+    }
+
+
+nurseAuthorizedForLocationTest : Test
+nurseAuthorizedForLocationTest =
+    describe "nurseAuthorizedForLocation"
+        [ describe "CHW (authorized per village)"
+            [ test "authorized when the selected village is one of theirs" <|
+                \_ ->
+                    nurseAuthorizedForLocation (Just (toEntityUuid "v1")) (Just (toEntityUuid "hc1")) (nurseWith [ "hc1" ] [ "v1" ] [ RoleCHW ])
+                        |> Expect.equal True
+            , test "NOT authorized after reassignment to a village they no longer hold - even though their parent health center still matches" <|
+                -- The bug: App.View gated on health center only, so this returned
+                -- True and the CHW kept working under the revoked village.
+                \_ ->
+                    nurseAuthorizedForLocation (Just (toEntityUuid "v2")) (Just (toEntityUuid "hc1")) (nurseWith [ "hc1" ] [ "v1" ] [ RoleCHW ])
+                        |> Expect.equal False
+            , test "NOT authorized when no village is selected" <|
+                \_ ->
+                    nurseAuthorizedForLocation Nothing (Just (toEntityUuid "hc1")) (nurseWith [ "hc1" ] [ "v1" ] [ RoleCHW ])
+                        |> Expect.equal False
+            ]
+        , describe "non-CHW nurse (authorized per health center)"
+            [ test "authorized when the selected health center is one of theirs" <|
+                \_ ->
+                    nurseAuthorizedForLocation Nothing (Just (toEntityUuid "hc1")) (nurseWith [ "hc1" ] [] [ RoleNurse ])
+                        |> Expect.equal True
+            , test "NOT authorized when the selected health center is not theirs" <|
+                \_ ->
+                    nurseAuthorizedForLocation Nothing (Just (toEntityUuid "hc2")) (nurseWith [ "hc1" ] [] [ RoleNurse ])
+                        |> Expect.equal False
+            , test "NOT authorized when no health center is selected" <|
+                \_ ->
+                    nurseAuthorizedForLocation Nothing Nothing (nurseWith [ "hc1" ] [] [ RoleNurse ])
+                        |> Expect.equal False
+            , test "a nurse's village membership does not authorize a health-center selection" <|
+                \_ ->
+                    nurseAuthorizedForLocation (Just (toEntityUuid "v1")) (Just (toEntityUuid "hc2")) (nurseWith [ "hc1" ] [ "v1" ] [ RoleNurse ])
+                        |> Expect.equal False
+            ]
+        ]
+
+
+all : Test
+all =
+    describe "Backend.Nurse" [ nurseAuthorizedForLocationTest ]

--- a/client/src/elm/Backend/Nurse/Utils.elm
+++ b/client/src/elm/Backend/Nurse/Utils.elm
@@ -1,4 +1,4 @@
-module Backend.Nurse.Utils exposing (assignedToHealthCenter, assignedToVillage, isAuthorithedNurse, isCommunityHealthWorker, isLabTechnician, resilienceRoleFromString, resilienceRoleToString)
+module Backend.Nurse.Utils exposing (assignedToHealthCenter, assignedToVillage, isAuthorithedNurse, isCommunityHealthWorker, isLabTechnician, nurseAuthorizedForLocation, resilienceRoleFromString, resilienceRoleToString)
 
 import Backend.Clinic.Model exposing (Clinic)
 import Backend.Entities exposing (..)
@@ -43,13 +43,30 @@ isLabTechnician =
 
 isAuthorithedNurse : Clinic -> Nurse -> Bool
 isAuthorithedNurse clinic nurse =
+    nurseAuthorizedForLocation clinic.villageId (Just clinic.healthCenterId) nurse
+
+
+{-| Is the nurse authorized to work at the currently selected location?
+
+A CHW is authorized per village (their `field_health_centers` holds the parent
+health center, so a health-center check alone would wrongly pass); every other
+nurse is authorized per health center. This is the single authorization gate,
+shared by the PinCode screen and every in-app page (`App.View.viewUserPage`), so
+the two can't drift - a mid-session reassignment that drops the selected
+location now fails everywhere at once.
+
+-}
+nurseAuthorizedForLocation : Maybe VillageId -> Maybe HealthCenterId -> Nurse -> Bool
+nurseAuthorizedForLocation maybeVillageId maybeHealthCenterId nurse =
     if isCommunityHealthWorker nurse then
-        clinic.villageId
+        maybeVillageId
             |> Maybe.map (\id -> assignedToVillage id nurse)
             |> Maybe.withDefault False
 
     else
-        assignedToHealthCenter clinic.healthCenterId nurse
+        maybeHealthCenterId
+            |> Maybe.map (\id -> assignedToHealthCenter id nurse)
+            |> Maybe.withDefault False
 
 
 resilienceRoleFromString : String -> Maybe ResilienceRole

--- a/client/src/elm/Backend/Nurse/Utils.elm
+++ b/client/src/elm/Backend/Nurse/Utils.elm
@@ -1,4 +1,4 @@
-module Backend.Nurse.Utils exposing (assignedToHealthCenter, assignedToVillage, isAuthorithedNurse, isCommunityHealthWorker, isLabTechnician, nurseAuthorizedForLocation, resilienceRoleFromString, resilienceRoleToString)
+module Backend.Nurse.Utils exposing (assignedToHealthCenter, assignedToVillage, isAuthorizedNurse, isCommunityHealthWorker, isLabTechnician, nurseAuthorizedForLocation, resilienceRoleFromString, resilienceRoleToString)
 
 import Backend.Clinic.Model exposing (Clinic)
 import Backend.Entities exposing (..)
@@ -41,8 +41,8 @@ isLabTechnician =
     resolveMainRole >> (==) (Just RoleLabTech)
 
 
-isAuthorithedNurse : Clinic -> Nurse -> Bool
-isAuthorithedNurse clinic nurse =
+isAuthorizedNurse : Clinic -> Nurse -> Bool
+isAuthorizedNurse clinic nurse =
     nurseAuthorizedForLocation clinic.villageId (Just clinic.healthCenterId) nurse
 
 

--- a/client/src/elm/Pages/Clinics/View.elm
+++ b/client/src/elm/Pages/Clinics/View.elm
@@ -10,7 +10,7 @@ import Backend.Clinic.Model exposing (Clinic, allClinicTypes)
 import Backend.Entities exposing (..)
 import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..))
 import Backend.Nurse.Model exposing (Nurse)
-import Backend.Nurse.Utils exposing (isAuthorithedNurse)
+import Backend.Nurse.Utils exposing (isAuthorizedNurse)
 import Gizra.NominalDate exposing (NominalDate)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -154,7 +154,7 @@ viewClinicButton : NominalDate -> Nurse -> ModelIndexedDb -> ( ClinicId, Clinic 
 viewClinicButton currentDate nurse db ( clinicId, clinic ) =
     let
         attributes =
-            if isAuthorithedNurse clinic nurse then
+            if isAuthorizedNurse clinic nurse then
                 let
                     sessions =
                         Dict.get clinicId db.sessionsByClinic

--- a/client/src/elm/Pages/PinCode/View.elm
+++ b/client/src/elm/Pages/PinCode/View.elm
@@ -4,7 +4,7 @@ import AssocList as Dict
 import Backend.Entities exposing (..)
 import Backend.Model exposing (ModelIndexedDb)
 import Backend.Nurse.Model exposing (Nurse)
-import Backend.Nurse.Utils exposing (assignedToHealthCenter, assignedToVillage, isCommunityHealthWorker, isLabTechnician)
+import Backend.Nurse.Utils exposing (assignedToHealthCenter, assignedToVillage, isCommunityHealthWorker, isLabTechnician, nurseAuthorizedForLocation)
 import Backend.Person.Model exposing (Initiator(..))
 import Backend.Person.Utils exposing (getHealthCenterName)
 import Backend.Utils exposing (stockManagementHCEnabled, stockManagementVillageEnabled)
@@ -49,15 +49,7 @@ view language zone currentTime features activePage nurseData ( healthCenterId, v
                             isCommunityHealthWorker nurse
 
                         selectedAuthorizedLocation =
-                            if isChw then
-                                villageId
-                                    |> Maybe.map (\id -> EverySet.member id nurse.villages)
-                                    |> Maybe.withDefault False
-
-                            else
-                                healthCenterId
-                                    |> Maybe.map (\id -> EverySet.member id nurse.healthCenters)
-                                    |> Maybe.withDefault False
+                            nurseAuthorizedForLocation villageId healthCenterId nurse
                     in
                     ( viewLoggedInHeader language isChw selectedAuthorizedLocation
                     , viewLoggedInContent language

--- a/client/src/elm/Pages/Session/View.elm
+++ b/client/src/elm/Pages/Session/View.elm
@@ -5,7 +5,7 @@ import AssocList as Dict
 import Backend.Entities exposing (..)
 import Backend.Model exposing (ModelIndexedDb)
 import Backend.Nurse.Model exposing (Nurse)
-import Backend.Nurse.Utils exposing (isAuthorithedNurse)
+import Backend.Nurse.Utils exposing (isAuthorizedNurse)
 import Backend.Session.Model exposing (EditableSession, Session)
 import Backend.Session.Utils exposing (isClosed)
 import EverySet exposing (EverySet)
@@ -102,7 +102,7 @@ viewFoundSession language currentDate zscores site features isChw nurse ( sessio
             authorized =
                 RemoteData.toMaybe db.clinics
                     |> Maybe.andThen (Dict.get session.clinicId)
-                    |> Maybe.map (\clinic -> isAuthorithedNurse clinic nurse)
+                    |> Maybe.map (\clinic -> isAuthorizedNurse clinic nurse)
                     |> Maybe.withDefault False
         in
         if authorized then


### PR DESCRIPTION
Fixes #1919

## Mechanism

Every in-app page passes through one authorization gate in `App/View.elm` (`viewUserPage`), which checks **health center only**:

```elm
selectedAuthorizedHealthCenter =
    Tuple.second loggedInModel.nurse |> .healthCenters |> EverySet.member healthCenterId
in
if selectedAuthorizedHealthCenter then …render… else …fall through to PinCode…
```

A CHW nurse carries the **parent health center** in `field_health_centers`, so for a CHW this check passes regardless of which village they're in.

The PinCode page is the only place that checks village — `Pages/PinCode/View.elm`:

```elm
selectedAuthorizedLocation =
    if isChw then
        villageId |> Maybe.map (\id -> EverySet.member id nurse.villages) |> …
    else
        healthCenterId |> Maybe.map (\id -> EverySet.member id nurse.healthCenters) |> …
```

Nurse revisions sync down mid-session (`UpdateNurseData`, `App/Update.elm`) and replace `loggedIn.nurse`, but `model.villageId` is never re-validated. So once a CHW's village V1 is removed from `field_villages` (a reassignment), the fresh nurse arrives, the health-center check still passes, and the stale `model.villageId` flows straight into the pages that key off it — `CreatePersonPage`, `EducationSession`, the village dashboard — so the CHW keeps registering patients and viewing data under the **old** village until they happen to land on the PinCode screen, where the check would finally fail.

A non-CHW nurse has no gap: if their health center is pulled, the existing check fails and bounces them to PinCode. This is purely the missing CHW-village parallel.

The intent is not ambiguous — the PinCode page **already** treats village as an authorizing boundary (it blocks a CHW whose selected village isn't in `nurse.villages`). The bug is that this authorization is enforced in exactly one place instead of everywhere.

## Impact — MED

A reassigned CHW silently continues working in a village they're no longer assigned to. The records are valid but filed under the wrong village context, with no indication anything is off. The window is "between the reassignment syncing down and the CHW next visiting the PinCode page," which mid-shift can be long.

## Fix

The root cause is duplication: the role-aware authorization check lived inline in the PinCode view (and, keyed on a `Clinic`, in `Backend.Nurse.Utils.isAuthorithedNurse`) but App/View reimplemented a weaker, health-center-only version. So:

- Extract one shared predicate `nurseAuthorizedForLocation : Maybe VillageId -> Maybe HealthCenterId -> Nurse -> Bool` into `Backend/Nurse/Utils.elm` (CHW → village, otherwise → health center).
- Route **all three** sites through it: `App.View.viewUserPage` (the fix), `Pages.PinCode.View` (dedup, behaviour-preserving), and `isAuthorithedNurse` (dedup, behaviour-preserving). Now the gates can't drift — a reassignment that drops the selected location fails everywhere at once.

I checked whether the stale `model.villageId` needs clearing on the reassignment: it does not. When the location is unauthorized the PinCode page renders a fresh village selector (`selectVillageOptions`) regardless of the stored value, so no extra `SetVillage Nothing` is needed.

## Expected visible change

A CHW whose village assignment was revoked mid-session is redirected to the PinCode screen (village now reads unauthorized) instead of continuing under the old village — matching what already happens to a non-CHW whose health center is revoked. No migration; nothing changes for correctly-assigned users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

