### PR TITLE
Encounter forms: count the heart-murmur question in the Core Physical Exam

### DIFF
--- a/client/src/elm/Pages/NCD/Activity/Utils.elm
+++ b/client/src/elm/Pages/NCD/Activity/Utils.elm
@@ -301,13 +301,14 @@ examinationTasksCompletedFromTotal currentDate assembled data task =
                 + taskCompleted form.lungs
                 + taskCompleted form.abdomen
                 + taskCompleted form.heart
+                + taskCompleted form.heartMurmur
                 + ([ form.brittleHair
                    , form.paleConjuctiva
                    ]
                     |> List.map taskCompleted
                     |> List.sum
                   )
-            , 7
+            , 8
             )
 
 

--- a/client/src/elm/Pages/Prenatal/Activity/Utils.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Utils.elm
@@ -5205,13 +5205,14 @@ examinationTasksCompletedFromTotal currentDate assembled data task =
                 + taskCompleted form.lungs
                 + taskCompleted form.abdomen
                 + taskCompleted form.heart
+                + taskCompleted form.heartMurmur
                 + ([ form.brittleHair
                    , form.paleConjuctiva
                    ]
                     |> List.map taskCompleted
                     |> List.sum
                   )
-            , 7
+            , 8
             )
 
         ObstetricalExam ->


### PR DESCRIPTION
Fixes #1951

## What was wrong

The Core Physical Exam has eight sub-questions, but the completion count summed only seven — omitting the always-rendered **heart murmur** question — in both `Pages/NCD/Activity/Utils.elm` and its byte-for-byte Prenatal twin.

The shared save requires it: `toCorePhysicalExamValue` does `… |> andMap form.heartMurmur`, and `heartMurmur` is a non-optional `Bool` in the stored value, so the whole `CorePhysicalExamValue` collapses to `Nothing` until it is answered.

So a nurse answers the seven counted questions, the counter reads **7/7**, Save enables — and Save does nothing: the value is `Nothing`, no measurement is written, and because `isJust coreExam` stays false the encounter can't be completed. A dead-end with a green "done" card and a Save button with no visible effect. Same class as #1891 (these two were the last of the count-vs-save family).

## The fix

Count the heart-murmur question: `+ taskCompleted form.heartMurmur`, total `7 → 8`, in both count blocks — placed next to `heart`, matching the field order in `toCorePhysicalExamValue`. The count now matches exactly what the save requires: skip it → 7/8 and Save disabled; answer it → 8/8 and a real value persists.

## Verification

`elm make src/elm/Main.elm` — Success, 548 modules. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2830 passed.

No bespoke test: the count is computed inside a `case` in each Activity Utils, not an exposed helper, so it isn't cleanly unit-testable — the same mechanical, compiler-verified shape as #1891, which was accepted without one. The change is a two-line count correction with the compiler confirming `taskCompleted : Maybe a -> Int` accepts `form.heartMurmur : Maybe Bool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)