### PR TITLE
Data entry: guard every entity create against double-tap duplicates

### DIFF
--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -85,7 +85,7 @@ import Backend.TraceContact.Model
 import Backend.TraceContact.Update
 import Backend.TuberculosisEncounter.Model
 import Backend.TuberculosisEncounter.Update
-import Backend.Utils exposing (everySetsEqual, gpsCoordinatesEnabled, mapAcuteIllnessMeasurements, mapChildMeasurements, mapChildScoreboardMeasurements, mapFamilyNutritionMeasurements, mapFollowUpMeasurements, mapHIVMeasurements, mapHomeVisitMeasurements, mapMotherMeasurements, mapNCDMeasurements, mapNutritionMeasurements, mapPrenatalMeasurements, mapStockManagementMeasurements, mapTuberculosisMeasurements, mapWellChildMeasurements, sw)
+import Backend.Utils exposing (everySetsEqual, gpsCoordinatesEnabled, isPostInFlight, mapAcuteIllnessMeasurements, mapChildMeasurements, mapChildScoreboardMeasurements, mapFamilyNutritionMeasurements, mapFollowUpMeasurements, mapHIVMeasurements, mapHomeVisitMeasurements, mapMotherMeasurements, mapNCDMeasurements, mapNutritionMeasurements, mapPrenatalMeasurements, mapStockManagementMeasurements, mapTuberculosisMeasurements, mapWellChildMeasurements, sw)
 import Backend.Village.Utils exposing (getVillageById, getVillageClinicId)
 import Backend.WellChildEncounter.Model exposing (EncounterWarning(..), emptyWellChildEncounter)
 import Backend.WellChildEncounter.Update
@@ -4190,11 +4190,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostPmtctParticipant initiator data ->
-            ( { model | postPmtctParticipant = Dict.insert data.child Loading model.postPmtctParticipant }
-            , sw.post pmtctParticipantEndpoint data
-                |> toCmd (RemoteData.fromResult >> HandlePostedPmtctParticipant data.child initiator)
-            , []
-            )
+            if isPostInFlight data.child model.postPmtctParticipant then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postPmtctParticipant = Dict.insert data.child Loading model.postPmtctParticipant }
+                , sw.post pmtctParticipantEndpoint data
+                    |> toCmd (RemoteData.fromResult >> HandlePostedPmtctParticipant data.child initiator)
+                , []
+                )
 
         HandlePostedPmtctParticipant id initiator data ->
             let
@@ -4229,146 +4233,150 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostRelationship personId myRelationship addGroup initiator ->
-            let
-                normalized =
-                    toRelationship personId myRelationship healthCenterId
+            if isPostInFlight personId model.postRelationship then
+                ( model, Cmd.none, [] )
 
-                -- If we'd also like to add these people to a group, construct
-                -- a Msg to do that.
-                extraMsgs =
-                    addGroup
-                        |> Maybe.map
-                            (\clinicId ->
-                                let
-                                    defaultAdultActivities =
-                                        case normalized.relatedBy of
-                                            ParentOf ->
-                                                MotherActivities
+            else
+                let
+                    normalized =
+                        toRelationship personId myRelationship healthCenterId
 
-                                            CaregiverFor ->
-                                                CaregiverActivities
+                    -- If we'd also like to add these people to a group, construct
+                    -- a Msg to do that.
+                    extraMsgs =
+                        addGroup
+                            |> Maybe.map
+                                (\clinicId ->
+                                    let
+                                        defaultAdultActivities =
+                                            case normalized.relatedBy of
+                                                ParentOf ->
+                                                    MotherActivities
 
-                                    childBirthDate =
-                                        Dict.get normalized.relatedTo model.people
-                                            |> Maybe.withDefault NotAsked
-                                            |> RemoteData.toMaybe
-                                            |> Maybe.andThen .birthDate
+                                                CaregiverFor ->
+                                                    CaregiverActivities
 
-                                    -- The start date determines when we start expecting this pair
-                                    -- to be attending a group encounter. We'll look to see if we
-                                    -- know the child's birth date. Normally, we will, because
-                                    -- we've probably just entered it, or we've loaded the child
-                                    -- for some other reason. We won't try to fetch the child here
-                                    -- if we don't have the child, at least for now, because it
-                                    -- would add complexity. If we don't know the child's
-                                    -- birthdate, we'll default to 28 days ago. That should be
-                                    -- enough so that, if we're in the middle of a group encounter,
-                                    -- the child will be expected at that group encounter.
-                                    defaultStartDate =
-                                        childBirthDate
-                                            |> Maybe.withDefault (Date.add Days -28 currentDate)
+                                        childBirthDate =
+                                            Dict.get normalized.relatedTo model.people
+                                                |> Maybe.withDefault NotAsked
+                                                |> RemoteData.toMaybe
+                                                |> Maybe.andThen .birthDate
 
-                                    -- For all groups but Sorwathe, we expect child to graduate from programm
-                                    -- after 26 months. Therefore, if we can resolve clinic type and child birthday,
-                                    -- we'll set expected graduation date.
-                                    defaultEndDate =
-                                        model.clinics
-                                            |> RemoteData.toMaybe
-                                            |> Maybe.andThen
-                                                (Dict.get clinicId
-                                                    >> Maybe.andThen
-                                                        (\clinic ->
-                                                            if List.member clinic.clinicType [ Sorwathe, Achi ] then
-                                                                Nothing
+                                        -- The start date determines when we start expecting this pair
+                                        -- to be attending a group encounter. We'll look to see if we
+                                        -- know the child's birth date. Normally, we will, because
+                                        -- we've probably just entered it, or we've loaded the child
+                                        -- for some other reason. We won't try to fetch the child here
+                                        -- if we don't have the child, at least for now, because it
+                                        -- would add complexity. If we don't know the child's
+                                        -- birthdate, we'll default to 28 days ago. That should be
+                                        -- enough so that, if we're in the middle of a group encounter,
+                                        -- the child will be expected at that group encounter.
+                                        defaultStartDate =
+                                            childBirthDate
+                                                |> Maybe.withDefault (Date.add Days -28 currentDate)
 
-                                                            else
-                                                                Maybe.map (Date.add Months graduatingAgeInMonth) childBirthDate
-                                                        )
-                                                )
-                                in
-                                PostPmtctParticipant initiator
-                                    { adult = normalized.person
-                                    , child = normalized.relatedTo
-                                    , adultActivities = defaultAdultActivities
-                                    , start = defaultStartDate
-                                    , end = defaultEndDate
-                                    , clinic = clinicId
-                                    , deleted = False
-                                    }
-                            )
-                        |> Maybe.Extra.toList
+                                        -- For all groups but Sorwathe, we expect child to graduate from programm
+                                        -- after 26 months. Therefore, if we can resolve clinic type and child birthday,
+                                        -- we'll set expected graduation date.
+                                        defaultEndDate =
+                                            model.clinics
+                                                |> RemoteData.toMaybe
+                                                |> Maybe.andThen
+                                                    (Dict.get clinicId
+                                                        >> Maybe.andThen
+                                                            (\clinic ->
+                                                                if List.member clinic.clinicType [ Sorwathe, Achi ] then
+                                                                    Nothing
 
-                -- We want to patch any relationship between these two,
-                -- whether or not reversed.
-                query1 =
-                    sw.select relationshipEndpoint
-                        { person = Just normalized.person
-                        , relatedTo = Just normalized.relatedTo
-                        }
-                        |> toTask
-                        |> Task.map (.items >> Dict.fromList)
+                                                                else
+                                                                    Maybe.map (Date.add Months graduatingAgeInMonth) childBirthDate
+                                                            )
+                                                    )
+                                    in
+                                    PostPmtctParticipant initiator
+                                        { adult = normalized.person
+                                        , child = normalized.relatedTo
+                                        , adultActivities = defaultAdultActivities
+                                        , start = defaultStartDate
+                                        , end = defaultEndDate
+                                        , clinic = clinicId
+                                        , deleted = False
+                                        }
+                                )
+                            |> Maybe.Extra.toList
 
-                query2 =
-                    sw.select relationshipEndpoint
-                        { person = Just normalized.relatedTo
-                        , relatedTo = Just normalized.person
-                        }
-                        |> toTask
-                        |> Task.map (.items >> Dict.fromList)
+                    -- We want to patch any relationship between these two,
+                    -- whether or not reversed.
+                    query1 =
+                        sw.select relationshipEndpoint
+                            { person = Just normalized.person
+                            , relatedTo = Just normalized.relatedTo
+                            }
+                            |> toTask
+                            |> Task.map (.items >> Dict.fromList)
 
-                existingRelationship =
-                    Task.map2 Dict.union query1 query2
-                        |> Task.map (Dict.toList >> List.head)
+                    query2 =
+                        sw.select relationshipEndpoint
+                            { person = Just normalized.relatedTo
+                            , relatedTo = Just normalized.person
+                            }
+                            |> toTask
+                            |> Task.map (.items >> Dict.fromList)
 
-                relationshipCmd =
-                    existingRelationship
-                        |> Task.andThen
-                            (\existing ->
-                                case existing of
-                                    Nothing ->
-                                        sw.post relationshipEndpoint normalized
-                                            |> toTask
-                                            |> Task.map (always myRelationship)
+                    existingRelationship =
+                        Task.map2 Dict.union query1 query2
+                            |> Task.map (Dict.toList >> List.head)
 
-                                    Just ( relationshipId, relationship ) ->
-                                        let
-                                            changes =
-                                                encodeRelationshipChanges { old = relationship, new = normalized }
-                                        in
-                                        if List.isEmpty changes then
-                                            -- If no changes, we just report success without posting to the DB
-                                            Task.succeed myRelationship
-
-                                        else
-                                            object changes
-                                                |> sw.patchAny relationshipEndpoint relationshipId
+                    relationshipCmd =
+                        existingRelationship
+                            |> Task.andThen
+                                (\existing ->
+                                    case existing of
+                                        Nothing ->
+                                            sw.post relationshipEndpoint normalized
                                                 |> toTask
                                                 |> Task.map (always myRelationship)
-                            )
-                        |> RemoteData.fromTask
-                        |> Task.perform (HandlePostedRelationship personId initiator)
-            in
-            ( { model | postRelationship = Dict.insert personId Loading model.postRelationship }
-            , relationshipCmd
-            , []
-            )
-                |> sequenceExtra
-                    (updateIndexedDb language
-                        currentDate
-                        currentTime
-                        coordinates
-                        zscores
-                        site
-                        features
-                        nurseId
-                        healthCenterId
-                        villageId
-                        isChw
-                        isLabTech
-                        activePage
-                        syncManager
-                    )
-                    extraMsgs
+
+                                        Just ( relationshipId, relationship ) ->
+                                            let
+                                                changes =
+                                                    encodeRelationshipChanges { old = relationship, new = normalized }
+                                            in
+                                            if List.isEmpty changes then
+                                                -- If no changes, we just report success without posting to the DB
+                                                Task.succeed myRelationship
+
+                                            else
+                                                object changes
+                                                    |> sw.patchAny relationshipEndpoint relationshipId
+                                                    |> toTask
+                                                    |> Task.map (always myRelationship)
+                                )
+                            |> RemoteData.fromTask
+                            |> Task.perform (HandlePostedRelationship personId initiator)
+                in
+                ( { model | postRelationship = Dict.insert personId Loading model.postRelationship }
+                , relationshipCmd
+                , []
+                )
+                    |> sequenceExtra
+                        (updateIndexedDb language
+                            currentDate
+                            currentTime
+                            coordinates
+                            zscores
+                            site
+                            features
+                            nurseId
+                            healthCenterId
+                            villageId
+                            isChw
+                            isLabTech
+                            activePage
+                            syncManager
+                        )
+                        extraMsgs
 
         HandlePostedRelationship personId initiator data ->
             let
@@ -4412,20 +4420,26 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostPerson relation initiator person ->
-            let
-                -- Adding GPS coordinates.
-                personWithCoordinates =
-                    if gpsCoordinatesEnabled features && person.saveGPSLocation then
-                        updatePersonWithCooridnates person coordinates
+            if RemoteData.isLoading model.postPerson then
+                -- A person create is already on its way; ignore the duplicate,
+                -- so a double-tapped "Save" can't register the same patient twice.
+                ( model, Cmd.none, [] )
 
-                    else
-                        person
-            in
-            ( { model | postPerson = Loading }
-            , sw.post personEndpoint personWithCoordinates
-                |> toCmd (RemoteData.fromResult >> RemoteData.map Tuple.first >> HandlePostedPerson relation initiator)
-            , []
-            )
+            else
+                let
+                    -- Adding GPS coordinates.
+                    personWithCoordinates =
+                        if gpsCoordinatesEnabled features && person.saveGPSLocation then
+                            updatePersonWithCooridnates person coordinates
+
+                        else
+                            person
+                in
+                ( { model | postPerson = Loading }
+                , sw.post personEndpoint personWithCoordinates
+                    |> toCmd (RemoteData.fromResult >> RemoteData.map Tuple.first >> HandlePostedPerson relation initiator)
+                , []
+                )
 
         HandlePostedPerson relation initiator data ->
             let
@@ -4651,11 +4665,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostSession session ->
-            ( { model | postSession = Loading }
-            , sw.post sessionEndpoint session
-                |> toCmd (RemoteData.fromResult >> RemoteData.map Tuple.first >> HandlePostedSession)
-            , []
-            )
+            if RemoteData.isLoading model.postSession then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postSession = Loading }
+                , sw.post sessionEndpoint session
+                    |> toCmd (RemoteData.fromResult >> RemoteData.map Tuple.first >> HandlePostedSession)
+                , []
+                )
 
         HandlePostedSession data ->
             let
@@ -4679,13 +4697,7 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostIndividualEncounterParticipant extraData session ->
-            let
-                alreadyInFlight =
-                    Dict.get session.person model.postIndividualEncounterParticipant
-                        |> Maybe.map RemoteData.isLoading
-                        |> Maybe.withDefault False
-            in
-            if alreadyInFlight then
+            if isPostInFlight session.person model.postIndividualEncounterParticipant then
                 -- A create for this person is already in flight; ignore the
                 -- duplicate, so a double-tapped "begin encounter" button can't
                 -- open two encounter participants (e.g. two open pregnancies).
@@ -4807,11 +4819,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostPrenatalEncounter postCreateDestination prenatalEncounter ->
-            ( { model | postPrenatalEncounter = Dict.insert prenatalEncounter.participant Loading model.postPrenatalEncounter }
-            , sw.post prenatalEncounterEndpoint prenatalEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedPrenatalEncounter prenatalEncounter.participant postCreateDestination)
-            , []
-            )
+            if isPostInFlight prenatalEncounter.participant model.postPrenatalEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postPrenatalEncounter = Dict.insert prenatalEncounter.participant Loading model.postPrenatalEncounter }
+                , sw.post prenatalEncounterEndpoint prenatalEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedPrenatalEncounter prenatalEncounter.participant postCreateDestination)
+                , []
+                )
 
         HandlePostedPrenatalEncounter participantId postCreateDestination data ->
             let
@@ -4854,11 +4870,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostNutritionEncounter nutritionEncounter ->
-            ( { model | postNutritionEncounter = Dict.insert nutritionEncounter.participant Loading model.postNutritionEncounter }
-            , sw.post nutritionEncounterEndpoint nutritionEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedNutritionEncounter nutritionEncounter.participant)
-            , []
-            )
+            if isPostInFlight nutritionEncounter.participant model.postNutritionEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postNutritionEncounter = Dict.insert nutritionEncounter.participant Loading model.postNutritionEncounter }
+                , sw.post nutritionEncounterEndpoint nutritionEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedNutritionEncounter nutritionEncounter.participant)
+                , []
+                )
 
         HandlePostedNutritionEncounter participantId data ->
             let
@@ -4882,11 +4902,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostHomeVisitEncounter homeVisitEncounter ->
-            ( { model | postHomeVisitEncounter = Dict.insert homeVisitEncounter.participant Loading model.postHomeVisitEncounter }
-            , sw.post homeVisitEncounterEndpoint homeVisitEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedHomeVisitEncounter homeVisitEncounter.participant)
-            , []
-            )
+            if isPostInFlight homeVisitEncounter.participant model.postHomeVisitEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postHomeVisitEncounter = Dict.insert homeVisitEncounter.participant Loading model.postHomeVisitEncounter }
+                , sw.post homeVisitEncounterEndpoint homeVisitEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedHomeVisitEncounter homeVisitEncounter.participant)
+                , []
+                )
 
         HandlePostedHomeVisitEncounter participantId data ->
             let
@@ -4910,11 +4934,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostWellChildEncounter wellChildEncounter ->
-            ( { model | postWellChildEncounter = Dict.insert wellChildEncounter.participant Loading model.postWellChildEncounter }
-            , sw.post wellChildEncounterEndpoint wellChildEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedWellChildEncounter wellChildEncounter.participant)
-            , []
-            )
+            if isPostInFlight wellChildEncounter.participant model.postWellChildEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postWellChildEncounter = Dict.insert wellChildEncounter.participant Loading model.postWellChildEncounter }
+                , sw.post wellChildEncounterEndpoint wellChildEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedWellChildEncounter wellChildEncounter.participant)
+                , []
+                )
 
         HandlePostedWellChildEncounter participantId data ->
             let
@@ -4938,11 +4966,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostAcuteIllnessEncounter acuteIllnessEncounter ->
-            ( { model | postAcuteIllnessEncounter = Dict.insert acuteIllnessEncounter.participant Loading model.postAcuteIllnessEncounter }
-            , sw.post acuteIllnessEncounterEndpoint acuteIllnessEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedAcuteIllnessEncounter acuteIllnessEncounter.participant)
-            , []
-            )
+            if isPostInFlight acuteIllnessEncounter.participant model.postAcuteIllnessEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postAcuteIllnessEncounter = Dict.insert acuteIllnessEncounter.participant Loading model.postAcuteIllnessEncounter }
+                , sw.post acuteIllnessEncounterEndpoint acuteIllnessEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedAcuteIllnessEncounter acuteIllnessEncounter.participant)
+                , []
+                )
 
         HandlePostedAcuteIllnessEncounter participantId data ->
             let
@@ -4966,11 +4998,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostNCDEncounter ncdEncounter ->
-            ( { model | postNCDEncounter = Dict.insert ncdEncounter.participant Loading model.postNCDEncounter }
-            , sw.post ncdEncounterEndpoint ncdEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedNCDEncounter ncdEncounter.participant)
-            , []
-            )
+            if isPostInFlight ncdEncounter.participant model.postNCDEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postNCDEncounter = Dict.insert ncdEncounter.participant Loading model.postNCDEncounter }
+                , sw.post ncdEncounterEndpoint ncdEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedNCDEncounter ncdEncounter.participant)
+                , []
+                )
 
         HandlePostedNCDEncounter participantId data ->
             let
@@ -4994,11 +5030,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostChildScoreboardEncounter childScoreboardEncounter ->
-            ( { model | postChildScoreboardEncounter = Dict.insert childScoreboardEncounter.participant Loading model.postChildScoreboardEncounter }
-            , sw.post childScoreboardEncounterEndpoint childScoreboardEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedChildScoreboardEncounter childScoreboardEncounter.participant)
-            , []
-            )
+            if isPostInFlight childScoreboardEncounter.participant model.postChildScoreboardEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postChildScoreboardEncounter = Dict.insert childScoreboardEncounter.participant Loading model.postChildScoreboardEncounter }
+                , sw.post childScoreboardEncounterEndpoint childScoreboardEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedChildScoreboardEncounter childScoreboardEncounter.participant)
+                , []
+                )
 
         HandlePostedChildScoreboardEncounter participantId data ->
             let
@@ -5022,11 +5062,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostTuberculosisEncounter tuberculosisEncounter ->
-            ( { model | postTuberculosisEncounter = Dict.insert tuberculosisEncounter.participant Loading model.postTuberculosisEncounter }
-            , sw.post tuberculosisEncounterEndpoint tuberculosisEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedTuberculosisEncounter tuberculosisEncounter.participant)
-            , []
-            )
+            if isPostInFlight tuberculosisEncounter.participant model.postTuberculosisEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postTuberculosisEncounter = Dict.insert tuberculosisEncounter.participant Loading model.postTuberculosisEncounter }
+                , sw.post tuberculosisEncounterEndpoint tuberculosisEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedTuberculosisEncounter tuberculosisEncounter.participant)
+                , []
+                )
 
         HandlePostedTuberculosisEncounter participantId data ->
             let
@@ -5050,11 +5094,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostHIVEncounter hivEncounter ->
-            ( { model | postHIVEncounter = Dict.insert hivEncounter.participant Loading model.postHIVEncounter }
-            , sw.post hivEncounterEndpoint hivEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedHIVEncounter hivEncounter.participant)
-            , []
-            )
+            if isPostInFlight hivEncounter.participant model.postHIVEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postHIVEncounter = Dict.insert hivEncounter.participant Loading model.postHIVEncounter }
+                , sw.post hivEncounterEndpoint hivEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedHIVEncounter hivEncounter.participant)
+                , []
+                )
 
         HandlePostedHIVEncounter participantId data ->
             let
@@ -5078,11 +5126,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostEducationSession educationSession ->
-            ( { model | postEducationSession = Loading }
-            , sw.post educationSessionEndpoint educationSession
-                |> toCmd (RemoteData.fromResult >> HandlePostedEducationSession)
-            , []
-            )
+            if RemoteData.isLoading model.postEducationSession then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postEducationSession = Loading }
+                , sw.post educationSessionEndpoint educationSession
+                    |> toCmd (RemoteData.fromResult >> HandlePostedEducationSession)
+                , []
+                )
 
         HandlePostedEducationSession data ->
             let
@@ -5106,13 +5158,7 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostFamilyEncounterParticipant session ->
-            let
-                alreadyInFlight =
-                    Dict.get session.person model.postFamilyEncounterParticipant
-                        |> Maybe.map RemoteData.isLoading
-                        |> Maybe.withDefault False
-            in
-            if alreadyInFlight then
+            if isPostInFlight session.person model.postFamilyEncounterParticipant then
                 -- Already creating a family encounter participant for this
                 -- person; ignore the double-tap.
                 ( model, Cmd.none, [] )
@@ -5149,11 +5195,15 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
             )
 
         PostFamilyNutritionEncounter familyNutritionEncounter ->
-            ( { model | postFamilyNutritionEncounter = Dict.insert familyNutritionEncounter.participant Loading model.postFamilyNutritionEncounter }
-            , sw.post familyNutritionEncounterEndpoint familyNutritionEncounter
-                |> toCmd (RemoteData.fromResult >> HandlePostedFamilyNutritionEncounter familyNutritionEncounter.participant)
-            , []
-            )
+            if isPostInFlight familyNutritionEncounter.participant model.postFamilyNutritionEncounter then
+                ( model, Cmd.none, [] )
+
+            else
+                ( { model | postFamilyNutritionEncounter = Dict.insert familyNutritionEncounter.participant Loading model.postFamilyNutritionEncounter }
+                , sw.post familyNutritionEncounterEndpoint familyNutritionEncounter
+                    |> toCmd (RemoteData.fromResult >> HandlePostedFamilyNutritionEncounter familyNutritionEncounter.participant)
+                , []
+                )
 
         HandlePostedFamilyNutritionEncounter participantId data ->
             let

--- a/client/src/elm/Backend/Utils.elm
+++ b/client/src/elm/Backend/Utils.elm
@@ -1,6 +1,6 @@
-module Backend.Utils exposing (editMeasurementCmd, everySetsEqual, familyNutritionEnabled, gpsCoordinatesEnabled, groupEducationEnabled, healthyStartEnabled, hivManagementEnabled, mapAcuteIllnessMeasurements, mapChildMeasurements, mapChildScoreboardMeasurements, mapFamilyNutritionMeasurements, mapFollowUpMeasurements, mapHIVMeasurements, mapHomeVisitMeasurements, mapMotherMeasurements, mapNCDMeasurements, mapNutritionMeasurements, mapPrenatalMeasurements, mapStockManagementMeasurements, mapTuberculosisMeasurements, mapWellChildMeasurements, ncdaEnabled, reportToWhatsAppEnabled, resolveFamilyParticipantForPerson, resolveFamilyParticipantsForPerson, resolveIndividualParticipantForPerson, resolveIndividualParticipantsForPerson, saveMeasurementCmd, stockManagementHCEnabled, stockManagementVillageEnabled, sw, tuberculosisManagementEnabled)
+module Backend.Utils exposing (editMeasurementCmd, everySetsEqual, familyNutritionEnabled, gpsCoordinatesEnabled, groupEducationEnabled, healthyStartEnabled, hivManagementEnabled, isPostInFlight, mapAcuteIllnessMeasurements, mapChildMeasurements, mapChildScoreboardMeasurements, mapFamilyNutritionMeasurements, mapFollowUpMeasurements, mapHIVMeasurements, mapHomeVisitMeasurements, mapMotherMeasurements, mapNCDMeasurements, mapNutritionMeasurements, mapPrenatalMeasurements, mapStockManagementMeasurements, mapTuberculosisMeasurements, mapWellChildMeasurements, ncdaEnabled, reportToWhatsAppEnabled, resolveFamilyParticipantForPerson, resolveFamilyParticipantsForPerson, resolveIndividualParticipantForPerson, resolveIndividualParticipantsForPerson, saveMeasurementCmd, stockManagementHCEnabled, stockManagementVillageEnabled, sw, tuberculosisManagementEnabled)
 
-import AssocList as Dict
+import AssocList as Dict exposing (Dict)
 import Backend.Entities exposing (..)
 import Backend.FamilyEncounterParticipant.Model exposing (FamilyEncounterType)
 import Backend.IndividualEncounterParticipant.Model exposing (IndividualEncounterType)
@@ -33,6 +33,25 @@ import SyncManager.Model exposing (SiteFeature(..))
 sw : Restful.Endpoint.CrudOperations w e k v c p
 sw =
     applyBackendUrl "/sw"
+
+
+{-| Is a create for this key already on its way to the backend?
+
+Entities are created optimistically: we mark the slot `Loading`, POST, and only
+navigate away once the response lands in the `HandlePosted...` handler. Until
+then the button that triggered the create is still on screen and still live, so
+a second tap would POST a second entity. Callers use this to ignore that tap.
+
+Only `Loading` blocks: a create that failed can be retried, and a key that
+already holds a `Success` from an earlier create is free to create again (a
+participant may legitimately get another encounter later on).
+
+-}
+isPostInFlight : k -> Dict k (RemoteData e a) -> Bool
+isPostInFlight key dict =
+    Dict.get key dict
+        |> Maybe.map RemoteData.isLoading
+        |> Maybe.withDefault False
 
 
 mapChildMeasurements : PersonId -> (ChildMeasurementList -> ChildMeasurementList) -> ModelIndexedDb -> ModelIndexedDb

--- a/client/src/elm/Backend/Utils/Test.elm
+++ b/client/src/elm/Backend/Utils/Test.elm
@@ -1,0 +1,59 @@
+module Backend.Utils.Test exposing (all)
+
+import AssocList as Dict exposing (Dict)
+import Backend.Utils exposing (isPostInFlight)
+import Expect
+import Http
+import RemoteData exposing (RemoteData(..), WebData)
+import Test exposing (Test, describe, test)
+
+
+{-| Entities are created optimistically: the slot goes `Loading`, we POST, and
+the page only moves on once the response lands. The button that started the
+create stays live for that whole round-trip, so a second tap would create a
+second entity - a duplicate encounter, or worse, a duplicate patient.
+
+`isPostInFlight` is what every create handler in Backend.Update asks before it
+posts. These pin the answers that matter: block while Loading, allow otherwise,
+and never let one key's create block another's.
+
+-}
+all : Test
+all =
+    describe "isPostInFlight"
+        [ test "a create already in flight for this key blocks the duplicate" <|
+            \_ ->
+                Dict.fromList [ ( "child", Loading ) ]
+                    |> isPostInFlight "child"
+                    |> Expect.equal True
+        , test "a key we have never posted for is free to create" <|
+            \_ ->
+                Dict.fromList [ ( "child", NotAsked ) ]
+                    |> isPostInFlight "child"
+                    |> Expect.equal False
+        , test "a key absent from the dict is free to create" <|
+            \_ ->
+                Dict.empty
+                    |> isPostInFlight "child"
+                    |> Expect.equal False
+        , test "an earlier successful create does not block a later one" <|
+            \_ ->
+                -- A participant legitimately gets another encounter another day.
+                Dict.fromList [ ( "child", Success () ) ]
+                    |> isPostInFlight "child"
+                    |> Expect.equal False
+        , test "a failed create can be retried" <|
+            \_ ->
+                Dict.fromList [ ( "child", Failure Http.NetworkError ) ]
+                    |> isPostInFlight "child"
+                    |> Expect.equal False
+        , test "a create in flight for one key does not block a different key" <|
+            \_ ->
+                let
+                    dict : Dict String (WebData ())
+                    dict =
+                        Dict.fromList [ ( "sibling", Loading ) ]
+                in
+                ( isPostInFlight "sibling" dict, isPostInFlight "child" dict )
+                    |> Expect.equal ( True, False )
+        ]


### PR DESCRIPTION
Fixes #1931

## What was wrong

Creates are optimistic: the handler marks its slot `Loading`, POSTs, and the page only moves on once the response lands in `HandlePosted...`. So the button that started the create stays on screen — and stays live — for the whole round-trip. A second tap in that window POSTs a second entity.

PR #1881 closed this for two handlers (`PostIndividualEncounterParticipant`, `PostFamilyEncounterParticipant`). The remaining fifteen creates had no guard at all:

| Create | Duplicate you get |
| --- | --- |
| 10 × `Post*Encounter` (Prenatal, Nutrition, HomeVisit, WellChild, AcuteIllness, NCD, ChildScoreboard, Tuberculosis, HIV, FamilyNutrition) | two encounters inside one episode — the **subsequent**-encounter path, where #1881's guard is never consulted |
| `PostPerson` | the same patient registered twice |
| `PostRelationship`, `PostPmtctParticipant` | duplicate relationship / group participation |
| `PostSession`, `PostEducationSession` | duplicate group session / education session |

These duplicates sync, land in the patient's history, and count in encounter-based reporting. `PostPerson` is the one that worried me most: everything downstream hangs off the person.

## The fix

One shared predicate — `Backend.Utils.isPostInFlight` — asked by every create handler before it posts. The two #1881 sites now use it too, so "in flight" has a single definition instead of being re-spelled per handler.

Only `Loading` blocks. A create that failed can still be retried, and a key holding an earlier `Success` is free to create again (a participant legitimately gets another encounter another day).

Two handlers (`PostPerson`, `PostRelationship`) had their `let` block moved inside the `else` branch, so their bindings aren't computed on the path that discards them — elm-review's `NoPrematureLetComputation` flagged that, correctly.

**Measurement saves are deliberately out of scope.** The 169 `Save*` handlers dispatch `SetActivePage` in the *same* update as the save rather than waiting for the response, so their duplicate window is a single frame rather than a round-trip, and many carry a `valueId` and PATCH rather than create. Different risk, different evidence — it shouldn't ride along on this.

## Verification

- `elm make src/elm/Main.elm` — Success, 548 modules. `elm-format` clean. `elm-review` clean (cold run).
- `elm-test` — 2806 passed, including 6 new tests for the predicate in `Backend/Utils/Test.elm`.
- **Discrimination:** neutering `isPostInFlight` to always return `False` (i.e. the pre-fix behaviour of these handlers) fails exactly the two tests that assert blocking — "a create already in flight for this key blocks the duplicate" and "a create in flight for one key does not block a different key" — while the four that assert *allowed* still pass. Restored, all 2806 green again.

Note on what a test can and cannot pin here: the handlers' only observable difference on a double-tap is the `Cmd` they return, and `Cmd`s are opaque in Elm — a handler-level unit test could not distinguish one POST from two. The predicate is where the logic lives, so that's what's tested; the wiring is carried by the compiler and the diff. (A test module importing `Backend/Update.elm` would also OOM the `test_elm` CI job — see #1927.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)