### PR TITLE
Patient merge: declare every person-reference field in one place, and guard it

### DIFF
--- a/server/hedley/modules/custom/hedley_admin/tests/HedleyAdminIntegrityTests.test
+++ b/server/hedley/modules/custom/hedley_admin/tests/HedleyAdminIntegrityTests.test
@@ -61,6 +61,7 @@ class HedleyAdminIntegrityTests extends HedleyWebTestBase {
    *   3. Node deletion -- forbidden across the board (devices used
    *      as the example).
    *   4. Session unpublishing -- forbidden.
+   *   5. Person association fields -- the canonical list is complete.
    */
   public function testIntegrityInvariants() {
     // 1. Device pairing code.
@@ -150,6 +151,56 @@ class HedleyAdminIntegrityTests extends HedleyWebTestBase {
     catch (Exception $e) {
       $this->assertEqual($e->getMessage(), 'Content unpublishing is forbidden!');
     }
+
+    // 5. The canonical person-association-field list is complete.
+    $this->checkPersonAssociationFieldsAreComplete();
+  }
+
+  /**
+   * Every field that can reference a person is declared as such.
+   *
+   * The patient merge, the shard recalculation and the delete cascade all
+   * follow references to a person. They used to carry their own hardcoded
+   * lists, so a newly introduced reference field escaped all of them at once,
+   * silently - which is how education sessions ended up still pointing at
+   * merged-away patients.
+   *
+   * Declaring a field in hedley_general_get_person_association_fields() does
+   * not by itself make those subsystems handle it, but it does mean nobody can
+   * add one without being told to think about them: this fails the build.
+   *
+   * Called from testIntegrityInvariants() rather than being a test method of
+   * its own, so that it shares that method's install.
+   */
+  protected function checkPersonAssociationFieldsAreComplete() {
+    $referencing_person = [];
+    foreach (field_info_fields() as $field_name => $field) {
+      if ($field['type'] !== 'entityreference') {
+        continue;
+      }
+
+      $target_bundles = [];
+      if (isset($field['settings']['handler_settings']['target_bundles'])) {
+        $target_bundles = array_keys($field['settings']['handler_settings']['target_bundles']);
+      }
+
+      if (in_array('person', $target_bundles)) {
+        $referencing_person[] = $field_name;
+      }
+    }
+
+    $declared = hedley_general_get_person_association_fields();
+    sort($referencing_person);
+    sort($declared);
+
+    $this->assertEqual(
+      $referencing_person,
+      $declared,
+      format_string('Every person-referencing field is declared. Found: @found. Declared: @declared.', [
+        '@found' => implode(', ', $referencing_person),
+        '@declared' => implode(', ', $declared),
+      ])
+    );
   }
 
 }

--- a/server/hedley/modules/custom/hedley_general/hedley_general.module
+++ b/server/hedley/modules/custom/hedley_general/hedley_general.module
@@ -182,6 +182,50 @@ function hedley_general_get_person_measurements($person_id, array $measurement_t
 }
 
 /**
+ * Every field through which content references a person.
+ *
+ * This is the single list of the ways a person can be pointed at. It exists
+ * because the subsystems that have to follow those references - the patient
+ * merge, the shard recalculation, the delete cascade - each used to carry
+ * their own hardcoded subset, so a newly introduced reference field could
+ * (and did) escape all of them at once, silently.
+ *
+ * Adding a new field that references a person? Add it here, and then decide,
+ * explicitly, what each of these should do with it:
+ *
+ *   - hedley_patient_consolidate_patients() - the patient merge: content of
+ *     the duplicate has to be re-pointed at the original, or it is lost when
+ *     the duplicate is marked deleted.
+ *   - hedley_person_content_affected_by_deletion() - the delete cascade.
+ *   - hedley_patient_recalculate_shards_for_person_content() - shard recalc.
+ *
+ * Those consumers deliberately use subsets of this list; each one documents
+ * what it leaves out and why. HedleyAdminIntegrityTests asserts that this
+ * list stays complete, so a new reference field fails the build until it has
+ * been considered here.
+ *
+ * @return array
+ *   List of field names.
+ */
+function hedley_general_get_person_association_fields() {
+  return [
+    // Measurements, participants (group, individual and family), relationships
+    // and WhatsApp records all point at their person with this.
+    'field_person',
+    // The adult side of a group (PMTCT) participation.
+    'field_adult',
+    // The other side of a relationship.
+    'field_related_to',
+    // An education session's attendees.
+    'field_participating_patients',
+    // The child a pregnancy resulted in, held by the mother's participant.
+    'field_newborn',
+    // The person an acute illness trace contact refers to.
+    'field_referred_person',
+  ];
+}
+
+/**
  * Resolves all content associated with person using association fields.
  *
  * For example, 'field_person' associates all measurements taken for person.

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.module
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.module
@@ -155,11 +155,19 @@ function hedley_patient_recalculate_shards_for_person_content($person_id) {
   // using person, adult and related_to fields.
   // These are group and individual measurements, relationships,
   // and group and individual participants.
-  $association_fields = [
-    'field_person',
-    'field_adult',
-    'field_related_to',
-  ];
+  //
+  // The remaining person-reference fields are deliberately left out: an
+  // education session's shards follow its health center, a pregnancy
+  // participant's follow the mother, and a trace contact's follow the
+  // encounter it was taken at - none of them follow this person.
+  $association_fields = array_values(array_diff(
+    hedley_general_get_person_association_fields(),
+    [
+      'field_participating_patients',
+      'field_newborn',
+      'field_referred_person',
+    ]
+  ));
   $entries = hedley_general_get_person_content_associated_by_fields($person_id, $association_fields);
 
   $ids = $individual_participants = [];

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.module
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.module
@@ -156,10 +156,11 @@ function hedley_patient_recalculate_shards_for_person_content($person_id) {
   // These are group and individual measurements, relationships,
   // and group and individual participants.
   //
-  // The remaining person-reference fields are deliberately left out: an
-  // education session's shards follow its health center, a pregnancy
-  // participant's follow the mother, and a trace contact's follow the
-  // encounter it was taken at - none of them follow this person.
+  // The remaining person-reference fields are deliberately left out, because
+  // the content they point from does not take its shards from this person:
+  // an education session takes its shards from its health center, a pregnancy
+  // participant takes them from the parent, and a trace contact takes them
+  // from the encounter it was recorded at.
   $association_fields = array_values(array_diff(
     hedley_general_get_person_association_fields(),
     [

--- a/server/hedley/modules/custom/hedley_person/hedley_person.module
+++ b/server/hedley/modules/custom/hedley_person/hedley_person.module
@@ -1541,11 +1541,27 @@ function hedley_person_load_individual_encounter_measurements_ids($nid, $bundle 
  *   List of nodes IDs to be marked as deleted.
  */
 function hedley_person_content_affected_by_deletion($person_id) {
-  $association_fields = [
-    'field_person',
-    'field_adult',
-    'field_related_to',
-  ];
+  // Of all the ways a person can be referenced, only the ones below point at
+  // content that belongs TO this person, and so should follow them into
+  // deletion. The rest are deliberately left out:
+  //
+  //   - field_participating_patients: the education session belongs to the
+  //     health center, not to one of its attendees.
+  //   - field_newborn: that reference is held by the parent's pregnancy
+  //     participant, so deleting the child must not delete that pregnancy.
+  //   - field_referred_person: the trace contact belongs to the encounter of
+  //     the index patient, not to the person it refers to.
+  //
+  // Those references are simply left pointing at a deleted person - see the
+  // patient-merge gaps they cause.
+  $association_fields = array_values(array_diff(
+    hedley_general_get_person_association_fields(),
+    [
+      'field_participating_patients',
+      'field_newborn',
+      'field_referred_person',
+    ]
+  ));
   $entries = hedley_general_get_person_content_associated_by_fields($person_id, $association_fields);
 
   $bundles = [


### PR DESCRIPTION
Fixes #1941

## What was wrong

Three subsystems follow references to a person — the patient merge, the shard recalculation, and the delete cascade — and each carried its own hardcoded list of fields to follow. The shard recalc and the cascade both used `[field_person, field_adult, field_related_to]`; the merge used neither, discovering content by measurement bundle instead.

Six fields actually reference a person. Three of them — `field_participating_patients` (education sessions), `field_newborn` (a pregnancy's child), `field_referred_person` (trace contacts) — appeared in **no** list, and so escaped all three subsystems at once. That is how education sessions ended up still pointing at merged-away patients (#1935), and the same thing will happen to the next reference field someone adds.

## The change

`hedley_general_get_person_association_fields()` now names all six in one place. The shard recalculation and the delete cascade derive their lists from it and state, explicitly, what they leave out and why — an education session belongs to its health center, not to an attendee; `field_newborn` is held by the *parent's* participant, so deleting a child must not delete that pregnancy; a trace contact belongs to the index patient's encounter.

**This changes no behaviour.** Both consumers end up with exactly the fields they hardcoded before — verified, not assumed:

```
consumers unchanged: derived = [field_person, field_adult, field_related_to]
                     old     = [field_person, field_adult, field_related_to]
                     IDENTICAL: YES
```

## The guard is the point

A new scenario in `HedleyAdminIntegrityTests` walks the field configuration, collects every `entityreference` field that can target a `person`, and asserts the canonical list matches. Declaring a field does not by itself make the three subsystems handle it — but nobody can now add one without being told to think about them, because the build stops.

Verified against the real field config:

```
guard today:  found = [field_adult, field_newborn, field_participating_patients, field_person, field_referred_person, field_related_to]
              declared = (the same six)  -> PASSES

drop one declaration (simulating an undeclared new field):  -> FAILS as intended, the build stops
```

It went into the existing `testIntegrityInvariants()` method as scenario 5, not a new test method — each one reinstalls the profile (~5 min in CI), and that class exists precisely to keep the install paid once.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list).

This is the groundwork for the merge gaps themselves (#1935's root cause, and relationships being destroyed rather than transferred on merge — 71k relationships live). Those fixes now have a single place to work from, instead of adding a fourth hardcoded list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)