### PR TITLE
Acute Illness: fix COVID rapid-test form reconstruction for pregnant/positive results

### DIFF
--- a/client/src/elm/Pages/AcuteIllness/Activity/Test.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Test.elm
@@ -29,6 +29,7 @@ import EverySet exposing (EverySet)
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
 import Measurement.Model exposing (emptyMuacForm)
+import Pages.AcuteIllness.Activity.Model exposing (emptyCovidTestingForm)
 import Pages.AcuteIllness.Activity.Types exposing (PhysicalExamTask(..))
 import Pages.AcuteIllness.Activity.Utils
     exposing
@@ -46,6 +47,7 @@ import Pages.AcuteIllness.Activity.Utils
         , respiratoryRateElevatedByAge
         , respiratoryRateElevatedByAgeForCovid19
         , symptomMaxDuration
+        , toCovidTestingValueWithDefault
         )
 import Pages.AcuteIllness.Encounter.Model exposing (AssembledData)
 import Restful.Endpoint exposing (EntityUuid, toEntityUuid)
@@ -874,6 +876,36 @@ all =
         , zincDosageTest
         , amoxicillinDosageTest
         , physicalExamSaveDisabledTest
+        , covidTestingRoundTripTest
+        ]
+
+
+{-| Re-opening a saved COVID rapid test used to reconstruct some results wrong:
+"unable to run while pregnant" came back as "performed / not pregnant" (and
+re-saved as no value), and a plain positive came back flagged pregnant (and
+re-saved as positive-and-pregnant). Saving from the edited form therefore
+corrupted the record. Every result must survive a form round-trip unchanged.
+-}
+covidTestingRoundTripTest : Test
+covidTestingRoundTripTest =
+    let
+        roundTrip result =
+            toCovidTestingValueWithDefault
+                (Just (CovidTestingValue result Nothing))
+                emptyCovidTestingForm
+                |> Expect.equal (Just (CovidTestingValue result Nothing))
+    in
+    describe "COVID rapid test result round-trips through the form unchanged"
+        [ test "unable to run while pregnant (was lost on re-save)" <|
+            \_ -> roundTrip RapidTestUnableToRunAndPregnant
+        , test "positive (was silently turned into positive-and-pregnant)" <|
+            \_ -> roundTrip RapidTestPositive
+        , test "positive and pregnant" <|
+            \_ -> roundTrip RapidTestPositiveAndPregnant
+        , test "negative" <|
+            \_ -> roundTrip RapidTestNegative
+        , test "unable to run" <|
+            \_ -> roundTrip RapidTestUnableToRun
         ]
 
 

--- a/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
@@ -1907,7 +1907,8 @@ fromCovidTestingValue saved =
         (\value ->
             let
                 testPerformed =
-                    value.result /= RapidTestUnableToRun |> Just
+                    not (List.member value.result [ RapidTestUnableToRun, RapidTestUnableToRunAndPregnant ])
+                        |> Just
 
                 testPositive =
                     case value.result of
@@ -1924,8 +1925,7 @@ fromCovidTestingValue saved =
                             Nothing
 
                 isPregnant =
-                    Just <|
-                        rapidTestPositive value.result
+                    Just (List.member value.result [ RapidTestPositiveAndPregnant, RapidTestUnableToRunAndPregnant ])
             in
             { testPerformed = testPerformed
             , testPositive = testPositive


### PR DESCRIPTION
Fixes #1953

## What was wrong

`fromCovidTestingValue` rebuilds the COVID testing form when a nurse re-opens the encounter, and it derived two of the three fields wrong:

```elm
testPerformed = value.result /= RapidTestUnableToRun |> Just
isPregnant    = Just <| rapidTestPositive value.result
```

- `testPerformed` only excludes plain `RapidTestUnableToRun`, so `RapidTestUnableToRunAndPregnant` came back as **performed = Yes** (it was not run).
- `isPregnant` is derived from `rapidTestPositive` (true only for the *positive* variants), so `RapidTestUnableToRunAndPregnant` came back **pregnant = No**, and a plain `RapidTestPositive` came back **pregnant = Yes**.

The saved value is correct; only the on-edit reconstruction was wrong. Save is gated on task count, not `isJust measurements.covidTesting`, so re-saving the mis-reconstructed form **corrupted the record** — verified via the public round-trip (`toCovidTestingValueWithDefault … emptyCovidTestingForm`):

- `RapidTestUnableToRunAndPregnant` re-saved to **`Nothing`** (record lost).
- `RapidTestPositive` re-saved to **`RapidTestPositiveAndPregnant`** (a non-pregnant positive silently flagged pregnant).

The malaria sibling already special-cases its pregnant variant; COVID never got the analogue.

## The fix

Enumerate the actual variants for both derivations, so all six results round-trip unchanged.

## Verification

`elm make src/elm/Main.elm` — Success, 548 modules. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2835 passed, including 5 new round-trip cases.

**Discrimination:** reverting the fix fails exactly the two changed variants — "unable to run while pregnant" and "positive" — while the three guard cases (positive-and-pregnant, negative, unable-to-run) still pass; restored, all green. The test drives the public API round-trip (`value → form → value`), so it also pins the reverse direction.

## Not fixed here

`RapidTestIndeterminate` also fails to round-trip (→ `Nothing`) in both old and new code — the form has no "indeterminate" field. Pre-existing and separate; I'll file it if the COVID form actually offers that option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)