### PR TITLE
Patient merge: re-point education-session attendance

### DIFF
--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -420,11 +420,14 @@ function _consolidate_patient_education_sessions($original, $duplicate) {
     $participants = $wrapper->field_participating_patients->value(['identifier' => TRUE]);
 
     $new_participants = [];
+    $seen = [];
     foreach ($participants as $participant_id) {
       $participant_id = ($participant_id == $duplicate) ? $original : $participant_id;
       // Skip if we already have this participant (the original may have
-      // attended the same session).
-      if (!in_array($participant_id, $new_participants)) {
+      // attended the same session). Node IDs used as array keys normalise any
+      // int/string difference, so this needs no explicit comparison.
+      if (!isset($seen[$participant_id])) {
+        $seen[$participant_id] = TRUE;
         $new_participants[] = $participant_id;
       }
     }

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -230,6 +230,12 @@ function _consolidate_patients_execute($original, $duplicate) {
   // relationships that still reference the duplicate - leaves them alone.
   $messages[] = _consolidate_patient_relationships($original, $duplicate);
 
+  // Education sessions reference their attendees, and are not measurements
+  // either. Re-point the duplicate to the original in every session it
+  // attended, so the original is recorded as the attendee rather than a
+  // person who no longer exists.
+  $messages[] = _consolidate_patient_education_sessions($original, $duplicate);
+
   // Mark duplicate patient as Deleted.
   $wrapper_duplicate->field_deleted->set(TRUE);
   $wrapper_duplicate->save();
@@ -322,6 +328,32 @@ function _consolidate_patient_relationships($original, $duplicate) {
 }
 
 /**
+ * Non-deleted node IDs of one bundle that reference a person via given fields.
+ *
+ * @param int $person_id
+ *   Node ID of the person.
+ * @param array $fields
+ *   The reference fields to look through.
+ * @param string $bundle
+ *   The node bundle to keep.
+ *
+ * @return array
+ *   Node IDs of that bundle, keyed by ID.
+ */
+function _hedley_patient_content_referencing_person($person_id, array $fields, $bundle) {
+  $entries = hedley_general_get_person_content_associated_by_fields($person_id, $fields);
+
+  $ids = [];
+  foreach ($entries as $entry) {
+    if ($entry->bundle === $bundle) {
+      $ids[$entry->entity_id] = $entry->entity_id;
+    }
+  }
+
+  return $ids;
+}
+
+/**
  * All non-deleted relationship node IDs a person takes part in, either side.
  *
  * @param int $person_id
@@ -331,19 +363,10 @@ function _consolidate_patient_relationships($original, $duplicate) {
  *   Relationship node IDs.
  */
 function _hedley_patient_relationships_for_person($person_id) {
-  $entries = hedley_general_get_person_content_associated_by_fields($person_id, [
+  return _hedley_patient_content_referencing_person($person_id, [
     'field_person',
     'field_related_to',
-  ]);
-
-  $ids = [];
-  foreach ($entries as $entry) {
-    if ($entry->bundle === 'relationship') {
-      $ids[$entry->entity_id] = $entry->entity_id;
-    }
-  }
-
-  return $ids;
+  ], 'relationship');
 }
 
 /**
@@ -361,6 +384,59 @@ function _hedley_patient_relationships_for_person($person_id) {
  */
 function _hedley_patient_relationship_key($person_id, $related_by, $related_to_id) {
   return implode(':', [$person_id, $related_by, $related_to_id]);
+}
+
+/**
+ * Re-points the duplicate patient to the original in its education sessions.
+ *
+ * A session's field_participating_patients is a multi-value list of the people
+ * who attended it. Replace the duplicate with the original in every session it
+ * attended; if the original attended the same session, the duplicate's entry
+ * is simply dropped so the original is not listed twice.
+ *
+ * Unlike a relationship, a session is not soft-deleted by the person-delete
+ * cascade (it belongs to the health center, not the attendee), so this exists
+ * only to keep the attendee list accurate - a merged-away person should not
+ * remain among a session's participants.
+ *
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_patient_education_sessions($original, $duplicate) {
+  $session_ids = _hedley_patient_content_referencing_person($duplicate, [
+    'field_participating_patients',
+  ], 'education_session');
+
+  $updated = 0;
+  foreach ($session_ids as $session_id) {
+    $wrapper = entity_metadata_wrapper('node', $session_id);
+    $participants = $wrapper->field_participating_patients->value(['identifier' => TRUE]);
+
+    $new_participants = [];
+    foreach ($participants as $participant_id) {
+      $participant_id = ($participant_id == $duplicate) ? $original : $participant_id;
+      // Skip if we already have this participant (the original may have
+      // attended the same session).
+      if (!in_array($participant_id, $new_participants)) {
+        $new_participants[] = $participant_id;
+      }
+    }
+
+    $wrapper->field_participating_patients->set($new_participants);
+    $wrapper->save();
+    $updated++;
+  }
+
+  return format_string('Education sessions: @updated re-pointed to the original.', [
+    '@updated' => $updated,
+  ]);
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -107,14 +107,56 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   }
 
   /**
-   * Merging a duplicate transfers, dedupes and prunes its relationships.
+   * Creates an education session with the given attendees.
    *
-   * All cases operate on disjoint people, so bundling them under one test
-   * method keeps the hedley-profile install (~5 min in CI) paid once. Each
-   * calls _consolidate_patient_relationships() directly - the piece that used
-   * to be missing, so the delete cascade destroyed these links instead.
+   * @param array $participants
+   *   Person node IDs attending the session.
+   *
+   * @return int
+   *   The education session node ID.
    */
-  public function testRelationshipsAreTransferredOnMerge() {
+  protected function createEducationSession(array $participants) {
+    $node = $this->drupalCreateNode(['type' => 'education_session']);
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $scheduled = date('Y-m-d', strtotime('-2 days'));
+    $wrapper->field_scheduled_date->set([
+      'value' => $scheduled,
+      'value2' => $scheduled,
+    ]);
+    $wrapper->field_education_topics->set(['malaria']);
+    $wrapper->field_participating_patients->set($participants);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * The sorted attendee node IDs of an education session.
+   *
+   * @param int $session_id
+   *   The education session node ID.
+   *
+   * @return array
+   *   Sorted person node IDs.
+   */
+  protected function sessionAttendees($session_id) {
+    $ids = entity_metadata_wrapper('node', node_load($session_id, NULL, TRUE))
+      ->field_participating_patients->value(['identifier' => TRUE]);
+    $ids = empty($ids) ? [] : $ids;
+    sort($ids);
+
+    return $ids;
+  }
+
+  /**
+   * Merging a duplicate transfers the content that references it.
+   *
+   * Covers the non-measurement links the merge has to move by hand:
+   * relationships (cases 1-6) and education-session attendance (cases 7-9).
+   * All cases operate on disjoint people, so bundling them under one test
+   * method keeps the hedley-profile install (~5 min in CI) paid once.
+   */
+  public function testContentIsTransferredOnMerge() {
     // 1. A duplicate child's link to its mother moves to the original child.
     $mother = $this->createPerson('Mother');
     $originalChild = $this->createPerson('OriginalChild');
@@ -214,6 +256,53 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
       $this->relationshipTriples($original),
       [implode(':', [$mother, 'parent', $original])],
       'The full merge transfers the relationship instead of letting the cascade delete it.'
+    );
+
+    // 7. A duplicate's education-session attendance moves to the original, so
+    // the session no longer lists a person who was merged away.
+    $original = $this->createPerson('Original7');
+    $duplicate = $this->createPerson('Duplicate7');
+    $other = $this->createPerson('Other7');
+    $session = $this->createEducationSession([$duplicate, $other]);
+
+    _consolidate_patient_education_sessions($original, $duplicate);
+
+    $expected = [$original, $other];
+    sort($expected);
+    $this->assertEqual(
+      $this->sessionAttendees($session),
+      $expected,
+      'The duplicate is replaced by the original in the session attendees.'
+    );
+
+    // 8. When both attended the same session, the original is not listed twice.
+    $original = $this->createPerson('Original8');
+    $duplicate = $this->createPerson('Duplicate8');
+    $other = $this->createPerson('Other8');
+    $session = $this->createEducationSession([$original, $duplicate, $other]);
+
+    _consolidate_patient_education_sessions($original, $duplicate);
+
+    $expected = [$original, $other];
+    sort($expected);
+    $this->assertEqual(
+      $this->sessionAttendees($session),
+      $expected,
+      'A session both attended lists the original once, not twice.'
+    );
+
+    // 9. Through the full merge path, the session is re-pointed before the
+    // duplicate is deleted, so the session never keeps a merged-away attendee.
+    $original = $this->createPerson('Original9');
+    $duplicate = $this->createPerson('Duplicate9');
+    $session = $this->createEducationSession([$duplicate]);
+
+    _consolidate_patients_execute($original, $duplicate);
+
+    $this->assertEqual(
+      $this->sessionAttendees($session),
+      [$original],
+      'The full merge re-points the session attendee to the original.'
     );
   }
 


### PR DESCRIPTION
Fixes #1947

> Stacked on #1946 (B-113). Review the [two-commit diff](https://github.com/TIP-Global-Health/eheza-app/compare/b113-merge-transfer-relationships...b114-merge-transfer-education-sessions) or wait for #1946 to merge, after which this retargets cleanly to develop.

## What was wrong

Merging a duplicate patient did not update the education sessions the duplicate attended, so the session kept listing a person who had been merged away.

`_consolidate_patients_execute()` discovers content only through `hedley_general_get_person_measurements()` — measurements only. An `education_session` is not a measurement, and its `field_participating_patients` was never re-pointed. Unlike a relationship, the session is *not* soft-deleted by the person-delete cascade (it belongs to the health center, not an attendee), so the duplicate's entry just lingers.

This is the root cause behind #1935: PR #1936 made the *statistics* skip soft-deleted attendees, but the session node itself still references the merged-away person, and other consumers (the Elm client receives the session with the participant UUID over sync) do not necessarily filter.

Verified against real code (`drush php-script`), the old path after a merge:

```
OLD path: session still lists deleted person D as attendee: YES (stale reference remains)
```

## The fix

`_consolidate_patient_education_sessions()`, called from the merge next to the relationship transfer: replace the duplicate with the original in each session's `field_participating_patients`, dropping the duplicate's entry when the original already attended (so the original is not listed twice).

No shard handling is needed here — an education session's shards are village-based and assigned only on create — unlike the relationship case in #1946.

I also extracted `_hedley_patient_content_referencing_person()` so the relationship and education-session lookups share the bundle-filter query instead of repeating it (a local review flagged the duplication).

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list).

**Discrimination against the real function** (`drush php-script`), three cases plus a re-verify of the relationship path through the shared helper:

```
CASE 1 (D and X attend; merge D -> O):  AFTER O,X       (D replaced)
CASE 2 (O, D and X attend; dedup):      AFTER O,X       (O not doubled)
CASE 3 (D did not attend):              AFTER X         (unchanged)
```

**Regression test:** three cases added to `HedleyPatientConsolidation` (cases 7-9), including one through the full `_consolidate_patients_execute()` path. They fold into the existing single test method, so no extra profile install. I confirmed the full execute path completes on a session-attending duplicate and that develop leaves the stale attendee (the bug via the real entry point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)