### PR TITLE
Child scoreboard: reload person node before writing NCDA data (lost-update fix)

### DIFF
--- a/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
+++ b/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
@@ -985,6 +985,18 @@ function hedley_ncda_calculate_aggregated_data_for_person($person, $birth_date_f
   }
 
   $encoded_data = json_encode($data);
+
+  // Assembling the data above may take seconds (hundreds of node loads), during
+  // which the person node could have been updated (device sync, admin edit).
+  // node_save() writes back every field of the object it's given, so saving the
+  // copy we started with would revert those updates. Reload before mutating, to
+  // keep the window between read and write as short as possible.
+  $person = node_load($person->nid, NULL, TRUE);
+  if (!$person) {
+    // Person was deleted while we were calculating.
+    return FALSE;
+  }
+
   $person->field_ncda_data[LANGUAGE_NONE][0]['value'] = $encoded_data;
   node_save($person);
 


### PR DESCRIPTION
Fixes #1929

## What was wrong

`hedley_ncda_calculate_aggregated_data_for_person()` wrote its result back with `node_save($person)` on the person object it had been handed at the **start** of the calculation. Between that load and the save sit hundreds of node loads (all of the child's measurements, prenatal encounters, immunisations) — ~100 ms to several seconds of work.

Because `node_save()` persists every field of the object it is given, any person update committing inside that window (a device syncing a name/birthdate/geo PATCH, an admin editing the person) was overwritten with the stale values. The save then bumped the node revision, propagating the reverted person out to every device on the next sync — a silent data loss, no error surfaced anywhere.

Recalculation is enqueued on every NCDA-triggering measurement save and on person edits themselves, so the windows are frequent and overlapping on a busy site.

## The fix

Reload the node immediately before the mutation, shrinking the read-to-write window from seconds to microseconds, and bail out if the person was deleted while we were calculating (`node_save(FALSE)` would fatal).

Both callers benefit: the AQ worker and `scripts/generate-data-for-all.php`.

This is a window-shrink, not an atomic write — Drupal 7 has no single-field save through the entity API, and a direct `db_update()` on the field table would bypass revisions and hooks. That trade-off is deliberate.

## Verification

- `php -l` clean; phpcs clean on both `Drupal` and `DrupalPractice` (full CI extension list).
- **Discrimination run against the real function** in ddev (person node 64), with a person edit committing between the worker's load and its save. `OLD` is the unpatched function; `NEW` is a verbatim copy of the patched one:

```
OLD  | edit wrote "CONCURRENT-OLD" | after worker save: REVERTED to "Yvan"  <- LOST UPDATE
     | field_ncda_data written: yes
NEW  | edit wrote "CONCURRENT-NEW" | after worker save: PRESERVED
     | field_ncda_data written: yes
```

Both paths still write `field_ncda_data`, so the recalculation itself is unaffected.

No SimpleTest class was added: `hedley_ncda` has none today, and a new test class costs a full extra Drupal install in CI with no existing class this fits into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)