### PR TITLE
Sync: send empty multi-value fields as null, not as [""]

### DIFF
--- a/client/src/elm/Backend/EducationSession/Test.elm
+++ b/client/src/elm/Backend/EducationSession/Test.elm
@@ -1,15 +1,20 @@
 module Backend.EducationSession.Test exposing (all)
 
 import AssocList as Dict exposing (Dict)
+import Backend.EducationSession.Decoder exposing (decodeEducationSession)
 import Backend.EducationSession.Model exposing (EducationSession, EducationTopic(..), Msg(..))
 import Backend.EducationSession.Utils exposing (applyUpdateToSessions)
 import Backend.Entities exposing (EducationSessionId, PersonId)
+import Backend.NCDEncounter.Decoder exposing (decodeNCDEncounter)
+import Backend.NCDEncounter.Types exposing (NCDDiagnosis(..))
+import Backend.NutritionEncounter.Decoder exposing (decodeNutritionEncounter)
 import Date
 import EverySet
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
+import Json.Decode exposing (decodeString)
 import RemoteData exposing (RemoteData(..), WebData)
-import Restful.Endpoint exposing (toEntityUuid)
+import Restful.Endpoint exposing (fromEntityUuid, toEntityUuid)
 import Test exposing (Test, describe, test)
 import Time
 
@@ -17,7 +22,97 @@ import Time
 all : Test
 all =
     describe "Backend.EducationSession"
-        [ applyUpdateToSessionsTests ]
+        [ applyUpdateToSessionsTests
+        , emptyMultiValueFieldTests
+        ]
+
+
+{-| The server used to run an unguarded `explode(',', ...)` over multi-value
+fields. A field with no values arrives from GROUP\_CONCAT as NULL, and exploding
+NULL yields a single empty string, so an empty field synced as `[""]` instead of
+as nothing at all.
+
+For the enum fields that stayed invisible - their decoders drop the unparseable
+"" - but `decodeEntityUuid` accepts "", and an education session is created
+empty the moment the nurse begins it. So every device received a session with a
+phantom empty-string participant in it.
+
+The server now sends `null` for an empty field. These pin that each affected
+decoder reads `null` exactly as it read the old `[""]`: the phantom participant
+is gone, and the encounter fields are unchanged.
+
+-}
+emptyMultiValueFieldTests : Test
+emptyMultiValueFieldTests =
+    describe "empty multi-value fields"
+        [ test "OLD payload: [\"\"] put a phantom empty UUID in the participant set" <|
+            \_ ->
+                decodeString decodeEducationSession (educationSessionJson "[\"\"]")
+                    |> Result.map (.participants >> EverySet.toList >> List.map fromEntityUuid)
+                    |> Expect.equal (Ok [ "" ])
+        , test "NEW payload: null decodes to no participants at all" <|
+            \_ ->
+                decodeString decodeEducationSession (educationSessionJson "null")
+                    |> Result.map (.participants >> EverySet.isEmpty)
+                    |> Expect.equal (Ok True)
+        , test "NCD diagnoses: null reads the same as the old [\"\"]" <|
+            \_ ->
+                let
+                    decodeDiagnoses payload =
+                        decodeString decodeNCDEncounter (ncdEncounterJson payload)
+                            |> Result.map .diagnoses
+                in
+                ( decodeDiagnoses "[\"\"]", decodeDiagnoses "null" )
+                    |> Expect.equal
+                        ( Ok (EverySet.singleton NoNCDDiagnosis)
+                        , Ok (EverySet.singleton NoNCDDiagnosis)
+                        )
+        , test "skipped forms: null reads the same as the old [\"\"]" <|
+            \_ ->
+                let
+                    decodeSkipped payload =
+                        decodeString decodeNutritionEncounter (nutritionEncounterJson payload)
+                            |> Result.map (.skippedForms >> EverySet.isEmpty)
+                in
+                ( decodeSkipped "[\"\"]", decodeSkipped "null" )
+                    |> Expect.equal ( Ok True, Ok True )
+        ]
+
+
+educationSessionJson : String -> String
+educationSessionJson participants =
+    """
+    { "scheduled_date": { "value": "2026-07-14" }
+    , "nurse": "nurse-uuid"
+    , "village_ref": "village-uuid"
+    , "education_topics": null
+    , "participating_patients": """ ++ participants ++ """
+    , "deleted": false
+    }
+    """
+
+
+ncdEncounterJson : String -> String
+ncdEncounterJson diagnoses =
+    """
+    { "individual_participant": "participant-uuid"
+    , "scheduled_date": { "value": "2026-07-14" }
+    , "ncd_diagnoses": """ ++ diagnoses ++ """
+    , "deleted": false
+    }
+    """
+
+
+nutritionEncounterJson : String -> String
+nutritionEncounterJson skippedForms =
+    """
+    { "individual_participant": "participant-uuid"
+    , "scheduled_date": { "value": "2026-07-14" }
+    , "nutrition_encounter_type": "nurse"
+    , "skipped_forms": """ ++ skippedForms ++ """
+    , "deleted": false
+    }
+    """
 
 
 

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/encounter/HedleyRestfulIndividualEncounter.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/encounter/HedleyRestfulIndividualEncounter.class.php
@@ -120,8 +120,12 @@ class HedleyRestfulIndividualEncounter extends HedleyRestfulSyncBase {
       unset($item->field_scheduled_date_field_scheduled_date_value2);
 
       foreach ($this->multiFields as $field_name) {
+        // An encounter starts with none of these set (no diagnoses, no skipped
+        // forms), so guard the explode: without it an empty field syncs as a
+        // single empty string instead of nothing at all. Same guard as
+        // HedleyRestfulActivityBase.
         $public_name = str_replace('field_', '', $field_name);
-        $item->{$public_name} = explode(',', $item->{$public_name});
+        $item->{$public_name} = !empty($item->{$public_name}) ? explode(',', $item->{$public_name}) : NULL;
       }
 
       foreach ($this->dateFields as $field_name) {

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/session/HedleyRestfulEducationSession.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/session/HedleyRestfulEducationSession.class.php
@@ -105,11 +105,17 @@ class HedleyRestfulEducationSession extends HedleyRestfulSyncBase {
       unset($item->uuid_nurse);
 
       $item->village_ref = $item->uuid_village_ref;
-      unset($item->uuid_individual_participant);
+      unset($item->uuid_village_ref);
 
-      $item->education_topics = explode(',', $item->education_topics);
+      // A session is created empty - the client POSTs it the moment the nurse
+      // begins the encounter - so both of these are routinely NULL here, and an
+      // unguarded explode() would turn that into a single empty string. The
+      // empty topic is dropped by the client's decoder, but an empty
+      // participant UUID is accepted, and lands in the session's participant
+      // set. NULL instead: the decoder's `optional` falls back to an empty set.
+      $item->education_topics = !empty($item->education_topics) ? explode(',', $item->education_topics) : NULL;
 
-      $item->participating_patients = explode(',', $item->uuids_participating_patients);
+      $item->participating_patients = !empty($item->uuids_participating_patients) ? explode(',', $item->uuids_participating_patients) : NULL;
       unset($item->uuids_participating_patients);
 
       unset($item->label);


### PR DESCRIPTION
Fixes #1939

## What was wrong

`explode(',', NULL)` returns `[""]`. A multi-value field with no values arrives from `GROUP_CONCAT` as `NULL`, so an empty field synced as a list holding one empty string. `HedleyRestfulActivityBase` guards this (`!empty(...) ? explode(...) : NULL`); `HedleyRestfulEducationSession` and `HedleyRestfulIndividualEncounter` did not.

For enum fields it stayed invisible, because the client's decoders drop the unparseable `""`. But `decodeEntityUuid` **accepts** `""`, and an education session is created empty — the client POSTs it the instant the nurse taps "begin encounter". So every device received that session with a phantom empty-string participant in its participant set.

Also fixed: `unset($item->uuid_individual_participant)` — a copy-paste slip — instead of `unset($item->uuid_village_ref)`, which was leaking the raw field into the payload.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list). `elm make` 548 modules, `elm-format` + `elm-review` clean, `elm-test` 2819 passed.

**Server: the real RESTful handler**, driven over a session created exactly the way the client creates one. `NEW` is the patched class, run in its own process so neither handler ever sees an item the other transformed:

```
OLD  | empty session      | education_topics = [""]        | participating_patients = [""]                | uuid_village_ref leaked: YES
NEW  | empty session      | education_topics = null        | participating_patients = null                | uuid_village_ref leaked: no
OLD  | session with data  | education_topics = ["malaria"] | participating_patients = ["a6e9c4a5-…"]      | uuid_village_ref leaked: YES
NEW  | session with data  | education_topics = ["malaria"] | participating_patients = ["a6e9c4a5-…"]      | uuid_village_ref leaked: no
```

The bottom two rows are the ones that matter for safety: a session with real data syncs exactly as before.

**Client: the payload change is safe, and that is now pinned by tests** (4 new, in `Backend/EducationSession/Test.elm`). They assert the old payload's phantom (`[""]` → a `""` UUID in the participant set), that `null` decodes to no participants at all, and — for the encounter fields this also touches — that `null` reads *identically* to the old `[""]`: NCD diagnoses still come out as `NoNCDDiagnosis`, skipped forms still empty. So no encounter behaviour changes.

## Note on the other unguarded `explode` sites

`HedleyRestfulNurses` (role / health_centers / villages), `HedleyRestfulCounselingSchedule` and `HedleyRestfulCounselingSessions` share the pattern, but their fields are never empty in practice (a nurse always has a role; counseling topics are migration-created). I left them alone rather than change payload shapes with no reachable trigger — flagging them here rather than silently widening the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)