### PR TITLE
Well Child: keep cleared Pregnancy Summary values cleared on reload

### DIFF
--- a/client/src/elm/Pages/WellChild/Activity/Model.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Model.elm
@@ -1,4 +1,4 @@
-module Pages.WellChild.Activity.Model exposing (DangerSignsData, HeadCircumferenceForm, HomeVisitData, ImmunisationData, MedicationData, Model, Msg(..), NextStepsData, NextVisitForm, NutritionAssessmentData, PregnancySummaryForm, SymptomsReviewForm, WarningPopupType(..), WellChildECDForm, WellChildVaccinationForm, emptyModel, medicationTasks)
+module Pages.WellChild.Activity.Model exposing (DangerSignsData, HeadCircumferenceForm, HomeVisitData, ImmunisationData, MedicationData, Model, Msg(..), NextStepsData, NextVisitForm, NutritionAssessmentData, PregnancySummaryForm, SymptomsReviewForm, WarningPopupType(..), WellChildECDForm, WellChildVaccinationForm, emptyModel, emptyPregnancySummaryForm, medicationTasks)
 
 import Backend.Entities exposing (..)
 import Backend.Measurement.Model exposing (..)
@@ -179,6 +179,7 @@ type alias PregnancySummaryForm =
     , apgarFiveMin : Maybe Float
     , apgarDirty : Bool
     , birthWeight : Maybe WeightInGrm
+    , birthWeightDirty : Bool
     , birthLengthAvailable : Maybe Bool
     , birthLength : Maybe HeightInCm
     , birthLengthDirty : Bool
@@ -198,6 +199,7 @@ emptyPregnancySummaryForm =
     , apgarFiveMin = Nothing
     , apgarDirty = False
     , birthWeight = Nothing
+    , birthWeightDirty = False
     , birthLengthAvailable = Nothing
     , birthLength = Nothing
     , birthLengthDirty = False

--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -1,15 +1,36 @@
 module Pages.WellChild.Activity.Test exposing (all)
 
+import Backend.Measurement.Model
+    exposing
+        ( HeightInCm(..)
+        , PregnancySummarySign(..)
+        , PregnancySummaryValue
+        , WeightInGrm(..)
+        )
 import Date
+import EverySet
 import Expect
-import Pages.WellChild.Activity.Utils exposing (resolveFirstEncounterDateAfterMilestone)
+import Pages.WellChild.Activity.Model exposing (emptyPregnancySummaryForm)
+import Pages.WellChild.Activity.Utils
+    exposing
+        ( pregnancySummaryFormWithDefault
+        , resolveFirstEncounterDateAfterMilestone
+        )
 import Test exposing (Test, describe, test)
 import Time
 
 
 all : Test
 all =
-    describe "Pages.WellChild.Activity.Utils.resolveFirstEncounterDateAfterMilestone"
+    describe "Pages.WellChild.Activity"
+        [ resolveFirstEncounterDateAfterMilestoneTests
+        , pregnancySummaryFormWithDefaultTests
+        ]
+
+
+resolveFirstEncounterDateAfterMilestoneTests : Test
+resolveFirstEncounterDateAfterMilestoneTests =
+    describe "resolveFirstEncounterDateAfterMilestone"
         [ test "picks the earliest encounter strictly AFTER the milestone, not an earlier one before it" <|
             \_ ->
                 let
@@ -39,5 +60,72 @@ all =
             \_ ->
                 resolveFirstEncounterDateAfterMilestone (Date.fromCalendarDate 2024 Time.Jul 1)
                     [ Date.fromCalendarDate 2024 Time.Jul 1 ]
+                    |> Expect.equal Nothing
+        ]
+
+
+{-| A saved Pregnancy Summary with every numeric filled in, so the tests can
+check what happens when the nurse clears one and re-opens the encounter.
+-}
+savedPregnancySummary : PregnancySummaryValue
+savedPregnancySummary =
+    { expectedDateConcluded = Date.fromCalendarDate 2024 Time.Jan 1
+    , deliveryComplications = EverySet.empty
+    , signs = EverySet.fromList [ ApgarScores, BirthLength ]
+    , apgarOneMin = Just 8
+    , apgarFiveMin = Just 9
+    , birthWeight = Just (WeightInGrm 3000)
+    , birthLength = Just (HeightInCm 50)
+    , birthDefects = EverySet.empty
+    }
+
+
+{-| Clearing a value (for example answering "Apgar scores available? No", which
+empties the scores and marks them dirty) must stay cleared when the form is
+rebuilt from the saved value. An untouched field still loads from the saved
+value.
+-}
+pregnancySummaryFormWithDefaultTests : Test
+pregnancySummaryFormWithDefaultTests =
+    let
+        resolve form =
+            pregnancySummaryFormWithDefault form (Just savedPregnancySummary)
+    in
+    describe "pregnancySummaryFormWithDefault"
+        [ test "cleared Apgar scores stay cleared when the field is dirty" <|
+            \_ ->
+                let
+                    resolved =
+                        resolve { emptyPregnancySummaryForm | apgarDirty = True }
+                in
+                ( resolved.apgarOneMin, resolved.apgarFiveMin )
+                    |> Expect.equal ( Nothing, Nothing )
+        , test "untouched Apgar scores load from the saved value" <|
+            \_ ->
+                let
+                    resolved =
+                        resolve emptyPregnancySummaryForm
+                in
+                ( resolved.apgarOneMin, resolved.apgarFiveMin )
+                    |> Expect.equal ( Just 8, Just 9 )
+        , test "an edited Apgar score wins over the saved value" <|
+            \_ ->
+                resolve { emptyPregnancySummaryForm | apgarDirty = True, apgarOneMin = Just 5 }
+                    |> .apgarOneMin
+                    |> Expect.equal (Just 5)
+        , test "a cleared birth weight stays cleared when the field is dirty" <|
+            \_ ->
+                resolve { emptyPregnancySummaryForm | birthWeightDirty = True }
+                    |> .birthWeight
+                    |> Expect.equal Nothing
+        , test "an untouched birth weight loads from the saved value" <|
+            \_ ->
+                resolve emptyPregnancySummaryForm
+                    |> .birthWeight
+                    |> Expect.equal (Just (WeightInGrm 3000))
+        , test "a cleared birth length stays cleared when the field is dirty" <|
+            \_ ->
+                resolve { emptyPregnancySummaryForm | birthLengthDirty = True }
+                    |> .birthLength
                     |> Expect.equal Nothing
         ]

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -46,6 +46,7 @@ import Pages.Utils
         , ifNullableTrue
         , ifTrue
         , maybeToBoolTask
+        , maybeValueConsideringIsDirtyField
         , resolveTasksCompletedFromTotal
         , taskAnyCompleted
         , valueConsideringIsDirtyField
@@ -240,12 +241,13 @@ pregnancySummaryFormWithDefault form saved =
                         (listNotEmptyWithException NoDeliveryComplications deliveryComplications |> Just)
                 , deliveryComplications = or form.deliveryComplications (Just deliveryComplications)
                 , apgarScoresAvailable = or form.apgarScoresAvailable (List.member ApgarScores signsFromValue |> Just)
-                , apgarOneMin = or form.apgarOneMin (Maybe.andThen .apgarOneMin saved)
-                , apgarFiveMin = or form.apgarFiveMin (Maybe.andThen .apgarFiveMin saved)
+                , apgarOneMin = maybeValueConsideringIsDirtyField form.apgarDirty form.apgarOneMin (Maybe.andThen .apgarOneMin saved)
+                , apgarFiveMin = maybeValueConsideringIsDirtyField form.apgarDirty form.apgarFiveMin (Maybe.andThen .apgarFiveMin saved)
                 , apgarDirty = form.apgarDirty
-                , birthWeight = or form.birthWeight (Maybe.andThen .birthWeight saved)
+                , birthWeight = maybeValueConsideringIsDirtyField form.birthWeightDirty form.birthWeight (Maybe.andThen .birthWeight saved)
+                , birthWeightDirty = form.birthWeightDirty
                 , birthLengthAvailable = or form.birthLengthAvailable (List.member BirthLength signsFromValue |> Just)
-                , birthLength = or form.birthLength (Maybe.andThen .birthLength saved)
+                , birthLength = maybeValueConsideringIsDirtyField form.birthLengthDirty form.birthLength (Maybe.andThen .birthLength saved)
                 , birthLengthDirty = form.birthLengthDirty
                 , birthDefectsPresent =
                     or form.birthDefectsPresent

--- a/client/src/elm/Pages/WellChild/Activity/View.elm
+++ b/client/src/elm/Pages/WellChild/Activity/View.elm
@@ -331,6 +331,7 @@ viewPregnancySummaryForm language currentDate assembled form_ =
                     (\value pregnancySummaryForm ->
                         { pregnancySummaryForm
                             | birthWeight = String.toFloat value |> Maybe.map WeightInGrm
+                            , birthWeightDirty = True
                         }
                     )
                 )


### PR DESCRIPTION
Fixes #1957

## What was wrong

`pregnancySummaryFormWithDefault` rebuilt the Newborn Pregnancy Summary form from the saved value with plain `or`, so a value the nurse had cleared was silently restored:

```elm
, apgarOneMin = or form.apgarOneMin (Maybe.andThen .apgarOneMin saved)   -- or Nothing (Just saved) = Just saved
, apgarDirty  = form.apgarDirty                                          -- set, but never consulted
```

The form already carries `apgarDirty` / `birthLengthDirty`, and the view sets them `True` when the nurse edits a value or answers "available? No" (which also empties the numeric) — but the rebuild ignored them. So answering "Apgar scores available? No" left the old scores in the saved record, and since the save builds `signs` from the availability answer, the stored value became self-contradictory (signs say "not available" while `apgarOneMin` still holds a value). Same for birth length.

`birthWeight` had no dirty flag at all, so a saved birth weight could be changed but never cleared — and it drives the < 2500 g low-birth-weight flag and the NCDA prefill, so a wrong value couldn't be retracted.

## The fix

Consult the dirty flags when rebuilding — `maybeValueConsideringIsDirtyField` for Apgar and birth length (flags already existed) — and add a `birthWeightDirty` flag (form field, view setter, rebuild) for birth weight. This is the same dirty-flag mechanism the codebase already uses for head circumference and the NCD lipid panel. A cleared value now stays cleared; an untouched field still loads from the saved value.

## Verification

`elm make src/elm/Main.elm` — Success, 548 modules. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2844 passed, including 6 new cases on the exposed pure `pregnancySummaryFormWithDefault`.

**Discrimination:** reverting the fix fails exactly the three "cleared … stays cleared" cases (Apgar, birth weight, birth length) while the guards (untouched loads saved; edited value wins) still pass; restored, all green.

Local `/code-review medium` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)