### PR TITLE
Patient merge: transfer the duplicate patient's relationships

### DIFF
--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -303,6 +303,12 @@ function _consolidate_patient_relationships($original, $duplicate) {
 
     $wrapper->field_person->set($new_person);
     $wrapper->field_related_to->set($new_related_to);
+    // Clear the shards so the presave hook recomputes them from the new
+    // endpoints. hedley_device_assign_shards() leaves an already-populated
+    // field alone, so without this the relationship keeps the duplicate's
+    // shards and misses any the original has but the duplicate did not - and
+    // the transferred link would not reach all of the original's devices.
+    $wrapper->field_shards->set([]);
     $wrapper->save();
     // A later relationship of the duplicate might now duplicate this one.
     $existing[$key] = TRUE;

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -224,12 +224,147 @@ function _consolidate_patients_execute($original, $duplicate) {
     }
   }
 
+  // Relationships are not measurements, so the loop above never sees them.
+  // Re-point them before the duplicate is marked deleted: once they point at
+  // the original (a live person), the delete cascade - which soft-deletes the
+  // relationships that still reference the duplicate - leaves them alone.
+  $messages[] = _consolidate_patient_relationships($original, $duplicate);
+
   // Mark duplicate patient as Deleted.
   $wrapper_duplicate->field_deleted->set(TRUE);
   $wrapper_duplicate->save();
 
   $messages[] = 'SUCCESS! All consolidations completed!';
   return $messages;
+}
+
+/**
+ * Re-points the duplicate patient's relationships onto the original patient.
+ *
+ * A relationship is one node - field_person (the parent/caregiver) is related
+ * to field_related_to (the child/cared-for) by field_related_by. A person
+ * appears as field_person when they are the adult and as field_related_to when
+ * they are the child, so the duplicate may sit on either side.
+ *
+ * For each of the duplicate's relationships we move its side to the original,
+ * except:
+ *   - a relationship that would then point the original at itself (the two
+ *     patients were directly related) is redundant, so it is deleted;
+ *   - a relationship the original already holds (same other person, same
+ *     relation, same direction) would be a duplicate, so it is deleted.
+ *
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_patient_relationships($original, $duplicate) {
+  // The duplicate's relationships, from either side. The helper already
+  // excludes deleted content.
+  $entries = hedley_general_get_person_content_associated_by_fields($duplicate, [
+    'field_person',
+    'field_related_to',
+  ]);
+  $relationship_ids = [];
+  foreach ($entries as $entry) {
+    if ($entry->bundle === 'relationship') {
+      $relationship_ids[$entry->entity_id] = $entry->entity_id;
+    }
+  }
+
+  // The relationships the original already holds, keyed so we can spot a
+  // would-be duplicate. The key is person + related_by + related_to.
+  $existing = [];
+  foreach (_hedley_patient_relationships_for_person($original) as $relationship_id) {
+    $wrapper = entity_metadata_wrapper('node', $relationship_id);
+    $key = _hedley_patient_relationship_key(
+      $wrapper->field_person->getIdentifier(),
+      $wrapper->field_related_by->value(),
+      $wrapper->field_related_to->getIdentifier()
+    );
+    $existing[$key] = TRUE;
+  }
+
+  $repointed = $dropped = 0;
+  foreach ($relationship_ids as $relationship_id) {
+    $wrapper = entity_metadata_wrapper('node', $relationship_id);
+    $person = $wrapper->field_person->getIdentifier();
+    $related_to = $wrapper->field_related_to->getIdentifier();
+
+    // Move whichever side is the duplicate onto the original.
+    $new_person = ($person == $duplicate) ? $original : $person;
+    $new_related_to = ($related_to == $duplicate) ? $original : $related_to;
+
+    $key = _hedley_patient_relationship_key($new_person, $wrapper->field_related_by->value(), $new_related_to);
+
+    if ($new_person == $new_related_to || isset($existing[$key])) {
+      // Self-referential (the two patients were related to each other) or a
+      // relationship the original already has - either way, redundant.
+      $wrapper->field_deleted->set(TRUE);
+      $wrapper->save();
+      $dropped++;
+      continue;
+    }
+
+    $wrapper->field_person->set($new_person);
+    $wrapper->field_related_to->set($new_related_to);
+    $wrapper->save();
+    // A later relationship of the duplicate might now duplicate this one.
+    $existing[$key] = TRUE;
+    $repointed++;
+  }
+
+  return format_string('Relationships: @repointed re-pointed to the original, @dropped dropped as redundant.', [
+    '@repointed' => $repointed,
+    '@dropped' => $dropped,
+  ]);
+}
+
+/**
+ * All non-deleted relationship node IDs a person takes part in, either side.
+ *
+ * @param int $person_id
+ *   Node ID of the person.
+ *
+ * @return array
+ *   Relationship node IDs.
+ */
+function _hedley_patient_relationships_for_person($person_id) {
+  $entries = hedley_general_get_person_content_associated_by_fields($person_id, [
+    'field_person',
+    'field_related_to',
+  ]);
+
+  $ids = [];
+  foreach ($entries as $entry) {
+    if ($entry->bundle === 'relationship') {
+      $ids[$entry->entity_id] = $entry->entity_id;
+    }
+  }
+
+  return $ids;
+}
+
+/**
+ * Builds a comparison key identifying a relationship by its content.
+ *
+ * @param int $person_id
+ *   The field_person target.
+ * @param string $related_by
+ *   The field_related_by value.
+ * @param int $related_to_id
+ *   The field_related_to target.
+ *
+ * @return string
+ *   The key.
+ */
+function _hedley_patient_relationship_key($person_id, $related_by, $related_to_id) {
+  return implode(':', [$person_id, $related_by, $related_to_id]);
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -264,18 +264,8 @@ function _consolidate_patients_execute($original, $duplicate) {
  * @throws EntityMetadataWrapperException
  */
 function _consolidate_patient_relationships($original, $duplicate) {
-  // The duplicate's relationships, from either side. The helper already
-  // excludes deleted content.
-  $entries = hedley_general_get_person_content_associated_by_fields($duplicate, [
-    'field_person',
-    'field_related_to',
-  ]);
-  $relationship_ids = [];
-  foreach ($entries as $entry) {
-    if ($entry->bundle === 'relationship') {
-      $relationship_ids[$entry->entity_id] = $entry->entity_id;
-    }
-  }
+  // The duplicate's relationships, from either side.
+  $relationship_ids = _hedley_patient_relationships_for_person($duplicate);
 
   // The relationships the original already holds, keyed so we can spot a
   // would-be duplicate. The key is person + related_by + related_to.

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.info
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.info
@@ -2,6 +2,7 @@ name = Hedley Patient
 description = Mother and Child related code.
 core = 7.x
 package = Hedley
+files[] = tests/HedleyPatientConsolidation.test
 dependencies[] = ctools
 dependencies[] = date
 dependencies[] = entityreference

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * @file
+ * Tests for the patient-merge (consolidation) flow.
+ */
+
+/**
+ * HedleyPatientConsolidation.
+ *
+ * Exercises how merging a duplicate patient into an original moves the
+ * duplicate's content onto the original.
+ */
+class HedleyPatientConsolidation extends HedleyWebTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp([
+      'hedley_patient',
+      'hedley_person',
+    ]);
+
+    // The merge helpers live in the drush include.
+    module_load_include('inc', 'hedley_patient', 'hedley_patient.drush');
+  }
+
+  /**
+   * Info hook.
+   */
+  public static function getInfo() {
+    return [
+      'name' => 'HedleyPatientConsolidation tests',
+      'description' => 'Tests the patient-merge (consolidation) flow.',
+      'group' => 'Hedley',
+    ];
+  }
+
+  /**
+   * Creates a bare person node.
+   *
+   * @param string $name
+   *   The first name, for readable failures.
+   *
+   * @return int
+   *   The person node ID.
+   */
+  protected function createPerson($name) {
+    $node = $this->drupalCreateNode(['type' => 'person']);
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_first_name->set($name);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * The live relationships a person takes part in, as person:by:related_to.
+   *
+   * @param int $person_id
+   *   The person node ID.
+   *
+   * @return array
+   *   Sorted triples describing each live relationship.
+   */
+  protected function relationshipTriples($person_id) {
+    $triples = [];
+    foreach (_hedley_patient_relationships_for_person($person_id) as $id) {
+      $wrapper = entity_metadata_wrapper('node', $id);
+      $triples[] = implode(':', [
+        $wrapper->field_person->getIdentifier(),
+        $wrapper->field_related_by->value(),
+        $wrapper->field_related_to->getIdentifier(),
+      ]);
+    }
+    sort($triples);
+
+    return $triples;
+  }
+
+  /**
+   * Merging a duplicate transfers, dedupes and prunes its relationships.
+   *
+   * All four cases operate on disjoint people, so bundling them under one test
+   * method keeps the hedley-profile install (~5 min in CI) paid once. Each
+   * calls _consolidate_patient_relationships() directly - the piece that used
+   * to be missing, so the delete cascade destroyed these links instead.
+   */
+  public function testRelationshipsAreTransferredOnMerge() {
+    // 1. A duplicate child's link to its mother moves to the original child.
+    $mother = $this->createPerson('Mother');
+    $originalChild = $this->createPerson('OriginalChild');
+    $duplicateChild = $this->createPerson('DuplicateChild');
+    $this->createRelationship($mother, $duplicateChild, 'parent');
+
+    _consolidate_patient_relationships($originalChild, $duplicateChild);
+
+    $this->assertEqual(
+      $this->relationshipTriples($originalChild),
+      [implode(':', [$mother, 'parent', $originalChild])],
+      'The mother link is transferred to the original child.'
+    );
+
+    // 2. When the original already holds the same link, it is not duplicated.
+    $mother = $this->createPerson('Mother2');
+    $originalChild = $this->createPerson('OriginalChild2');
+    $duplicateChild = $this->createPerson('DuplicateChild2');
+    $this->createRelationship($mother, $originalChild, 'parent');
+    $this->createRelationship($mother, $duplicateChild, 'parent');
+
+    _consolidate_patient_relationships($originalChild, $duplicateChild);
+
+    $this->assertEqual(
+      $this->relationshipTriples($originalChild),
+      [implode(':', [$mother, 'parent', $originalChild])],
+      'A relationship the original already holds is not duplicated.'
+    );
+
+    // 3. A relationship between the two merged patients is dropped, not turned
+    // into the original pointing at itself.
+    $originalChild = $this->createPerson('OriginalChild3');
+    $duplicateChild = $this->createPerson('DuplicateChild3');
+    $this->createRelationship($originalChild, $duplicateChild, 'caregiver');
+
+    _consolidate_patient_relationships($originalChild, $duplicateChild);
+
+    $this->assertEqual(
+      $this->relationshipTriples($originalChild),
+      [],
+      'A relationship between the two patients being merged is dropped.'
+    );
+
+    // 4. When the duplicate is the adult, its link to a child moves too.
+    $originalMother = $this->createPerson('OriginalMother4');
+    $duplicateMother = $this->createPerson('DuplicateMother4');
+    $child = $this->createPerson('Child4');
+    $this->createRelationship($duplicateMother, $child, 'parent');
+
+    _consolidate_patient_relationships($originalMother, $duplicateMother);
+
+    $this->assertEqual(
+      $this->relationshipTriples($originalMother),
+      [implode(':', [$originalMother, 'parent', $child])],
+      'The duplicate adult\'s link to a child is transferred.'
+    );
+  }
+
+}

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -50,6 +50,10 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
     $node = $this->drupalCreateNode(['type' => 'person']);
     $wrapper = entity_metadata_wrapper('node', $node);
     $wrapper->field_first_name->set($name);
+    // field_second_name is required on the person bundle. node_save() does not
+    // enforce that (Drupal 7 skips field validation on programmatic save), but
+    // set it anyway so the person gets a proper title, as createMother does.
+    $wrapper->field_second_name->set('Test');
     $wrapper->save();
 
     return $node->nid;

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -42,11 +42,13 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
    *
    * @param string $name
    *   The first name, for readable failures.
+   * @param array $shards
+   *   Optional; health center node IDs to assign as the person's shards.
    *
    * @return int
    *   The person node ID.
    */
-  protected function createPerson($name) {
+  protected function createPerson($name, array $shards = []) {
     $node = $this->drupalCreateNode(['type' => 'person']);
     $wrapper = entity_metadata_wrapper('node', $node);
     $wrapper->field_first_name->set($name);
@@ -54,9 +56,30 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
     // enforce that (Drupal 7 skips field validation on programmatic save), but
     // set it anyway so the person gets a proper title, as createMother does.
     $wrapper->field_second_name->set('Test');
+    if (!empty($shards)) {
+      $wrapper->field_shards->set($shards);
+    }
     $wrapper->save();
 
     return $node->nid;
+  }
+
+  /**
+   * The shard (health center) node IDs assigned to a node.
+   *
+   * @param int $nid
+   *   The node ID.
+   *
+   * @return array
+   *   Sorted shard node IDs.
+   */
+  protected function shardsOf($nid) {
+    $shards = entity_metadata_wrapper('node', node_load($nid, NULL, TRUE))
+      ->field_shards->value(['identifier' => TRUE]);
+    $shards = empty($shards) ? [] : $shards;
+    sort($shards);
+
+    return $shards;
   }
 
   /**
@@ -86,7 +109,7 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   /**
    * Merging a duplicate transfers, dedupes and prunes its relationships.
    *
-   * All four cases operate on disjoint people, so bundling them under one test
+   * All cases operate on disjoint people, so bundling them under one test
    * method keeps the hedley-profile install (~5 min in CI) paid once. Each
    * calls _consolidate_patient_relationships() directly - the piece that used
    * to be missing, so the delete cascade destroyed these links instead.
@@ -147,6 +170,50 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
       $this->relationshipTriples($originalMother),
       [implode(':', [$originalMother, 'parent', $child])],
       'The duplicate adult\'s link to a child is transferred.'
+    );
+
+    // 5. The re-pointed relationship picks up the original's shards, so it
+    // reaches the original's devices. The duplicate's shards would otherwise
+    // stick, hiding the link on any health center the original has but the
+    // duplicate did not.
+    $hc1 = $this->createHealthCenter();
+    $hc2 = $this->createHealthCenter();
+    $mother = $this->createPerson('Mother5', [$hc1]);
+    $originalChild = $this->createPerson('OriginalChild5', [$hc1, $hc2]);
+    $duplicateChild = $this->createPerson('DuplicateChild5', [$hc1]);
+    $this->createRelationship($mother, $duplicateChild, 'parent');
+
+    _consolidate_patient_relationships($originalChild, $duplicateChild);
+
+    $originalChildRelationships = _hedley_patient_relationships_for_person($originalChild);
+    $relationshipId = reset($originalChildRelationships);
+    $expectedShards = array_values(array_unique(array_merge($this->shardsOf($mother), $this->shardsOf($originalChild))));
+    sort($expectedShards);
+    $this->assertEqual(
+      $this->shardsOf($relationshipId),
+      $expectedShards,
+      'The re-pointed relationship carries the union of the mother and original shards.'
+    );
+    $this->assertTrue(
+      in_array($hc2, $this->shardsOf($relationshipId)),
+      'The relationship reaches the health center only the original belonged to.'
+    );
+
+    // 6. Through the full merge path, the relationship is re-pointed BEFORE the
+    // duplicate is deleted, so the person-delete cascade cannot destroy it.
+    // This guards the ordering in _consolidate_patients_execute(): move the
+    // re-point after the field_deleted save and this fails.
+    $mother = $this->createPerson('Mother6');
+    $original = $this->createPerson('Original6');
+    $duplicate = $this->createPerson('Duplicate6');
+    $this->createRelationship($mother, $duplicate, 'parent');
+
+    _consolidate_patients_execute($original, $duplicate);
+
+    $this->assertEqual(
+      $this->relationshipTriples($original),
+      [implode(':', [$mother, 'parent', $original])],
+      'The full merge transfers the relationship instead of letting the cascade delete it.'
     );
   }
 


### PR DESCRIPTION
Fixes #1945

## What was wrong

Merging a duplicate patient into an original **destroyed the duplicate's family relationships** rather than moving them.

`_consolidate_patients_execute()` discovers the duplicate's content only through `hedley_general_get_person_measurements()` — measurements only. A `relationship` is not a measurement, and `field_related_to` appears nowhere in the merge, so relationships were never re-pointed. The merge then marked the duplicate `field_deleted = TRUE`, and the person-delete cascade soft-deleted the relationships that still referenced it.

The loss scenario is the normal way duplicates arise. A CHW registers child **C2**, links it to mother **M**; C2 turns out to duplicate existing child **C1**. Merge C2 → C1: C1 absorbs the measurements, but C2's link to M is deleted — **the child no longer appears under its mother**. Symmetric when the duplicate is the adult.

## The fix

Re-point the duplicate's relationships onto the original before it is marked deleted — both the `field_person` side (duplicate is the adult) and the `field_related_to` side (duplicate is the child) — dropping two redundant kinds:

- a relationship between the two patients being merged (re-pointing would make the original relate to itself);
- a relationship the original already holds (same other person, relation and direction).

Doing this *before* `field_deleted` is set is what saves them: once they point at the original — a live person — the cascade (which soft-deletes relationships referencing the *duplicate*) no longer touches them.

Relationships have exactly two person-pointing fields, both intrinsic to the bundle, so this queries them directly through the existing `hedley_general_get_person_content_associated_by_fields()` helper and does not depend on #1942.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list).

**Discrimination against the real code** (`drush php-script`), all four cases, driving the actual `_consolidate_patient_relationships()`:

```
CASE 1 (duplicate child linked to a mother):
  AFTER merge, C1 links:  M parent C1          <- the mother link transferred
CASE 2 (both children already linked to M):
  AFTER merge, C1 links:  M parent C1          <- deduped, not doubled
CASE 3 (the two children were related to each other):
  AFTER merge, C1 links:  (none)               <- self-referential link dropped
CASE 4 (duplicate is the adult):
  AFTER merge, M1 links:  M1 parent K          <- adult's link to a child transferred
```

And the **old path**, to prove the bug and that the fix addresses it:

```
relationship M-parent-C2 after cascade: field_deleted = TRUE (DESTROYED)
C1 live relationships after merge: (NONE - the mother link was lost)
```

**Regression test:** a new `HedleyPatientConsolidation` test class — the first for the merge flow — exercising all four cases against the real function. It went in as one test method (each reinstalls the profile), and the class gives the remaining merge-gap fixes a home. `simpletest` runs in parallel with the longer E2E job, so the extra class does not move wall-clock.

## Scope

This fixes merges going **forward**. It does **not** retroactively repair relationships already destroyed by past merges — that is a separate backfill and a separate decision, which I will file rather than fold in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)