### PR TITLE
Group education: apply education session update to cache without waiting for its revision

### DIFF
--- a/client/src/elm/Backend/EducationSession/Test.elm
+++ b/client/src/elm/Backend/EducationSession/Test.elm
@@ -1,28 +1,23 @@
 module Backend.EducationSession.Test exposing (all)
 
-import AssocList as Dict
-import Backend.EducationSession.Model exposing (EducationSession, EducationTopic(..))
+import AssocList as Dict exposing (Dict)
+import Backend.EducationSession.Model exposing (EducationSession, EducationTopic(..), Msg(..))
+import Backend.EducationSession.Utils exposing (applyUpdateToSessions)
 import Backend.Entities exposing (EducationSessionId, PersonId)
-import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..), emptyModelIndexedDb)
-import Backend.Update exposing (updateIndexedDb)
 import Date
 import EverySet
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
-import Pages.Page exposing (Page(..))
-import RemoteData exposing (RemoteData(..))
+import RemoteData exposing (RemoteData(..), WebData)
 import Restful.Endpoint exposing (toEntityUuid)
-import SyncManager.Model exposing (Flags, Site(..))
 import Test exposing (Test, describe, test)
 import Time
-import Translate.Model exposing (Language(..))
-import ZScore.Model
 
 
 all : Test
 all =
     describe "Backend.EducationSession"
-        [ optimisticSessionCacheTests ]
+        [ applyUpdateToSessionsTests ]
 
 
 
@@ -65,68 +60,14 @@ session =
     }
 
 
-modelWithSession : ModelIndexedDb
-modelWithSession =
-    { emptyModelIndexedDb
-        | educationSessions = Dict.singleton sessionId (Success session)
-    }
+sessions : Dict EducationSessionId (WebData EducationSession)
+sessions =
+    Dict.singleton sessionId (Success session)
 
 
-syncManagerFlags : Flags
-syncManagerFlags =
-    { syncInfoGeneral =
-        { lastFetchedRevisionId = 0
-        , lastSuccesfulContact = 0
-        , remainingToUpload = 0
-        , remainingToDownload = 0
-        , deviceName = ""
-        , status = SyncManager.Model.NotAvailable
-        , rollbarToken = ""
-        , site = SiteUnknown
-        , features = EverySet.empty
-        }
-    , syncInfoAuthorities = Nothing
-    , batchSize = 100
-    , syncSpeed =
-        { idle = 3000
-        , cycle = 50
-        , offline = 10000
-        }
-    }
-
-
-{-| Runs an education session message through the real `updateIndexedDb`, and
-hands back the resulting `ModelIndexedDb`. The only inputs that matter here are
-the message and the model - the rest are inert defaults.
--}
-applyMsg : Backend.EducationSession.Model.Msg -> ModelIndexedDb -> ModelIndexedDb
-applyMsg subMsg model =
-    let
-        ( updated, _, _ ) =
-            updateIndexedDb English
-                currentDate
-                (Time.millisToPosix 0)
-                Nothing
-                ZScore.Model.emptyModel
-                SiteRwanda
-                EverySet.empty
-                Nothing
-                Nothing
-                Nothing
-                False
-                False
-                PinCodePage
-                (SyncManager.Model.emptyModel syncManagerFlags)
-                (MsgEducationSession sessionId subMsg)
-                model
-    in
-    updated
-
-
-cachedSession : ModelIndexedDb -> Maybe EducationSession
-cachedSession model =
-    Dict.get sessionId model.educationSessions
-        |> Maybe.andThen RemoteData.toMaybe
+cachedSession : Dict EducationSessionId (WebData EducationSession) -> Maybe EducationSession
+cachedSession =
+    Dict.get sessionId >> Maybe.andThen RemoteData.toMaybe
 
 
 
@@ -134,32 +75,36 @@ cachedSession model =
 
 
 {-| The scenarios mirror issue #1927. Every education session write is a full
-entity PATCH, rebuilt from the session held at `educationSessions`. That dict
-used to be refreshed only once the revision for the PATCH echoed back from the
+entity PATCH, rebuilt from the session held at the sessions dict. That dict used
+to be refreshed only once the revision for the PATCH echoed back from the
 service worker, asynchronously - so a write that fired before the echo of its
 predecessor landed rebuilt the entity from the pre-update session, and reverted
 the field that predecessor had set.
 
-The cached session is exactly what the next PATCH is built from, which is why
-asserting on it is asserting on the payload that gets written.
+The session held at the dict is exactly what the next PATCH is built from, which
+is why asserting on it is asserting on the payload that gets written. Every test
+here applies its updates back to back, with no revision echoing in between.
 
 -}
-optimisticSessionCacheTests : Test
-optimisticSessionCacheTests =
+applyUpdateToSessionsTests : Test
+applyUpdateToSessionsTests =
     let
         checkInParticipants participants =
-            applyMsg <| Backend.EducationSession.Model.Update (\value -> { value | participants = participants })
+            applyUpdateToSessions sessionId <|
+                Update (\value -> { value | participants = participants })
 
         selectTopics topics =
-            applyMsg <| Backend.EducationSession.Model.Update (\value -> { value | topics = topics })
+            applyUpdateToSessions sessionId <|
+                Update (\value -> { value | topics = topics })
 
         endSession =
-            applyMsg <| Backend.EducationSession.Model.Update (\value -> { value | endDate = Just currentDate })
+            applyUpdateToSessions sessionId <|
+                Update (\value -> { value | endDate = Just currentDate })
     in
-    describe "education session cache"
-        [ test "an update is applied to the cached session right away, without waiting for its revision to echo back" <|
+    describe "applyUpdateToSessions"
+        [ test "an update is applied to the session right away, without waiting for its revision to echo back" <|
             \_ ->
-                modelWithSession
+                sessions
                     |> checkInParticipants (EverySet.singleton firstParticipant)
                     |> cachedSession
                     |> Maybe.map .participants
@@ -170,7 +115,7 @@ optimisticSessionCacheTests =
                     participants =
                         EverySet.fromList [ firstParticipant, secondParticipant ]
                 in
-                modelWithSession
+                sessions
                     |> checkInParticipants participants
                     |> endSession
                     |> cachedSession
@@ -187,7 +132,7 @@ optimisticSessionCacheTests =
                     topics =
                         EverySet.fromList [ TopicMalaria, TopicNCD ]
                 in
-                modelWithSession
+                sessions
                     |> selectTopics topics
                     |> checkInParticipants (EverySet.singleton firstParticipant)
                     |> cachedSession
@@ -198,10 +143,15 @@ optimisticSessionCacheTests =
                                 , participants = EverySet.singleton firstParticipant
                             }
                         )
-        , test "a message that is not an update leaves the cached session as is" <|
+        , test "a message that is not an update leaves the session as is" <|
             \_ ->
-                modelWithSession
-                    |> applyMsg (Backend.EducationSession.Model.HandleUpdated (Success ()))
+                sessions
+                    |> applyUpdateToSessions sessionId (HandleUpdated (Success ()))
                     |> cachedSession
                     |> Expect.equal (Just session)
+        , test "an update for a session we do not hold is a no-op" <|
+            \_ ->
+                Dict.empty
+                    |> endSession
+                    |> Expect.equal Dict.empty
         ]

--- a/client/src/elm/Backend/EducationSession/Test.elm
+++ b/client/src/elm/Backend/EducationSession/Test.elm
@@ -1,0 +1,207 @@
+module Backend.EducationSession.Test exposing (all)
+
+import AssocList as Dict
+import Backend.EducationSession.Model exposing (EducationSession, EducationTopic(..))
+import Backend.Entities exposing (EducationSessionId, PersonId)
+import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..), emptyModelIndexedDb)
+import Backend.Update exposing (updateIndexedDb)
+import Date
+import EverySet
+import Expect
+import Gizra.NominalDate exposing (NominalDate)
+import Pages.Page exposing (Page(..))
+import RemoteData exposing (RemoteData(..))
+import Restful.Endpoint exposing (toEntityUuid)
+import SyncManager.Model exposing (Flags, Site(..))
+import Test exposing (Test, describe, test)
+import Time
+import Translate.Model exposing (Language(..))
+import ZScore.Model
+
+
+all : Test
+all =
+    describe "Backend.EducationSession"
+        [ optimisticSessionCacheTests ]
+
+
+
+-- FIXTURES
+
+
+currentDate : NominalDate
+currentDate =
+    Date.fromCalendarDate 2020 Time.Jun 1
+
+
+sessionId : EducationSessionId
+sessionId =
+    toEntityUuid "education-session"
+
+
+firstParticipant : PersonId
+firstParticipant =
+    toEntityUuid "person-1"
+
+
+secondParticipant : PersonId
+secondParticipant =
+    toEntityUuid "person-2"
+
+
+{-| A session as it stands right after being created - no topics were selected,
+and no participants were checked in yet.
+-}
+session : EducationSession
+session =
+    { startDate = currentDate
+    , nurse = toEntityUuid "nurse"
+    , village = toEntityUuid "village"
+    , topics = EverySet.empty
+    , participants = EverySet.empty
+    , endDate = Nothing
+    , deleted = False
+    , shard = Nothing
+    }
+
+
+modelWithSession : ModelIndexedDb
+modelWithSession =
+    { emptyModelIndexedDb
+        | educationSessions = Dict.singleton sessionId (Success session)
+    }
+
+
+syncManagerFlags : Flags
+syncManagerFlags =
+    { syncInfoGeneral =
+        { lastFetchedRevisionId = 0
+        , lastSuccesfulContact = 0
+        , remainingToUpload = 0
+        , remainingToDownload = 0
+        , deviceName = ""
+        , status = SyncManager.Model.NotAvailable
+        , rollbarToken = ""
+        , site = SiteUnknown
+        , features = EverySet.empty
+        }
+    , syncInfoAuthorities = Nothing
+    , batchSize = 100
+    , syncSpeed =
+        { idle = 3000
+        , cycle = 50
+        , offline = 10000
+        }
+    }
+
+
+{-| Runs an education session message through the real `updateIndexedDb`, and
+hands back the resulting `ModelIndexedDb`. The only inputs that matter here are
+the message and the model - the rest are inert defaults.
+-}
+applyMsg : Backend.EducationSession.Model.Msg -> ModelIndexedDb -> ModelIndexedDb
+applyMsg subMsg model =
+    let
+        ( updated, _, _ ) =
+            updateIndexedDb English
+                currentDate
+                (Time.millisToPosix 0)
+                Nothing
+                ZScore.Model.emptyModel
+                SiteRwanda
+                EverySet.empty
+                Nothing
+                Nothing
+                Nothing
+                False
+                False
+                PinCodePage
+                (SyncManager.Model.emptyModel syncManagerFlags)
+                (MsgEducationSession sessionId subMsg)
+                model
+    in
+    updated
+
+
+cachedSession : ModelIndexedDb -> Maybe EducationSession
+cachedSession model =
+    Dict.get sessionId model.educationSessions
+        |> Maybe.andThen RemoteData.toMaybe
+
+
+
+-- TESTS
+
+
+{-| The scenarios mirror issue #1927. Every education session write is a full
+entity PATCH, rebuilt from the session held at `educationSessions`. That dict
+used to be refreshed only once the revision for the PATCH echoed back from the
+service worker, asynchronously - so a write that fired before the echo of its
+predecessor landed rebuilt the entity from the pre-update session, and reverted
+the field that predecessor had set.
+
+The cached session is exactly what the next PATCH is built from, which is why
+asserting on it is asserting on the payload that gets written.
+
+-}
+optimisticSessionCacheTests : Test
+optimisticSessionCacheTests =
+    let
+        checkInParticipants participants =
+            applyMsg <| Backend.EducationSession.Model.Update (\value -> { value | participants = participants })
+
+        selectTopics topics =
+            applyMsg <| Backend.EducationSession.Model.Update (\value -> { value | topics = topics })
+
+        endSession =
+            applyMsg <| Backend.EducationSession.Model.Update (\value -> { value | endDate = Just currentDate })
+    in
+    describe "education session cache"
+        [ test "an update is applied to the cached session right away, without waiting for its revision to echo back" <|
+            \_ ->
+                modelWithSession
+                    |> checkInParticipants (EverySet.singleton firstParticipant)
+                    |> cachedSession
+                    |> Maybe.map .participants
+                    |> Expect.equal (Just <| EverySet.singleton firstParticipant)
+        , test "ending a session right after a participant was checked in does not drop that participant" <|
+            \_ ->
+                let
+                    participants =
+                        EverySet.fromList [ firstParticipant, secondParticipant ]
+                in
+                modelWithSession
+                    |> checkInParticipants participants
+                    |> endSession
+                    |> cachedSession
+                    |> Expect.equal
+                        (Just
+                            { session
+                                | participants = participants
+                                , endDate = Just currentDate
+                            }
+                        )
+        , test "checking in a participant right after topics were selected does not drop the topics" <|
+            \_ ->
+                let
+                    topics =
+                        EverySet.fromList [ TopicMalaria, TopicNCD ]
+                in
+                modelWithSession
+                    |> selectTopics topics
+                    |> checkInParticipants (EverySet.singleton firstParticipant)
+                    |> cachedSession
+                    |> Expect.equal
+                        (Just
+                            { session
+                                | topics = topics
+                                , participants = EverySet.singleton firstParticipant
+                            }
+                        )
+        , test "a message that is not an update leaves the cached session as is" <|
+            \_ ->
+                modelWithSession
+                    |> applyMsg (Backend.EducationSession.Model.HandleUpdated (Success ()))
+                    |> cachedSession
+                    |> Expect.equal (Just session)
+        ]

--- a/client/src/elm/Backend/EducationSession/Utils.elm
+++ b/client/src/elm/Backend/EducationSession/Utils.elm
@@ -1,6 +1,42 @@
-module Backend.EducationSession.Utils exposing (educationTopicFromString, educationTopicToString)
+module Backend.EducationSession.Utils exposing (applyUpdateToSessions, educationTopicFromString, educationTopicToString)
 
-import Backend.EducationSession.Model exposing (EducationTopic(..))
+import AssocList as Dict exposing (Dict)
+import Backend.EducationSession.Model exposing (EducationSession, EducationTopic(..), Msg(..))
+import Backend.Entities exposing (..)
+import RemoteData exposing (RemoteData(..), WebData)
+
+
+{-| Applies an education session update to the sessions dict we hold at
+ModelIndexedDb, right when the update is dispatched.
+
+Session update is performed by a full entity PATCH, which is rebuilt from the
+session we hold at that dict. The dict is refreshed when the revision for the
+PATCH echoes back from the service worker, which happens asynchronously.
+Therefore, we apply the update to the dict right away. Otherwise, an update
+that is triggered before the echo of its predecessor lands would rebuild the
+entity from the pre-update session, and revert the field that predecessor had
+set. For example, ending the session right after the last participant was
+checked in would drop that participant.
+
+-}
+applyUpdateToSessions :
+    EducationSessionId
+    -> Msg
+    -> Dict EducationSessionId (WebData EducationSession)
+    -> Dict EducationSessionId (WebData EducationSession)
+applyUpdateToSessions sessionId msg sessions =
+    case msg of
+        HandleUpdated _ ->
+            sessions
+
+        Update updateFunc ->
+            Dict.get sessionId sessions
+                |> Maybe.andThen RemoteData.toMaybe
+                |> Maybe.map
+                    (\session ->
+                        Dict.insert sessionId (Success <| updateFunc session) sessions
+                    )
+                |> Maybe.withDefault sessions
 
 
 educationTopicToString : EducationTopic -> String

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -17,6 +17,7 @@ import Backend.Counseling.Decoder exposing (combineCounselingSchedules)
 import Backend.Dashboard.Model exposing (DashboardStatsRaw)
 import Backend.EducationSession.Model
 import Backend.EducationSession.Update
+import Backend.EducationSession.Utils
 import Backend.Endpoints exposing (ComputedDashboardParams, PersonParams(..), PmtctParticipantParams(..), SessionParams(..), acuteIllnessEncounterEndpoint, acuteIllnessMeasurementsEndpoint, acuteIllnessTraceContactEndpoint, childMeasurementListEndpoint, childScoreboardEncounterEndpoint, childScoreboardMeasurementsEndpoint, clinicEndpoint, computedDashboardEndpoint, counselingScheduleEndpoint, counselingTopicEndpoint, educationSessionEndpoint, familyEncounterParticipantEndpoint, familyNutritionEncounterEndpoint, familyNutritionMeasurementsEndpoint, followUpMeasurementsEndpoint, healthCenterEndpoint, hivEncounterEndpoint, hivMeasurementsEndpoint, homeVisitEncounterEndpoint, homeVisitMeasurementsEndpoint, individualEncounterParticipantEndpoint, motherMeasurementListEndpoint, ncdEncounterEndpoint, ncdMeasurementsEndpoint, nutritionEncounterEndpoint, nutritionMeasurementsEndpoint, participantFormEndpoint, personEndpoint, pmtctParticipantEndpoint, pregnancyByNewbornEndpoint, prenatalEncounterEndpoint, prenatalMeasurementsEndpoint, relationshipEndpoint, resilienceSurveyEndpoint, sessionEndpoint, stockManagementMeasurementsEndpoint, tuberculosisEncounterEndpoint, tuberculosisMeasurementsEndpoint, villageEndpoint, villageStockManagementMeasurementsEndpoint, wellChildEncounterEndpoint, wellChildMeasurementsEndpoint)
 import Backend.Entities exposing (..)
 import Backend.FamilyEncounterParticipant.Model
@@ -4061,26 +4062,13 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
 
                 ( subModel, subCmd, appMsgs ) =
                     Backend.EducationSession.Update.update sessionId encounter subMsg requests
-
-                -- Session update is performed by a full entity PATCH, which is rebuilt
-                -- from the session we hold here, at educationSessions dict. That dict is
-                -- refreshed when the revision for the PATCH echoes back from service
-                -- worker, which happens asynchronously.
-                -- Therefore, we apply the update to the dict right away. Otherwise, an
-                -- update that is triggered before the echo of its predecessor lands would
-                -- rebuild the entity from pre-update session, reverting the field that
-                -- predecessor has set. For example, ending the session right after last
-                -- participant was checked in would drop that participant.
-                educationSessions =
-                    case ( subMsg, encounter ) of
-                        ( Backend.EducationSession.Model.Update updateFunc, Just session ) ->
-                            Dict.insert sessionId (Success <| updateFunc session) model.educationSessions
-
-                        _ ->
-                            model.educationSessions
             in
             ( { model
-                | educationSessions = educationSessions
+                | educationSessions =
+                    -- The update is applied to the sessions dict right away, since that
+                    -- dict is what the next PATCH is rebuilt from. See the docs at
+                    -- applyUpdateToSessions.
+                    Backend.EducationSession.Utils.applyUpdateToSessions sessionId subMsg model.educationSessions
                 , educationSessionRequests = Dict.insert sessionId subModel model.educationSessionRequests
               }
             , Cmd.map (MsgEducationSession sessionId) subCmd

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4061,8 +4061,28 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
 
                 ( subModel, subCmd, appMsgs ) =
                     Backend.EducationSession.Update.update sessionId encounter subMsg requests
+
+                -- Session update is performed by a full entity PATCH, which is rebuilt
+                -- from the session we hold here, at educationSessions dict. That dict is
+                -- refreshed when the revision for the PATCH echoes back from service
+                -- worker, which happens asynchronously.
+                -- Therefore, we apply the update to the dict right away. Otherwise, an
+                -- update that is triggered before the echo of its predecessor lands would
+                -- rebuild the entity from pre-update session, reverting the field that
+                -- predecessor has set. For example, ending the session right after last
+                -- participant was checked in would drop that participant.
+                educationSessions =
+                    case ( subMsg, encounter ) of
+                        ( Backend.EducationSession.Model.Update updateFunc, Just session ) ->
+                            Dict.insert sessionId (Success <| updateFunc session) model.educationSessions
+
+                        _ ->
+                            model.educationSessions
             in
-            ( { model | educationSessionRequests = Dict.insert sessionId subModel model.educationSessionRequests }
+            ( { model
+                | educationSessions = educationSessions
+                , educationSessionRequests = Dict.insert sessionId subModel model.educationSessionRequests
+              }
             , Cmd.map (MsgEducationSession sessionId) subCmd
             , appMsgs
             )


### PR DESCRIPTION
Fixes #1927

## Problem

A nurse checks in the last participant of an education session and immediately taps "Record Group Education". The session is finalized with the participant set from **before** that last check-in — the participant is dropped, silently.

## Mechanism

Every education session write is a **full entity PATCH, rebuilt from the session held in the cache** (`Backend/EducationSession/Update.elm` → `updateFunc session |> sw.patchFull`, where `session` is `Dict.get sessionId model.educationSessions`).

Each page action is a one-field read-modify-write — `SaveTopics` sets `topics`, `SaveAttendance` sets `participants`, `EndEncounter` sets `endDate` — so every PATCH carries the *other* fields straight from the cache.

That cache was refreshed only by an **asynchronous echo**: the service worker's `patchNode` writes IndexedDB, `sendRevisedNode` posts the written node back, and Elm handles it as `EducationSessionRevision`. `HandleUpdated` records only the `WebData ()` status and never writes the entity back.

So two writes inside one echo window make the second one rebuild from the pre-first-write cache and, being a *full* replace, revert the first:

1. `SaveAttendance` → PATCH with `participants = {A, B, C}`
2. before the echo lands, `EndEncounter` → PATCH with `endDate` **and `participants` still `{A, B}`**
3. last write wins → C is gone.

Same for topics, if a participant is toggled while the `SaveTopics` PATCH is still in flight.

## Change

Apply the update to `model.educationSessions` right away, when the `Update` message is dispatched, rather than waiting for the revision to echo back. Every later PATCH is then rebuilt from a current session. One place, and it closes the whole class — all fields, any interleaving, including fields added later.

The cache briefly holds a write that has not been confirmed, which is safe here: `sw.patchFull` writes to the local IndexedDB that *is* the client's source of truth, and the echo carries back the same value. (On a failed PATCH the cache was left stale anyway, so this is not a regression.)

## Verification

- `elm make src/elm/Main.elm` — Success. `elm-format --validate`, `elm-review` — clean.
- `elm-test "src/elm/**/Test.elm"` — 2793 passed (4 new in `Backend/EducationSession/Test.elm`).

The logic lives in `Backend/EducationSession/Utils.applyUpdateToSessions`, and the tests apply updates to it back to back with no echo in between, so they reproduce the race directly rather than by timing. The session held in that dict is exactly what the next PATCH is built from, which is why asserting on it asserts on the payload that gets written.

(The first revision of this branch tested by driving `updateIndexedDb` itself. That pulled `Backend/Update.elm` — and with it essentially the whole app — into the `elm-test` compilation, and the CI Elm test job was OOM-killed, since it does not add the swap space that the client install does. Extracting the helper keeps the test compile graph small; the code under test is the same.)

**Discrimination** — reverting the fix while keeping the tests fails exactly the three race tests:

```
✗ an update is applied to the cached session right away, without waiting for its revision to echo back
✗ ending a session right after a participant was checked in does not drop that participant
✗ checking in a participant right after topics were selected does not drop the topics
```

The fourth test — "a message that is not an update leaves the cached session as is" — passes both before and after, pinning that the optimistic write happens only on `Update`.
