### PR TITLE
Family Nutrition: fetch cared-for (MyCaregiven) children for its encounters

### DIFF
--- a/client/src/elm/Backend/FamilyNutritionEncounter/Fetch.elm
+++ b/client/src/elm/Backend/FamilyNutritionEncounter/Fetch.elm
@@ -5,7 +5,7 @@ import Backend.Entities exposing (..)
 import Backend.FamilyEncounterParticipant.Model exposing (FamilyEncounterType(..))
 import Backend.FamilyNutritionEncounter.Utils exposing (getFamilyNutritionEncountersForParticipant)
 import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..))
-import Backend.Relationship.Model exposing (MyRelatedBy(..))
+import Backend.Relationship.Utils exposing (isChildRelation)
 import Backend.Utils exposing (resolveFamilyParticipantForPerson)
 import EverySet
 import Maybe.Extra
@@ -20,7 +20,7 @@ fetch id db =
                 |> Maybe.andThen RemoteData.toMaybe
                 |> Maybe.map
                     (Dict.values
-                        >> List.filter (.relatedBy >> (==) MyChild)
+                        >> List.filter (.relatedBy >> isChildRelation)
                         >> EverySet.fromList
                         >> EverySet.toList
                         >> List.map (.relatedTo >> FetchPerson)

--- a/client/src/elm/Backend/Relationship/Test.elm
+++ b/client/src/elm/Backend/Relationship/Test.elm
@@ -1,0 +1,28 @@
+module Backend.Relationship.Test exposing (all)
+
+import Backend.Relationship.Model exposing (MyRelatedBy(..))
+import Backend.Relationship.Utils exposing (isChildRelation)
+import Expect
+import Test exposing (Test, describe, test)
+
+
+isChildRelationTest : Test
+isChildRelationTest =
+    -- Both a person's own child and a child they are a caregiver for count as
+    -- children of the family: the Family Nutrition fetch and its assembler both
+    -- rely on this, so a MyCaregiven child is fetched and shown, not dropped.
+    describe "isChildRelation"
+        [ test "MyChild is a child relation" <|
+            \_ -> isChildRelation MyChild |> Expect.equal True
+        , test "MyCaregiven (cared-for child) is a child relation" <|
+            \_ -> isChildRelation MyCaregiven |> Expect.equal True
+        , test "MyParent is not a child relation" <|
+            \_ -> isChildRelation MyParent |> Expect.equal False
+        , test "MyCaregiver is not a child relation" <|
+            \_ -> isChildRelation MyCaregiver |> Expect.equal False
+        ]
+
+
+all : Test
+all =
+    describe "Backend.Relationship" [ isChildRelationTest ]

--- a/client/src/elm/Backend/Relationship/Utils.elm
+++ b/client/src/elm/Backend/Relationship/Utils.elm
@@ -1,7 +1,31 @@
-module Backend.Relationship.Utils exposing (toMyRelationship, toRelationship)
+module Backend.Relationship.Utils exposing (isChildRelation, toMyRelationship, toRelationship)
 
 import Backend.Entities exposing (..)
 import Backend.Relationship.Model exposing (MyRelatedBy(..), MyRelationship, RelatedBy(..), Relationship)
+
+
+{-| From the reference person's point of view, is the related person a child
+they are responsible for - either their own child (`MyChild`) or one they are a
+caregiver for (`MyCaregiven`)?
+
+Used both to decide which related persons to fetch and which to assemble as
+family members for a Family Nutrition encounter, so the two stay in step.
+
+-}
+isChildRelation : MyRelatedBy -> Bool
+isChildRelation relatedBy =
+    case relatedBy of
+        MyChild ->
+            True
+
+        MyCaregiven ->
+            True
+
+        MyParent ->
+            False
+
+        MyCaregiver ->
+            False
 
 
 {-| Consider a `Relationship` from the point of view of the specified person.

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Utils.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Utils.elm
@@ -9,7 +9,7 @@ import Backend.Measurement.Model exposing (..)
 import Backend.Model exposing (ModelIndexedDb)
 import Backend.Person.Model exposing (Person)
 import Backend.Person.Utils exposing (ageInMonths, isPersonAnAdult)
-import Backend.Relationship.Model exposing (MyRelatedBy(..))
+import Backend.Relationship.Utils exposing (isChildRelation)
 import Gizra.NominalDate exposing (NominalDate)
 import Pages.FamilyNutrition.Encounter.Model exposing (AssembledData, FamilyMember(..))
 import RemoteData exposing (RemoteData(..), WebData)
@@ -61,12 +61,7 @@ generateAssembledData id db =
                                     |> Maybe.andThen RemoteData.toMaybe
                                     |> Maybe.map
                                         (Dict.values
-                                            >> List.filter
-                                                (.relatedBy
-                                                    >> (\relatedBy ->
-                                                            List.member relatedBy [ MyChild, MyCaregiven ]
-                                                       )
-                                                )
+                                            >> List.filter (.relatedBy >> isChildRelation)
                                             >> List.filterMap
                                                 (\rel ->
                                                     Dict.get rel.relatedTo db.people


### PR DESCRIPTION
Fixes #1921

## Mechanism

A Family Nutrition encounter is built for a family head, and its family members are the head's dependent children. There's a filter mismatch between what the fetch loads and what the assembler consumes:

- **Fetch** — `Backend/FamilyNutritionEncounter/Fetch.elm`, `fetchChildrenMsgs`:
  ```elm
  >> List.filter (.relatedBy >> (==) MyChild)   -- only MyChild → FetchPerson
  ```
- **Consumer** — `Pages/FamilyNutrition/Encounter/Utils.elm`, `generateAssembledData`:
  ```elm
  >> List.filter (.relatedBy >> \r -> List.member r [ MyChild, MyCaregiven ])
  ```

`FetchRelationshipsForPerson` loads only the relationship rows, not the related persons — each related person needs an explicit `FetchPerson`. Because the fetch issues `FetchPerson` only for `MyChild` relations, a **`MyCaregiven`** child (a cared-for child in a caregiver-headed family, not the head's biological child) never enters `db.people`. The consumer then does `List.filterMap (Dict.get relatedTo db.people)`, which silently drops that child.

The two sides key off the same person: the page fetch (`Pages/FamilyNutrition/Encounter/Fetch.elm`) resolves `participant.person` from the encounter and passes it into the backend fetch, and the consumer resolves `participant.person` from the same encounter. Same key, divergent filter.

## Impact

In a caregiver-headed family, the cared-for child never appears as a selectable family member. Its Aheza / MUAC / Photo can't be recorded, and the "next member with pending activities" auto-advance skips over it — silently, no error. (Masked when the child is already in `db.people` from prior navigation, or when Family Nutrition participants are always biological parents so `MyCaregiven` never occurs.)

## Fix

The root cause is a duplicated predicate that drifted. Extract one shared predicate into `Backend/Relationship/Utils.elm`:

```elm
isChildRelation : MyRelatedBy -> Bool   -- MyChild | MyCaregiven → True; MyParent | MyCaregiver → False
```

and route **both** the fetch (the fix) and the consumer (dedup, behaviour-preserving) through it, so they can't diverge again. Written as an exhaustive `case` rather than `List.member`, so adding a future `MyRelatedBy` constructor forces a decision at compile time.

## Expected visible change

In a caregiver-headed family, the cared-for child shows up as a selectable member with its own MUAC / Aheza / Photo activities, and auto-advance stops on it — matching how biological children already behave. No migration; nothing changes for families whose members are all biological children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

