### PR TITLE
Sync: skip the post-sync page reload while the nurse is on a working screen

### DIFF
--- a/client/src/elm/SyncManager/Test.elm
+++ b/client/src/elm/SyncManager/Test.elm
@@ -4,7 +4,7 @@ import Device.Model exposing (Device)
 import EverySet
 import Expect
 import Json.Encode
-import Pages.Page exposing (Page(..))
+import Pages.Page exposing (Page(..), UserPage(..))
 import RemoteData
 import SyncManager.Model
     exposing
@@ -20,7 +20,7 @@ import SyncManager.Model
         , emptyModel
         )
 import SyncManager.Update
-import SyncManager.Utils exposing (determineDownloadPhotosStatus)
+import SyncManager.Utils exposing (determineDownloadPhotosStatus, pageAllowsBackgroundRefresh)
 import Test exposing (Test, describe, test)
 import Time
 
@@ -64,7 +64,7 @@ testDevice =
 
 all : Test
 all =
-    describe "SyncManager photo lane"
+    describe "SyncManager"
         [ test "determineDownloadPhotosStatus progresses the photo lane while the data lane is downloading" <|
             \() ->
                 determineDownloadPhotosStatus
@@ -170,4 +170,20 @@ all =
                     |> .model
                     |> .lastSaveError
                     |> Expect.equal Nothing
+
+        -- A long catch-up sync can schedule a page reload. It must not fire
+        -- while a nurse is logged in and possibly mid-form, or their unsaved
+        -- entries are lost; it is only allowed on the pre-login screens.
+        , test "background refresh is skipped on a logged-in page" <|
+            \() ->
+                pageAllowsBackgroundRefresh (UserPage ClinicalPage)
+                    |> Expect.equal False
+        , test "background refresh is allowed on the PIN page" <|
+            \() ->
+                pageAllowsBackgroundRefresh PinCodePage
+                    |> Expect.equal True
+        , test "background refresh is allowed on the device page" <|
+            \() ->
+                pageAllowsBackgroundRefresh DevicePage
+                    |> Expect.equal True
         ]

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -104,7 +104,15 @@ update currentTime activePage dbVersion device msg model =
                     [ MsgDebouncer <| provideInput TryDownloadingPhotos ]
 
         RefreshPage ->
-            SubModelReturn model (refreshPage ()) noError []
+            if SyncManager.Utils.pageAllowsBackgroundRefresh activePage then
+                SubModelReturn model (refreshPage ()) noError []
+
+            else
+                -- The nurse is in a logged-in workflow - they may have navigated
+                -- here while the reload was pending - so reloading would discard
+                -- unsaved form entries. Skip it; the newly-synced data still
+                -- surfaces through the regular fetch.
+                noChange
 
         BackendAuthorityFetch ->
             case model.syncStatus of

--- a/client/src/elm/SyncManager/Utils.elm
+++ b/client/src/elm/SyncManager/Utils.elm
@@ -1,4 +1,4 @@
-module SyncManager.Utils exposing (backendAuthorityEntityToRevision, backendGeneralEntityToRevision, determineDownloadPhotosStatus, determineSyncStatus, encodeBackendAuthorityEntity, encodeBackendGeneralEntity, getBackendAuthorityEntityIdentifier, getBackendGeneralEntityIdentifier, getDataToSendAuthority, getDataToSendGeneral, getDownloadPhotosSpeedForSubscriptions, getImageFromBackendAuthorityEntity, getSyncSpeedForSubscriptions, getSyncedHealthCenters, indexDbSaveErrorFromReason, resolveIncidentDetailsMsg, siteFeaturesFromString, siteFromString, syncInfoAuthorityForPort, syncInfoAuthorityFromPort, syncInfoGeneralForPort, syncInfoGeneralFromPort, syncInfoStatusToString)
+module SyncManager.Utils exposing (backendAuthorityEntityToRevision, backendGeneralEntityToRevision, determineDownloadPhotosStatus, determineSyncStatus, encodeBackendAuthorityEntity, encodeBackendGeneralEntity, getBackendAuthorityEntityIdentifier, getBackendGeneralEntityIdentifier, getDataToSendAuthority, getDataToSendGeneral, getDownloadPhotosSpeedForSubscriptions, getImageFromBackendAuthorityEntity, getSyncSpeedForSubscriptions, getSyncedHealthCenters, indexDbSaveErrorFromReason, pageAllowsBackgroundRefresh, resolveIncidentDetailsMsg, siteFeaturesFromString, siteFromString, syncInfoAuthorityForPort, syncInfoAuthorityFromPort, syncInfoGeneralForPort, syncInfoGeneralFromPort, syncInfoStatusToString)
 
 import Activity.Model exposing (Activity(..), ChildActivity(..))
 import Backend.AcuteIllnessEncounter.Encoder
@@ -44,7 +44,34 @@ import SyncManager.Model exposing (..)
 import Utils.WebData
 
 
-{-| Decide on the Sync status. Either keep the exiting one, or set the next one,
+{-| After a large download, a background sync may reload the page. That is only
+safe before the nurse is working: reloading a logged-in (`UserPage`) session
+would discard whatever form entries have not been saved yet, so the reload is
+skipped there. On any other page (device, PIN, service worker) there is no
+in-progress work to lose.
+-}
+pageAllowsBackgroundRefresh : Page -> Bool
+pageAllowsBackgroundRefresh page =
+    -- Enumerated rather than defaulted, so a new Page constructor forces this
+    -- safety decision to be made rather than silently allowing the reload.
+    case page of
+        DevicePage ->
+            True
+
+        PageNotFound _ ->
+            True
+
+        PinCodePage ->
+            True
+
+        ServiceWorkerPage ->
+            True
+
+        UserPage _ ->
+            False
+
+
+{-| Decide on the Sync status. Either keep the existing one, or set the next one,
 according to the order `SyncStatus` is defined.
 -}
 determineSyncStatus : Page -> Model -> Model


### PR DESCRIPTION
Fixes #1955

## What was wrong

When a background sync's authority-download phase exceeds 45s, `SyncManager` schedules a page reload (`SchedulePageRefresh` → 15s debounce → `RefreshPage` → `refreshPage()` → `location.reload()`). It had no page gating. In-progress form state lives in the in-memory `LoggedInModel` page dicts and does **not** survive `location.reload()`.

**Trigger:** device offline over a weekend, or the health center just re-added (forcing a full re-download). The nurse logs in and starts entering a form while the >45s catch-up runs; it completes, and ~15s later the page silently reloads, wiping unsaved fields.

## The fix

Gate the reload where it **fires**: `RefreshPage` reloads only when the nurse is on a pre-login screen (device / PIN / service worker) and skips otherwise, via a new pure `SyncManager.Utils.pageAllowsBackgroundRefresh : Page -> Bool` (any `UserPage` → not safe).

Checking at fire time — not when the reload is scheduled 15s earlier — matters: a nurse who is on a safe screen when the sync completes but then logs in and starts a form during the debounce window is still protected. The skip is a no-op (`noChange`), not a re-schedule, so there is no retry loop and no interaction with the shared debouncer. The newly-synced data still surfaces through the regular reactive fetch, and photo download runs on its own independent timer, so both are unaffected.

## Verification

`elm make src/elm/Main.elm` — Success, 548 modules. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2833 passed, including 3 new cases pinning `pageAllowsBackgroundRefresh` (UserPage → skip; PIN / device → allow).

The reload is an opaque port `Cmd`, so — as with the double-tap guard (#1932) — the test pins the pure predicate that drives the decision, with the handler wiring compiler-verified.

## Review note

This is SyncManager, so it went through the high (multi-agent) review. The first pass caught a real bug in an earlier *defer-and-retry* approach (re-scheduling into a shared last-write-wins debouncer that a photo-download schedule would clobber, plus an all-session 15s wakeup loop) — hence this simpler fire-site skip. A follow-up concern (gating at dispatch left a 15s window) drove moving the gate to the fire site. The design and the reactive-fetch-covers-the-data conclusion were verified across those passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)