### PR TITLE
Dashboard stats: count children, not encounters, in nutrition prevalence percentages

### DIFF
--- a/server/elm/src/Pages/Reports/Utils.elm
+++ b/server/elm/src/Pages/Reports/Utils.elm
@@ -273,11 +273,19 @@ generatePrevalenceNutritionMetricsResults : NutritionMetrics -> NutritionMetrics
 generatePrevalenceNutritionMetricsResults metrics =
     let
         calculatePercentage nominator total =
-            if List.isEmpty total then
+            let
+                -- The metric lists hold one entry per encounter, so a child
+                -- measured several times during the period appears several
+                -- times. Count children on both sides: deduplicating only the
+                -- total inflated the percentage, and could push it past 100%.
+                totalChildren =
+                    unique total
+            in
+            if List.isEmpty totalChildren then
                 0
 
             else
-                (toFloat (List.length nominator) / toFloat (List.length total)) * 100
+                (toFloat (List.length (unique nominator)) / toFloat (List.length totalChildren)) * 100
 
         stuntingTotal =
             metrics.stuntingModerate

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -2817,6 +2817,13 @@ function hedley_reports_generate_incidence_nutrition_metrics_results(array $curr
  *   The percentage value as a string, rounded to three decimal places.
  */
 function hedley_reports_calculate_percentage(array $nominator, array $total) {
+  // The metric arrays hold one entry per encounter, so a child measured
+  // several times during the period appears several times. Count children on
+  // both sides: deduplicating only the total (as callers do) inflated the
+  // percentage, and could push it past 100%.
+  $nominator = array_unique($nominator);
+  $total = array_unique($total);
+
   if (empty($total)) {
     return "0%";
   }

--- a/server/hedley/modules/custom/hedley_reports/tests/HedleyReportsDataEndpoint.test
+++ b/server/hedley/modules/custom/hedley_reports/tests/HedleyReportsDataEndpoint.test
@@ -174,6 +174,10 @@ class HedleyReportsDataEndpoint extends HedleyWebTestBase {
     $request = ['app_type' => 'reports', 'base_revision' => 0];
     $result = $this->invokeReportsDataAsUser($hc_sqm, $request);
     $this->assertNull($result, 'HC-scoped SQM denied when health_center is missing.');
+
+    // Piggy-backs on this method's install, per the note above: a second
+    // test method would pay another full hedley-profile install.
+    $this->checkPrevalencePercentages();
   }
 
   /**
@@ -183,8 +187,11 @@ class HedleyReportsDataEndpoint extends HedleyWebTestBase {
    * are measured against is deduplicated by child. A child measured twice in
    * the period therefore used to count twice in the numerator but once in the
    * denominator, inflating the percentage - past 100% in the extreme.
+   *
+   * Called from testReportsDataAccess() rather than being a test method of
+   * its own, so that it shares that method's install.
    */
-  public function testPrevalencePercentagesCountChildrenNotEncounters() {
+  protected function checkPrevalencePercentages() {
     // Child 1 was measured twice in the period, both times moderately stunted;
     // child 2 once, normal. Half the children are moderately stunted.
     $metrics = [

--- a/server/hedley/modules/custom/hedley_reports/tests/HedleyReportsDataEndpoint.test
+++ b/server/hedley/modules/custom/hedley_reports/tests/HedleyReportsDataEndpoint.test
@@ -25,7 +25,7 @@ class HedleyReportsDataEndpoint extends HedleyWebTestBase {
   public static function getInfo() {
     return [
       'name' => 'Reports Data endpoint tests',
-      'description' => 'Access control for /api/reports-data POST endpoint.',
+      'description' => 'Access control for /api/reports-data POST endpoint, and prevalence metric calculation.',
       'group' => 'Hedley',
     ];
   }
@@ -174,6 +174,65 @@ class HedleyReportsDataEndpoint extends HedleyWebTestBase {
     $request = ['app_type' => 'reports', 'base_revision' => 0];
     $result = $this->invokeReportsDataAsUser($hc_sqm, $request);
     $this->assertNull($result, 'HC-scoped SQM denied when health_center is missing.');
+  }
+
+  /**
+   * Prevalence percentages count children, not encounters.
+   *
+   * The metric arrays collect one entry per encounter, while the total they
+   * are measured against is deduplicated by child. A child measured twice in
+   * the period therefore used to count twice in the numerator but once in the
+   * denominator, inflating the percentage - past 100% in the extreme.
+   */
+  public function testPrevalencePercentagesCountChildrenNotEncounters() {
+    // Child 1 was measured twice in the period, both times moderately stunted;
+    // child 2 once, normal. Half the children are moderately stunted.
+    $metrics = [
+      'stunting_moderate' => [1, 1],
+      'stunting_severe' => [],
+      'stunting_normal' => [2],
+      'wasting_moderate' => [],
+      'wasting_severe' => [],
+      'wasting_normal' => [],
+      'underweight_moderate' => [],
+      'underweight_severe' => [],
+      'underweight_normal' => [],
+      'acute_malnutrition_mam' => [],
+      'acute_malnutrition_sam' => [],
+      'acute_malnutrition_normal' => [],
+    ];
+    $results = hedley_reports_generate_prevalence_nutrition_metrics_results($metrics);
+    $this->assertEqual($results['stunting_moderate'], '50%', 'A child measured twice counts once: 1 of 2 children, not 2 of 2.');
+
+    // The degenerate case: repeat measurements of the only child in the
+    // bucket used to yield 200%.
+    $metrics['stunting_moderate'] = [1, 1];
+    $metrics['stunting_normal'] = [];
+    $results = hedley_reports_generate_prevalence_nutrition_metrics_results($metrics);
+    $this->assertEqual($results['stunting_moderate'], '100%', 'A percentage can never exceed 100%.');
+
+    // Severity buckets are independent, and a child seen in several of them
+    // still counts once per bucket.
+    $metrics = [
+      'stunting_moderate' => [1, 1, 2],
+      'stunting_severe' => [3],
+      'stunting_normal' => [4, 4],
+      'wasting_moderate' => [],
+      'wasting_severe' => [],
+      'wasting_normal' => [],
+      'underweight_moderate' => [],
+      'underweight_severe' => [],
+      'underweight_normal' => [],
+      'acute_malnutrition_mam' => [],
+      'acute_malnutrition_sam' => [],
+      'acute_malnutrition_normal' => [],
+    ];
+    $results = hedley_reports_generate_prevalence_nutrition_metrics_results($metrics);
+    $this->assertEqual($results['stunting_moderate'], '50%', 'Children 1 and 2 of 4 distinct children are moderately stunted.');
+    $this->assertEqual($results['stunting_severe'], '25%', 'Child 3 of 4 distinct children is severely stunted.');
+
+    // An empty bucket stays at 0%, and does not divide by zero.
+    $this->assertEqual($results['wasting_moderate'], '0%', 'An empty total yields 0%.');
   }
 
 }


### PR DESCRIPTION
Fixes #1933

## What was wrong

The prevalence denominator counted **children**; the numerator counted **encounters**.

`hedley_reports_generate_prevalence_nutrition_metrics_results()` deduplicates the total with `array_unique`, but `hedley_reports_calculate_percentage()` divided raw counts — and the metric buckets hold one entry *per encounter* (`hedley_reports_categorize_z_score()` pushes the person id on every call; the monthly merge is a plain `array_merge`). A child measured twice in the period therefore counted twice on top and once underneath.

## The fix

Deduplicate both sides in `hedley_reports_calculate_percentage()`, and mirror it in `server/elm/src/Pages/Reports/Utils.elm` — the PHP precomputes the report while the Elm app also computes it live, so the two must move together or they disagree about the same screen.

Plain deduplication, per product decision: a child who is moderate early in the period and normal later still counts once in the moderate numerator. Changing *that* is a redefinition of the metric (latest-status, or exclude status-changers) and is a clinical call, deliberately not made here.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list). `elm-format`, `elm make src/Main.elm` (84 modules) and `elm-review` all clean on `server/elm`.

**Discrimination against the real function** (`drush php-script`, stunting bucket) — `OLD` is the unpatched code from the tree, `NEW` a verbatim copy of the patched functions:

| case | OLD | NEW | truth |
| --- | --- | --- | --- |
| child A measured 2× moderate, child B 1× normal | 100% | **50%** | 50% |
| child A measured 2× moderate, no other children | 200% | **100%** | 100% |
| A,A,B moderate; C severe; D,D normal | 75% (sev 25%) | **50%** (sev 25%) | 50% / 25% |
| no repeat measurements | 50% | 50% | 50% (unchanged) |

The last row matters: clean data is untouched, so this only removes inflation.

**Incidence is a genuine no-op.** It shares `hedley_reports_calculate_percentage()`, but its numerators are already built from `array_unique` inputs through `array_intersect`/`array_diff`. Checked with a duplicate-heavy input: the numerator comes out `[1,2,3]`, and `count() === count(array_unique())`, so the new `array_unique` changes nothing there.

**Regression test** folded into the existing `HedleyReportsDataEndpoint` class, as a helper called from `testReportsDataAccess()` — `setUp()` runs per test *method* in `DrupalWebTestCase`, so a second `test*` method would pay another full ~9 min hedley-profile install (caught by Copilot; fixed in 9ddfc5dba): the two-children case, the 200% degenerate case, independent severity buckets, and the empty-total case. Its expected values were verified against the real function via the harness above; the SimpleTest scaffolding itself first executes in CI.

**Not covered by a test:** the Elm mirror. `server/elm` has no test infrastructure at all (no `elm-test` dependency; CI only lints it), so that side rests on the compiler plus its being a line-for-line mirror of the PHP fix. Worth a separate item if we want it properly covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)