### PR TITLE
Patient merge: re-point the pregnancy-newborn link

### DIFF
--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -236,6 +236,12 @@ function _consolidate_patients_execute($original, $duplicate) {
   // person who no longer exists.
   $messages[] = _consolidate_patient_education_sessions($original, $duplicate);
 
+  // When the duplicate is a newborn, the parent's pregnancy participant points
+  // at it through field_newborn. That field is not among the ones the delete
+  // cascade follows, so re-point it here or the participant would keep naming a
+  // person who no longer exists.
+  $messages[] = _consolidate_patient_newborn_references($original, $duplicate);
+
   // Mark duplicate patient as Deleted.
   $wrapper_duplicate->field_deleted->set(TRUE);
   $wrapper_duplicate->save();
@@ -439,6 +445,37 @@ function _consolidate_patient_education_sessions($original, $duplicate) {
 
   return format_string('Education sessions: @updated re-pointed to the original.', [
     '@updated' => $updated,
+  ]);
+}
+
+/**
+ * Re-points a parent's pregnancy participant from the newborn duplicate.
+ *
+ * An individual_participant records a pregnancy through field_person (the
+ * parent) and field_newborn (the child it resulted in). When the duplicate is
+ * that child, the participant keeps naming it after the merge, because
+ * field_newborn is not one of the fields the person-delete cascade follows.
+ * Re-point those participants at the original.
+ *
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_patient_newborn_references($original, $duplicate) {
+  $participant_ids = _hedley_patient_content_referencing_person($duplicate, [
+    'field_newborn',
+  ], 'individual_participant');
+
+  _associate_content_by_field($participant_ids, 'field_newborn', $original);
+
+  return format_string('Newborn references: @count re-pointed to the original.', [
+    '@count' => count($participant_ids),
   ]);
 }
 

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -149,12 +149,49 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   }
 
   /**
+   * Creates a pregnancy participant for a parent and its newborn.
+   *
+   * @param int $parent
+   *   The parent's person node ID.
+   * @param int $newborn
+   *   The newborn's person node ID.
+   *
+   * @return int
+   *   The individual_participant node ID.
+   */
+  protected function createPregnancyParticipant($parent, $newborn) {
+    $node = $this->drupalCreateNode(['type' => 'individual_participant']);
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_person->set($parent);
+    $wrapper->field_encounter_type->set('antenatal');
+    $wrapper->field_newborn->set($newborn);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * The person a participant names as its newborn.
+   *
+   * @param int $participant_id
+   *   The individual_participant node ID.
+   *
+   * @return int|null
+   *   The newborn person node ID, or NULL.
+   */
+  protected function participantNewborn($participant_id) {
+    return entity_metadata_wrapper('node', node_load($participant_id, NULL, TRUE))
+      ->field_newborn->getIdentifier();
+  }
+
+  /**
    * Merging a duplicate transfers the content that references it.
    *
    * Covers the non-measurement links the merge has to move by hand:
-   * relationships (cases 1-6) and education-session attendance (cases 7-9).
-   * All cases operate on disjoint people, so bundling them under one test
-   * method keeps the hedley-profile install (~5 min in CI) paid once.
+   * relationships (cases 1-6), education-session attendance (cases 7-9) and the
+   * pregnancy->newborn link (cases 10-11). All cases operate on disjoint
+   * people, so bundling them under one test method keeps the hedley-profile
+   * install (~5 min in CI) paid once.
    */
   public function testContentIsTransferredOnMerge() {
     // 1. A duplicate child's link to its mother moves to the original child.
@@ -303,6 +340,35 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
       $this->sessionAttendees($session),
       [$original],
       'The full merge re-points the session attendee to the original.'
+    );
+
+    // 10. When the duplicate is a newborn, the parent's pregnancy participant
+    // is re-pointed at the original child.
+    $parent = $this->createPerson('Parent10');
+    $originalChild = $this->createPerson('OriginalChild10');
+    $duplicateChild = $this->createPerson('DuplicateChild10');
+    $participant = $this->createPregnancyParticipant($parent, $duplicateChild);
+
+    _consolidate_patient_newborn_references($originalChild, $duplicateChild);
+
+    $this->assertEqual(
+      $this->participantNewborn($participant),
+      $originalChild,
+      'The pregnancy participant names the original child as its newborn.'
+    );
+
+    // 11. The same through the full merge path.
+    $parent = $this->createPerson('Parent11');
+    $originalChild = $this->createPerson('OriginalChild11');
+    $duplicateChild = $this->createPerson('DuplicateChild11');
+    $participant = $this->createPregnancyParticipant($parent, $duplicateChild);
+
+    _consolidate_patients_execute($originalChild, $duplicateChild);
+
+    $this->assertEqual(
+      $this->participantNewborn($participant),
+      $originalChild,
+      'The full merge re-points the pregnancy participant to the original child.'
     );
   }
 


### PR DESCRIPTION
Fixes #1949

> Stacked on #1948 (B-114) → #1946 (B-113). Review the [three-commit-family diff](https://github.com/TIP-Global-Health/eheza-app/compare/b114-merge-transfer-education-sessions...b116-merge-transfer-newborn); it retargets to develop as the stack merges.

## What was wrong

An `individual_participant` records a pregnancy through `field_person` (the parent) and `field_newborn` (the child it resulted in). When the merged-away duplicate is that child, the merge left the participant naming it — `field_newborn` isn't one of the fields the person-delete cascade follows, so the reference just lingered.

Verified against real code, through the full merge entry point:

```
develop execute, newborn-referencing duplicate: participant still names deleted DC: YES (stale reference remains)
```

## The fix

`_consolidate_patient_newborn_references()`, called from `_consolidate_patients_execute()` alongside the relationship and education-session transfers. It reuses the shared `_hedley_patient_content_referencing_person()` helper and the existing `_associate_content_by_field()` to move `field_newborn` from the duplicate to the original. Single-value field, and participant shards derive from `field_person` (the parent), so no dedup or shard handling is needed.

This completes the patient-merge gap group from the audit: relationships (#1946), education-session attendance (#1948), and now the pregnancy→newborn link.

## Verification

`php -l` clean; phpcs clean on `Drupal` + `DrupalPractice` (full CI extension list). Local `/code-review medium` — no findings (the change reuses both shared helpers rather than re-inlining).

**Discrimination against the real function** (`drush php-script`):

```
FIX:  participant.field_newborn  DuplicateChild -> OriginalChild
OLD:  participant still points at the deleted newborn: YES ; participant itself deleted: false
```

**Regression test:** cases 10-11 added to `HedleyPatientConsolidation` — the direct call and the full `_consolidate_patients_execute()` path — folded into the existing single test method, so no extra profile install. Confirmed the full path completes on a newborn-referencing duplicate and that develop leaves the stale reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)