### PR TITLE
Reports: reload person node before writing reports data (lost-update fix)

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -1326,6 +1326,19 @@ function hedley_reports_calculate_aggregated_data_for_person($person) {
   }
 
   $encoded_data = json_encode($data);
+
+  // Assembling the data above may take seconds (hundreds of node loads), during
+  // which the person node could have been updated (device sync, admin edit), or
+  // the NCDA worker could have written its own aggregate to it. node_save()
+  // writes back every field of the object it's given, so saving the copy we
+  // started with would revert those updates. Reload before mutating, to keep
+  // the window between read and write as short as possible.
+  $person = node_load($person->nid, NULL, TRUE);
+  if (!$person) {
+    // Person was deleted while we were calculating.
+    return FALSE;
+  }
+
   $person->field_reports_data[LANGUAGE_NONE][0]['value'] = $encoded_data;
   node_save($person);
 


### PR DESCRIPTION
Fixes #1943

## What was wrong

`hedley_reports.module:1329` is byte-for-byte the pattern fixed in `hedley_ncda` by #1930: the worker loads the person, spends seconds assembling the aggregate from hundreds of nodes, then writes `field_reports_data` onto **that stale copy** and `node_save()`s the whole node.

Two victims:

1. **Person edits.** A device syncing a name/birthdate/geo PATCH, or an admin edit, is silently reverted — and the revision bump propagates the reverted person to every device. This is #1930's bug, still live in `hedley_reports`. It needs **no queue concurrency at all**: one Reports worker running alongside normal device sync is enough.
2. **The NCDA aggregate.** NCDA and Reports are co-enqueued on every triggering measurement write, so if NCDA finishes while Reports is assembling, its freshly computed `field_ncda_data` gets reverted to the pre-computation snapshot. That is the cross-worker half of B-058.

## The fix

Reload the node immediately before the mutation, mirroring #1930. The person-edit revert is closed outright; the cross-worker window shrinks from seconds to microseconds.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list).

**Discrimination against the real function** (`drush php-script`, person 64) — a person edit *and* an NCDA aggregate write both commit while the Reports worker is assembling. `OLD` is the unpatched function; `NEW` a verbatim copy of the patched one:

```
OLD  | person edit: REVERTED ("Yvan") | NCDA aggregate: REVERTED (clobbered) | reports data written: yes
NEW  | person edit: PRESERVED         | NCDA aggregate: PRESERVED            | reports data written: yes
```

Both paths still write the reports data, so the aggregation itself is unaffected.

## Deliberately not fixed here

The heavier half of B-058 — targeted single-field writes, or serialising the NCDA and Reports tasks per person — is left out. It only pays off if production really does run concurrent queue processes (a plain crontab whose runs overrun the 5-minute interval, or ad-hoc operator drush); under a Jenkins-driven serialized run it buys almost nothing. That is an ops question, and it should not hold up the half above, which is a live data-loss bug regardless of scheduling.

Like #1930, this is a window-shrink, not an atomic write: Drupal 7 has no single-field save through the entity API, and a direct `db_update()` on the field table would bypass revisions and hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)