### PR TITLE
Progress report: fetch health centers on every page that renders one

### DIFF
--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/Fetch.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/Fetch.elm
@@ -2,7 +2,7 @@ module Pages.ChildScoreboard.ProgressReport.Fetch exposing (fetch)
 
 import AssocList as Dict
 import Backend.Entities exposing (..)
-import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb)
+import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..))
 import Pages.AcuteIllness.Participant.Fetch
 import Pages.ChildScoreboard.Encounter.Fetch
 import RemoteData
@@ -29,4 +29,8 @@ fetch id db =
                 maybePersonId
                 |> Maybe.withDefault []
     in
-    Pages.ChildScoreboard.Encounter.Fetch.fetch id db ++ fetchAcuteIllnessDataMsgs
+    -- See Pages.Nutrition.ProgressReport.Fetch: the Next Appointment pane needs
+    -- the health centers, and nothing else on this page fetches them.
+    FetchHealthCenters
+        :: Pages.ChildScoreboard.Encounter.Fetch.fetch id db
+        ++ fetchAcuteIllnessDataMsgs

--- a/client/src/elm/Pages/Nutrition/ProgressReport/Fetch.elm
+++ b/client/src/elm/Pages/Nutrition/ProgressReport/Fetch.elm
@@ -2,7 +2,7 @@ module Pages.Nutrition.ProgressReport.Fetch exposing (fetch)
 
 import AssocList as Dict
 import Backend.Entities exposing (..)
-import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb)
+import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..))
 import Pages.AcuteIllness.Participant.Fetch
 import Pages.Nutrition.Encounter.Fetch
 import RemoteData
@@ -29,4 +29,10 @@ fetch id db =
                 maybePersonId
                 |> Maybe.withDefault []
     in
-    Pages.Nutrition.Encounter.Fetch.fetch id db ++ fetchAcuteIllnessDataMsgs
+    -- The report's Next Appointment pane resolves the health center's name, so
+    -- the health centers have to be fetched here: CheckDataWanted drops them
+    -- once they go unwanted for 5 minutes, and nothing else on this page asks
+    -- for them again.
+    FetchHealthCenters
+        :: Pages.Nutrition.Encounter.Fetch.fetch id db
+        ++ fetchAcuteIllnessDataMsgs

--- a/client/src/elm/Pages/PatientRecord/Fetch.elm
+++ b/client/src/elm/Pages/PatientRecord/Fetch.elm
@@ -29,7 +29,11 @@ fetch currentDate personId db =
                     )
                 |> Maybe.withDefault []
     in
-    [ FetchPerson personId
+    -- See Pages.Nutrition.ProgressReport.Fetch: the child's report renders the
+    -- Next Appointment pane, which needs the health centers, and nothing else
+    -- on this page fetches them.
+    [ FetchHealthCenters
+    , FetchPerson personId
     , FetchRelationshipsForPerson personId
     , FetchEducationSessionsForPerson personId
     ]

--- a/client/src/elm/Pages/ProgressReport/Fetch.elm
+++ b/client/src/elm/Pages/ProgressReport/Fetch.elm
@@ -1,14 +1,17 @@
 module Pages.ProgressReport.Fetch exposing (fetch)
 
 import Backend.Entities exposing (..)
-import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb)
+import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..))
 import Backend.NutritionEncounter.Fetch
 import Pages.AcuteIllness.Participant.Fetch
 
 
 fetch : PersonId -> ModelIndexedDb -> ( List MsgIndexedDb, List MsgIndexedDb )
 fetch childId db =
-    ( (Backend.Model.FetchExpectedSessions childId
+    -- See Pages.Nutrition.ProgressReport.Fetch: the Next Appointment pane needs
+    -- the health centers, and nothing else on this page fetches them.
+    ( (FetchHealthCenters
+        :: Backend.Model.FetchExpectedSessions childId
         :: Backend.NutritionEncounter.Fetch.fetch childId db
       )
         ++ Pages.AcuteIllness.Participant.Fetch.fetch childId db

--- a/client/src/elm/Pages/ProgressReport/Test.elm
+++ b/client/src/elm/Pages/ProgressReport/Test.elm
@@ -1,0 +1,66 @@
+module Pages.ProgressReport.Test exposing (all)
+
+import Backend.Model exposing (ModelIndexedDb, MsgIndexedDb(..), emptyModelIndexedDb)
+import Date
+import Expect
+import Pages.ChildScoreboard.ProgressReport.Fetch
+import Pages.Nutrition.ProgressReport.Fetch
+import Pages.PatientRecord.Fetch
+import Pages.ProgressReport.Fetch
+import Pages.WellChild.ProgressReport.Fetch
+import Restful.Endpoint exposing (toEntityUuid)
+import Test exposing (Test, describe, test)
+import Time
+
+
+{-| Every progress report renders the Next Appointment pane, which resolves the
+health center's name out of `db.healthCenters`. Those are dropped by
+CheckDataWanted once they go unwanted for five minutes, so a report page that
+never asks for them renders the Location line blank - silently, on a clinical
+document that also gets shared over WhatsApp.
+
+Only the WellChild variant used to fetch them. These pin that every page which
+renders the report asks for them.
+
+-}
+all : Test
+all =
+    let
+        db : ModelIndexedDb
+        db =
+            emptyModelIndexedDb
+
+        currentDate =
+            Date.fromCalendarDate 2026 Time.Jul 14
+
+        asks msgs =
+            List.member FetchHealthCenters msgs
+    in
+    describe "progress report pages fetch the health centers"
+        [ test "WellChild (the one that always did)" <|
+            \_ ->
+                Pages.WellChild.ProgressReport.Fetch.fetch (toEntityUuid "encounter") db
+                    |> asks
+                    |> Expect.equal True
+        , test "Nutrition" <|
+            \_ ->
+                Pages.Nutrition.ProgressReport.Fetch.fetch (toEntityUuid "encounter") db
+                    |> asks
+                    |> Expect.equal True
+        , test "Child Scoreboard" <|
+            \_ ->
+                Pages.ChildScoreboard.ProgressReport.Fetch.fetch (toEntityUuid "encounter") db
+                    |> asks
+                    |> Expect.equal True
+        , test "Group (Pages.ProgressReport)" <|
+            \_ ->
+                Pages.ProgressReport.Fetch.fetch (toEntityUuid "child") db
+                    |> Tuple.first
+                    |> asks
+                    |> Expect.equal True
+        , test "Patient Record" <|
+            \_ ->
+                Pages.PatientRecord.Fetch.fetch currentDate (toEntityUuid "person") db
+                    |> asks
+                    |> Expect.equal True
+        ]


### PR DESCRIPTION
Fixes #1937

## What was wrong

The report's Next Appointment pane resolves the health center's name from the local database:

```elm
getHealthCenterName child.healthCenterId db |> Maybe.withDefault ""
```

Five pages render that report, but only `Pages/WellChild/ProgressReport/Fetch.elm` issued `FetchHealthCenters`. `CheckDataWanted` forgets data that has gone unwanted for five minutes and resets `healthCenters = NotAsked`, and nothing on the other four pages asks again — so `Maybe.withDefault ""` quietly prints an empty Location.

The nurse sees a blank Location on a clinical document (one that also gets shared over WhatsApp), with no error, and only after they have been in the app a while — which is exactly why it survives casual testing.

## The fix

Issue `FetchHealthCenters` from the four fetch modules that lack it — Nutrition, Child Scoreboard, the group `ProgressReport`, and Patient Record — mirroring the WellChild variant. `Backend/Fetch.elm` guards the fetch with `isNotAsked`, so it is free when the health centers are already loaded.

## Verification

- `elm make src/elm/Main.elm` — Success, 548 modules. `elm-format` clean, `elm-review` clean (cold run).
- `elm-test` — 2820 passed, including a new `Pages/ProgressReport/Test.elm`.

The fetch functions are pure (`ModelIndexedDb -> List MsgIndexedDb`), so the new tests assert the thing that actually broke: each of the five pages asks for the health centers. **Discrimination:** reverting the Nutrition page's fetch to its old body fails exactly that one test (`✗ Nutrition`, 2819/1) and leaves the other four passing; restored, all 2820 green.

While checking the anchors I confirmed the affected set is exactly these five pages: Tuberculosis, Acute Illness and Family Nutrition import other helpers from that module but do not call `viewProgressReport`, so they render no Next Appointment pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)