### PR TITLE
NCD: keep cleared creatinine, BUN, ALT and AST results cleared on reload

### DIFF
--- a/client/src/elm/Measurement/Model.elm
+++ b/client/src/elm/Measurement/Model.elm
@@ -1720,26 +1720,42 @@ type alias CreatinineResultForm =
     { executionNote : Maybe TestExecutionNote
     , executionDate : Maybe NominalDate
     , creatinineResult : Maybe Float
+    , creatinineResultDirty : Bool
     , bunResult : Maybe Float
+    , bunResultDirty : Bool
     }
 
 
 emptyCreatinineResultForm : CreatinineResultForm
 emptyCreatinineResultForm =
-    CreatinineResultForm Nothing Nothing Nothing Nothing
+    { executionNote = Nothing
+    , executionDate = Nothing
+    , creatinineResult = Nothing
+    , creatinineResultDirty = False
+    , bunResult = Nothing
+    , bunResultDirty = False
+    }
 
 
 type alias LiverFunctionResultForm =
     { executionNote : Maybe TestExecutionNote
     , executionDate : Maybe NominalDate
     , altResult : Maybe Float
+    , altResultDirty : Bool
     , astResult : Maybe Float
+    , astResultDirty : Bool
     }
 
 
 emptyLiverFunctionResultForm : LiverFunctionResultForm
 emptyLiverFunctionResultForm =
-    LiverFunctionResultForm Nothing Nothing Nothing Nothing
+    { executionNote = Nothing
+    , executionDate = Nothing
+    , altResult = Nothing
+    , altResultDirty = False
+    , astResult = Nothing
+    , astResultDirty = False
+    }
 
 
 type alias NCDAData =

--- a/client/src/elm/Measurement/Test.elm
+++ b/client/src/elm/Measurement/Test.elm
@@ -4,21 +4,26 @@ import AssocList as Dict
 import Backend.Measurement.Model
     exposing
         ( ColorAlertIndication(..)
+        , CreatinineTestValue
+        , LiverFunctionTestValue
         , MuacInCm(..)
+        , TestExecutionNote(..)
         , VaccineDose(..)
         , WellChildVaccineType(..)
         )
 import Date exposing (Unit(..))
 import Expect
-import Measurement.Model exposing (MsgChild(..), emptyModelChild)
+import Measurement.Model exposing (MsgChild(..), emptyCreatinineResultForm, emptyLiverFunctionResultForm, emptyModelChild)
 import Measurement.Update exposing (updateChild)
 import Measurement.Utils
     exposing
-        ( getAllDosesForVaccine
+        ( creatinineResultFormWithDefault
+        , getAllDosesForVaccine
         , getInputConstraintsHeight
         , getInputConstraintsWeight
         , getIntervalForVaccine
         , initialVaccinationDateByBirthDate
+        , liverFunctionResultFormWithDefault
         , muacOutsideConstraints
         , outsideConstraints
         )
@@ -346,6 +351,85 @@ muacOutsideConstraintsTest =
         ]
 
 
+{-| A saved creatinine test with both results filled in, so the tests can check
+what happens when the nurse clears one and re-opens the recurrent encounter.
+-}
+savedCreatinineTest : CreatinineTestValue
+savedCreatinineTest =
+    { executionNote = TestNoteRunToday
+    , executionDate = Just (Date.fromCalendarDate 2024 Time.Jan 1)
+    , creatinineResult = Just 1.2
+    , bunResult = Just 15
+    }
+
+
+creatinineResultFormWithDefaultTest : Test
+creatinineResultFormWithDefaultTest =
+    let
+        resolve form =
+            creatinineResultFormWithDefault form (Just savedCreatinineTest)
+    in
+    describe "creatinineResultFormWithDefault"
+        [ test "a cleared creatinine result stays cleared when the field is dirty" <|
+            \_ ->
+                resolve { emptyCreatinineResultForm | creatinineResultDirty = True }
+                    |> .creatinineResult
+                    |> Expect.equal Nothing
+        , test "an untouched creatinine result loads from the saved value" <|
+            \_ ->
+                resolve emptyCreatinineResultForm
+                    |> .creatinineResult
+                    |> Expect.equal (Just 1.2)
+        , test "an edited creatinine result wins over the saved value" <|
+            \_ ->
+                resolve { emptyCreatinineResultForm | creatinineResultDirty = True, creatinineResult = Just 2.5 }
+                    |> .creatinineResult
+                    |> Expect.equal (Just 2.5)
+        , test "a cleared BUN result stays cleared when the field is dirty" <|
+            \_ ->
+                resolve { emptyCreatinineResultForm | bunResultDirty = True }
+                    |> .bunResult
+                    |> Expect.equal Nothing
+        ]
+
+
+{-| A saved liver function test with both results filled in, for the same
+clear-then-reopen check.
+-}
+savedLiverFunctionTest : LiverFunctionTestValue
+savedLiverFunctionTest =
+    { executionNote = TestNoteRunToday
+    , executionDate = Just (Date.fromCalendarDate 2024 Time.Jan 1)
+    , altResult = Just 30
+    , astResult = Just 25
+    }
+
+
+liverFunctionResultFormWithDefaultTest : Test
+liverFunctionResultFormWithDefaultTest =
+    let
+        resolve form =
+            liverFunctionResultFormWithDefault form (Just savedLiverFunctionTest)
+    in
+    describe "liverFunctionResultFormWithDefault"
+        [ test "a cleared ALT result stays cleared when the field is dirty" <|
+            \_ ->
+                resolve { emptyLiverFunctionResultForm | altResultDirty = True }
+                    |> .altResult
+                    |> Expect.equal Nothing
+        , test "an untouched ALT result loads from the saved value" <|
+            \_ ->
+                resolve emptyLiverFunctionResultForm
+                    |> .altResult
+                    |> Expect.equal (Just 30)
+        , test "a cleared AST result stays cleared when the field is dirty" <|
+            \_ ->
+                resolve { emptyLiverFunctionResultForm | astResultDirty = True }
+                    |> .astResult
+                    |> Expect.equal Nothing
+        ]
+
+
 all : Test
 all =
     describe "Measurement of children: form tests"
@@ -358,4 +442,6 @@ all =
         , updateChildSetMuacTest
         , outsideConstraintsTest
         , muacOutsideConstraintsTest
+        , creatinineResultFormWithDefaultTest
+        , liverFunctionResultFormWithDefaultTest
         ]

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -7870,8 +7870,10 @@ creatinineResultFormWithDefault form saved =
             (\value ->
                 { executionNote = or form.executionNote (Just value.executionNote)
                 , executionDate = or form.executionDate value.executionDate
-                , creatinineResult = or form.creatinineResult value.creatinineResult
-                , bunResult = or form.bunResult value.bunResult
+                , creatinineResult = maybeValueConsideringIsDirtyField form.creatinineResultDirty form.creatinineResult value.creatinineResult
+                , creatinineResultDirty = form.creatinineResultDirty
+                , bunResult = maybeValueConsideringIsDirtyField form.bunResultDirty form.bunResult value.bunResult
+                , bunResultDirty = form.bunResultDirty
                 }
             )
 
@@ -7903,8 +7905,10 @@ liverFunctionResultFormWithDefault form saved =
             (\value ->
                 { executionNote = or form.executionNote (Just value.executionNote)
                 , executionDate = or form.executionDate value.executionDate
-                , altResult = or form.altResult value.altResult
-                , astResult = or form.astResult value.astResult
+                , altResult = maybeValueConsideringIsDirtyField form.altResultDirty form.altResult value.altResult
+                , altResultDirty = form.altResultDirty
+                , astResult = maybeValueConsideringIsDirtyField form.astResultDirty form.astResult value.astResult
+                , astResultDirty = form.astResultDirty
                 }
             )
 

--- a/client/src/elm/Pages/NCD/RecurrentActivity/Update.elm
+++ b/client/src/elm/Pages/NCD/RecurrentActivity/Update.elm
@@ -301,7 +301,7 @@ update currentDate id db msg model =
                     model.labResultsData.creatinineTestForm
 
                 updatedForm =
-                    { form | creatinineResult = String.toFloat value }
+                    { form | creatinineResult = String.toFloat value, creatinineResultDirty = True }
 
                 updatedData =
                     model.labResultsData
@@ -318,7 +318,7 @@ update currentDate id db msg model =
                     model.labResultsData.creatinineTestForm
 
                 updatedForm =
-                    { form | bunResult = String.toFloat value }
+                    { form | bunResult = String.toFloat value, bunResultDirty = True }
 
                 updatedData =
                     model.labResultsData
@@ -346,7 +346,7 @@ update currentDate id db msg model =
                     model.labResultsData.liverFunctionTestForm
 
                 updatedForm =
-                    { form | altResult = String.toFloat value }
+                    { form | altResult = String.toFloat value, altResultDirty = True }
 
                 updatedData =
                     model.labResultsData
@@ -363,7 +363,7 @@ update currentDate id db msg model =
                     model.labResultsData.liverFunctionTestForm
 
                 updatedForm =
-                    { form | astResult = String.toFloat value }
+                    { form | astResult = String.toFloat value, astResultDirty = True }
 
                 updatedData =
                     model.labResultsData


### PR DESCRIPTION
Fixes #1959

## What was wrong

On an NCD **recurrent (lab-results)** encounter, the creatinine/BUN and liver-function (ALT/AST) result forms rebuilt from the saved measurement with a bare `or`:

```elm
, creatinineResult = or form.creatinineResult value.creatinineResult   -- or Nothing value = value
, bunResult        = or form.bunResult value.bunResult
...
, altResult = or form.altResult value.altResult
, astResult = or form.astResult value.astResult
```

The view re-runs this merge on every render, so the moment the nurse cleared a result field the next render restored the saved number. A wrong value could be overwritten with a different number but **never retracted to blank**. There was no dirty flag anywhere: the two form aliases had none, the four Set handlers set only the value, and the two `*FormWithDefault` functions didn't consult one.

## Reachability

Both are gated identically to the lipid panel — the initial NCD encounter offers them on a 12-month recurring cadence (`recurrentTestRequired 12`), and the recurrent encounter shows the result form when the test was performed (`wasTestPerformed .creatinineTest` / `.liverFunctionTest`). No feature flag or diagnosis restriction.

## The fix

Mirror the **lipid panel**, which already has the complete dirty-flag pattern in these same three files:

- `Measurement/Model.elm` — add `creatinineResultDirty`/`bunResultDirty` and `altResultDirty`/`astResultDirty` to the two form aliases; default them `False` (empty forms converted from positional to record literals).
- `Pages/NCD/RecurrentActivity/Update.elm` — set the matching `…Dirty = True` in the four Set handlers.
- `Measurement/Utils.elm` — read the flag with `maybeValueConsideringIsDirtyField` when rebuilding, carrying the `…Dirty` field through. (`executionDate`/`executionNote` stay bare `or`, exactly as the lipid sibling leaves them.)

This completes the R9-4 lab dirty-flag class (PR #1883) for the two forms left out at the time.

## Verification

`elm make src/elm/Main.elm` — Success. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2845 passed, including 7 new cases on the two pure `*FormWithDefault` functions.

**Discrimination:** reverting only the logic (dirty-aware → bare `or`, keeping the flags) fails exactly the four "cleared … stays cleared" cases (creatinine, BUN, ALT, AST), each leaking the saved value back; the untouched-loads-saved and edited-wins guards still pass. Restored → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)