### PR TITLE
Dashboard stats: exclude soft-deleted persons from group education figures

### DIFF
--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -2304,8 +2304,14 @@ function hedley_stats_get_group_education_data($health_center_id, array &$patien
   $query->leftJoin('field_data_field_education_topics', 'et', 'et.entity_id = node.nid');
   $query->addField('et', 'field_education_topics_value');
   $query->addExpression("GROUP_CONCAT(DISTINCT et.field_education_topics_value)", 'education_topics');
-  // Resolve participants.
-  $query->leftJoin('field_data_field_participating_patients', 'pp', 'pp.entity_id = node.nid');
+  // Resolve participants. A person who was soft-deleted - most commonly the
+  // duplicate side of a patient merge - is still referenced by the session, so
+  // exclude them here: otherwise they keep being counted among the attendees,
+  // and their name and gender are shipped to the dashboard.
+  $query->leftJoin('field_data_field_participating_patients', 'pp', hedley_stats_exclude_deleted_from_join(
+    'pp.entity_id = node.nid',
+    'pp.field_participating_patients_target_id'
+  ));
   $query->addField('pp', 'field_participating_patients_target_id');
   $query->addExpression("GROUP_CONCAT(DISTINCT pp.field_participating_patients_target_id)", 'participating_patients');
   $query->groupBy('node.nid');
@@ -3500,32 +3506,37 @@ function hedley_stats_run_node_query_in_batches(SelectQuery $query, $batch = 100
 }
 
 /**
- * Adds a soft-delete exclusion to a measurement JOIN's ON condition.
+ * Adds a soft-delete exclusion to a JOIN's ON condition.
  *
- * The dashboard statistics builders reach measurement values by joining the
- * field_<program>_encounter table (whose entity_id is the measurement node ID)
- * and then joining each value field off that alias. Soft-deleting a measurement
- * only sets its field_deleted flag; the node and its field rows remain, so
- * the measurement's values would otherwise keep being pulled into the
- * aggregates on every stats recalculation.
+ * Soft-deleting a node only sets its field_deleted flag; the node and its field
+ * rows remain, so anything the statistics builders reach through a JOIN would
+ * otherwise keep being pulled into the aggregates on every recalculation. Two
+ * kinds of node are excluded this way:
+ *
+ *   - Measurements, reached by joining the field_<program>_encounter table
+ *     (whose entity_id is the measurement node ID) and then joining each value
+ *     field off that alias.
+ *   - Persons, reached through a reference field - e.g. an education session's
+ *     field_participating_patients, whose target_id is the person node ID.
  *
  * The exclusion is folded into the JOIN's ON clause (rather than added as a
- * WHERE condition) so that a soft-deleted measurement is treated as absent from
- * the LEFT JOIN - its values simply do not appear - without dropping the
- * encounter row. A WHERE filter on a fanned-in measurement would instead drop
- * the whole encounter when all of its measurements are deleted.
+ * WHERE condition) so that a soft-deleted node is treated as absent from the
+ * LEFT JOIN - it simply does not appear - without dropping the row that joined
+ * to it. A WHERE filter would instead drop the whole encounter when all of its
+ * measurements are deleted, or the whole session when one attendee is.
  *
  * @param string $on_condition
- *   The original ON condition of the measurement join.
- * @param string $measurement_entity_id
- *   SQL reference to the measurement node ID within that join, e.g.
- *   "ai_encounter.entity_id".
+ *   The original ON condition of the join.
+ * @param string $entity_id
+ *   SQL reference, within that join, to the node ID whose field_deleted flag
+ *   should be honoured - e.g. "ai_encounter.entity_id" for a measurement, or
+ *   "pp.field_participating_patients_target_id" for a referenced person.
  *
  * @return string
  *   The ON condition extended with the soft-delete exclusion.
  */
-function hedley_stats_exclude_deleted_from_join($on_condition, $measurement_entity_id) {
-  return "($on_condition) AND NOT EXISTS (SELECT 1 FROM {field_data_field_deleted} hsd WHERE hsd.entity_id = $measurement_entity_id AND hsd.field_deleted_value = 1)";
+function hedley_stats_exclude_deleted_from_join($on_condition, $entity_id) {
+  return "($on_condition) AND NOT EXISTS (SELECT 1 FROM {field_data_field_deleted} hsd WHERE hsd.entity_id = $entity_id AND hsd.field_deleted_value = 1)";
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -83,6 +83,7 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
    *   3. Session attendance (smoke check that the function runs).
    *   4. Stats-blob sync with cache-hash invalidation.
    *   5. Soft-deleted measurements are excluded from stats aggregates (B-032).
+   *   6. Soft-deleted persons are excluded from group education stats (B-033).
    */
   public function testStatsCalculations() {
     // 1. Total encounters.
@@ -291,6 +292,86 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->assertFalse(empty($encounter_after), 'Encounter is retained after its measurement is soft-deleted.');
     $this->assertTrue(empty($encounter_after['muac']), 'Soft-deleted MUAC is excluded from stats after recalculation.');
     $this->assertEqual(['edema'], $encounter_after['nutrition_signs'], 'Live nutrition sign is retained.');
+
+    // 6. Soft-deleted persons are excluded from group education stats (B-033).
+    //
+    // Merging a duplicate patient soft-deletes the duplicate person, but
+    // nothing re-points the education sessions that reference them. Those
+    // sessions kept counting the deleted person among their attendees, and
+    // shipped their name and gender to the dashboard.
+    $this->resetHealthCenter();
+    $live = $this->createMother($this->clinicId);
+    $duplicate = $this->createMother($this->clinicId);
+    $this->createEducationSession([$live, $duplicate]);
+
+    // Baseline: both attendees are counted, and both have details.
+    $patients_details = [];
+    hedley_stats_handle_cache(HEDLEY_STATS_CACHE_CLEAR, HEDLEY_STATS_SYNC_GROUP_EDUCATION_DATA, $this->healthCenterId);
+    $before = $this->extractEducationParticipants(hedley_stats_get_group_education_data($this->healthCenterId, $patients_details));
+    $this->assertEqual([$live, $duplicate], $before, 'Both attendees are counted before the merge.');
+    $this->assertFalse(empty($patients_details[$duplicate]), 'The duplicate has details before the merge.');
+
+    // Merge the duplicate away, as hedley_patient's merge flow does.
+    $duplicate_wrapper = entity_metadata_wrapper('node', $duplicate);
+    $duplicate_wrapper->field_deleted->set(TRUE);
+    $duplicate_wrapper->save();
+
+    // The session keeps its live attendee; the deleted person is neither
+    // counted nor described. Before the fix, both assertions failed.
+    $patients_details = [];
+    hedley_stats_handle_cache(HEDLEY_STATS_CACHE_CLEAR, HEDLEY_STATS_SYNC_GROUP_EDUCATION_DATA, $this->healthCenterId);
+    $after = $this->extractEducationParticipants(hedley_stats_get_group_education_data($this->healthCenterId, $patients_details));
+    $this->assertEqual([$live], $after, 'The soft-deleted attendee is no longer counted.');
+    $this->assertTrue(empty($patients_details[$duplicate]), 'The soft-deleted attendee\'s name is not shipped to the dashboard.');
+  }
+
+  /**
+   * Create an education session attended by the given persons.
+   *
+   * @param array $participants
+   *   Person node IDs attending the session.
+   *
+   * @return int
+   *   The education session node ID.
+   */
+  protected function createEducationSession(array $participants) {
+    $node = $this->drupalCreateNode(['type' => 'education_session']);
+
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $scheduled_date = date('Y-m-d', strtotime('-3 days'));
+    $wrapper->field_scheduled_date->set([
+      'value' => $scheduled_date,
+      'value2' => $scheduled_date,
+    ]);
+    $wrapper->field_education_topics->set(['malaria']);
+    $wrapper->field_participating_patients->set($participants);
+    $wrapper->field_shards->set([$this->healthCenterId]);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * Flatten the participant IDs out of a group-education stats structure.
+   *
+   * @param array $data
+   *   A hedley_stats_get_group_education_data() result: sessions by village.
+   *
+   * @return array
+   *   Sorted participant node IDs, as integers.
+   */
+  protected function extractEducationParticipants(array $data) {
+    $participants = [];
+    foreach ($data as $sessions) {
+      foreach ($sessions as $session) {
+        foreach ($session['participating_patients'] as $participant) {
+          $participants[] = (int) $participant;
+        }
+      }
+    }
+    sort($participants);
+
+    return $participants;
   }
 
   /**


### PR DESCRIPTION
Fixes #1935

## What was wrong

An education session's attendees were pulled with no soft-delete check, and every id that came back was `node_load`ed and handed to `hedley_stats_add_patient_details()`, which emits `name` and `gender`.

The live trigger is the duplicate-patient merge: it soft-deletes the duplicate person (which succeeds — education attendance is session-side, so it doesn't trip the person-delete guard), and **nothing re-points `field_participating_patients`** on the sessions referencing them. So the merged-away person kept being counted as an attendee, and their name kept being shipped to the dashboard, on every recalculation.

## The fix

Fold the exclusion into the participants JOIN's ON condition, reusing `hedley_stats_exclude_deleted_from_join()` — the helper the six measurement builders already use (B-032, #1909). In the ON clause rather than a WHERE, a deleted attendee is simply absent from the join; the session and its remaining attendees are untouched. (A session whose *only* attendee was merged away then has no participants, and the existing empty-participants guard skips it — which is right.)

The helper's docblock said "measurement" throughout. Persons reached through a reference field are a second, different case, so I reworded it to cover both rather than leave documentation that no longer matches its uses.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list).

**End-to-end discrimination against the real function** (`drush php-script`) — a session attended by one live person and one merged-away duplicate. `OLD` is the unpatched `hedley_stats_get_group_education_data()`; `NEW` is a verbatim copy of the patched one:

```
OLD  | attendees counted: 505,506      | deleted person's name shipped: YES -> "Fixture"
NEW  | attendees counted: 505          | deleted person's name shipped: no
```

**Regression test** added as scenario 6 inside the existing `testStatsCalculations()` method — *not* as a new test method, since each one reinstalls the whole profile (~5 min in CI); the class documents this and now has one more scenario rather than one more install. It asserts both halves: the deleted attendee is no longer counted, and their details are no longer emitted.

I ran the fixture against the **unpatched** tree first, and its assertions fail there — so the new scenario genuinely discriminates rather than passing vacuously. Two fixture bugs surfaced that way and were fixed before CI ever saw them (`field_scheduled_date` is a date range wanting a formatted `Y-m-d`, and `field_education_topics` is a `list_text` with allowed values, not an integer).

## Residual, deliberately not fixed here

The session node still *references* the deleted person; only the statistics ignore them now. Re-pointing `field_participating_patients` during a merge (a `_consolidate_education_session_content_execute` handler) is a change to the merge flow itself and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)