### PR TITLE
Well Child: schedule the 18-month ECD visit instead of skipping to 24 months

### DIFF
--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -2,14 +2,26 @@ module Pages.WellChild.Activity.Test exposing (all)
 
 import Date
 import Expect
-import Pages.WellChild.Activity.Utils exposing (resolveFirstEncounterDateAfterMilestone)
+import Pages.WellChild.Activity.Utils
+    exposing
+        ( resolveFirstEncounterDateAfterMilestone
+        , resolveNextDateForECDVisit
+        )
 import Test exposing (Test, describe, test)
 import Time
 
 
 all : Test
 all =
-    describe "Pages.WellChild.Activity.Utils.resolveFirstEncounterDateAfterMilestone"
+    describe "Pages.WellChild.Activity.Utils"
+        [ resolveFirstEncounterDateAfterMilestoneTests
+        , resolveNextDateForECDVisitTests
+        ]
+
+
+resolveFirstEncounterDateAfterMilestoneTests : Test
+resolveFirstEncounterDateAfterMilestoneTests =
+    describe "resolveFirstEncounterDateAfterMilestone"
         [ test "picks the earliest encounter strictly AFTER the milestone, not an earlier one before it" <|
             \_ ->
                 let
@@ -40,4 +52,40 @@ all =
                 resolveFirstEncounterDateAfterMilestone (Date.fromCalendarDate 2024 Time.Jul 1)
                     [ Date.fromCalendarDate 2024 Time.Jul 1 ]
                     |> Expect.equal Nothing
+        ]
+
+
+{-| The ECD sign group starting at 18 months means a child seen between 15 and
+17 months should return at 18 months, not skip to 24 months.
+-}
+resolveNextDateForECDVisitTests : Test
+resolveNextDateForECDVisitTests =
+    let
+        birthDate =
+            Date.fromCalendarDate 2024 Time.Jan 1
+
+        resolve current =
+            resolveNextDateForECDVisit current birthDate True
+    in
+    describe "resolveNextDateForECDVisit"
+        [ test "a 15-month-old is scheduled for the 18-month visit, not 24 months" <|
+            \_ ->
+                resolve (Date.fromCalendarDate 2025 Time.Apr 1)
+                    |> Expect.equal (Just (Date.fromCalendarDate 2025 Time.Jul 1))
+        , test "a 17-month-old is still scheduled for the 18-month visit" <|
+            \_ ->
+                resolve (Date.fromCalendarDate 2025 Time.Jun 1)
+                    |> Expect.equal (Just (Date.fromCalendarDate 2025 Time.Jul 1))
+        , test "an 18-month-old moves on to the 24-month visit" <|
+            \_ ->
+                resolve (Date.fromCalendarDate 2025 Time.Jul 1)
+                    |> Expect.equal (Just (Date.fromCalendarDate 2026 Time.Jan 1))
+        , test "the 15-month rung is unchanged for a younger child" <|
+            \_ ->
+                resolve (Date.fromCalendarDate 2024 Time.Nov 1)
+                    |> Expect.equal (Just (Date.fromCalendarDate 2025 Time.Apr 1))
+        , test "the years ladder is unchanged for a two-year-old" <|
+            \_ ->
+                resolve (Date.fromCalendarDate 2026 Time.Jan 1)
+                    |> Expect.equal (Just (Date.fromCalendarDate 2027 Time.Jan 1))
         ]

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.WellChild.Activity.Utils exposing (activityCompleted, albendazoleAdministrationFormConfig, dangerSignsTasksCompletedFromTotal, ecdSigns6To12MonthsMajors, ecdSignsFrom13Weeks, ecdSignsFrom5Weeks, expectActivity, expectImmunisationTask, expectMedicationTask, expectNextStepsTask, expectNutritionAssessmentTask, expectedECDSignsOnMilestone, generateASAPImmunisationDate, generateCompletedECDSigns, generateNextDateForImmunisationVisit, generateNextVisitDates, generateNutritionAssessment, generateRemianingECDSignsAfterCurrentEncounter, generateRemianingECDSignsBeforeCurrentEncounter, generateVitalsFormConfig, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, headCircumferenceFormAndTasks, headCircumferenceFormWithDefault, immunisationTasks, immunisationTasksCompletedFromTotal, mandatoryDangerSignsTasksCompleted, mandatoryNutritionAssessmentTasksCompleted, mebendezoleAdministrationFormConfig, medicationTasksCompletedFromTotal, nextStepsTasks, nextStepsTasksCompletedFromTotal, nextVisitFormWithDefault, nutritionAssessmentSaveDisabled, nutritionAssessmentTaskCompleted, nutritionAssessmentTasksCompletedFromTotal, pregnancySummaryFormWithDefault, resolveFirstEncounterDateAfterMilestone, resolveNextDateForImmunisationVisit, resolveNutritionAssessmentTasks, symptomsReviewFormInputsAndTasks, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType, vaccinationFormDynamicContentAndTasks, vitaminAAdministrationFormConfig, wellChildECDFormWithDefault)
+module Pages.WellChild.Activity.Utils exposing (activityCompleted, albendazoleAdministrationFormConfig, dangerSignsTasksCompletedFromTotal, ecdSigns6To12MonthsMajors, ecdSignsFrom13Weeks, ecdSignsFrom5Weeks, expectActivity, expectImmunisationTask, expectMedicationTask, expectNextStepsTask, expectNutritionAssessmentTask, expectedECDSignsOnMilestone, generateASAPImmunisationDate, generateCompletedECDSigns, generateNextDateForImmunisationVisit, generateNextVisitDates, generateNutritionAssessment, generateRemianingECDSignsAfterCurrentEncounter, generateRemianingECDSignsBeforeCurrentEncounter, generateVitalsFormConfig, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, headCircumferenceFormAndTasks, headCircumferenceFormWithDefault, immunisationTasks, immunisationTasksCompletedFromTotal, mandatoryDangerSignsTasksCompleted, mandatoryNutritionAssessmentTasksCompleted, mebendezoleAdministrationFormConfig, medicationTasksCompletedFromTotal, nextStepsTasks, nextStepsTasksCompletedFromTotal, nextVisitFormWithDefault, nutritionAssessmentSaveDisabled, nutritionAssessmentTaskCompleted, nutritionAssessmentTasksCompletedFromTotal, pregnancySummaryFormWithDefault, resolveFirstEncounterDateAfterMilestone, resolveNextDateForECDVisit, resolveNextDateForImmunisationVisit, resolveNutritionAssessmentTasks, symptomsReviewFormInputsAndTasks, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType, vaccinationFormDynamicContentAndTasks, vitaminAAdministrationFormConfig, wellChildECDFormWithDefault)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Measurement.Model exposing (..)
@@ -1897,65 +1897,82 @@ generateNextDateForECDVisit currentDate assembled =
         |> Maybe.andThen
             (\birthDate ->
                 let
-                    ageWeeks =
-                        Date.diff Weeks birthDate currentDate
-
                     noRemainingSigns =
                         List.isEmpty <| generateRemianingECDSignsAfterCurrentEncounter currentDate assembled
                 in
-                if ageWeeks < 6 then
-                    -- Since 6 weeks question appear from age of 5 weeks,
-                    -- we check if they were completed then.
-                    -- If so, we schedule next ECD visit to following
-                    -- milestone, which is at 14 weeks.
-                    if ageWeeks == 5 && noRemainingSigns then
-                        Just <| Date.add Weeks 14 birthDate
-
-                    else
-                        Just <| Date.add Weeks 6 birthDate
-
-                else if ageWeeks < 14 then
-                    -- Since 14 weeks question appear from age of 13 weeks,
-                    -- we check if they were completed then.
-                    -- If so, we schedule next ECD visit to following
-                    -- milestone, which is at 6 months.
-                    if ageWeeks == 13 && noRemainingSigns then
-                        Just <| Date.add Months 6 birthDate
-
-                    else
-                        Just <| Date.add Weeks 14 birthDate
-
-                else
-                    let
-                        ageMonths =
-                            Date.diff Months birthDate currentDate
-                    in
-                    if ageMonths < 6 then
-                        Just <| Date.add Months 6 birthDate
-
-                    else if ageMonths < 15 then
-                        Just <| Date.add Months 15 birthDate
-
-                    else
-                        let
-                            ageYears =
-                                Date.diff Years birthDate currentDate
-                        in
-                        if ageYears < 2 then
-                            Just <| Date.add Years 2 birthDate
-
-                        else if ageYears < 3 then
-                            Just <| Date.add Years 3 birthDate
-
-                        else if ageYears < 4 then
-                            Just <| Date.add Years 4 birthDate
-
-                        else if not noRemainingSigns then
-                            Just <| Date.add Months 6 currentDate
-
-                        else
-                            Nothing
+                resolveNextDateForECDVisit currentDate birthDate noRemainingSigns
             )
+
+
+{-| Resolves the date for the next ECD visit from the child's birth date and
+whether the current milestone's signs are all done. Extracted from
+generateNextDateForECDVisit so the ladder can be unit tested without an
+AssembledData value.
+
+Each rung matches an ECD sign group that becomes assessable at that age.
+
+-}
+resolveNextDateForECDVisit : NominalDate -> NominalDate -> Bool -> Maybe NominalDate
+resolveNextDateForECDVisit currentDate birthDate noRemainingSigns =
+    let
+        ageWeeks =
+            Date.diff Weeks birthDate currentDate
+    in
+    if ageWeeks < 6 then
+        -- Since 6 weeks question appear from age of 5 weeks,
+        -- we check if they were completed then.
+        -- If so, we schedule next ECD visit to following
+        -- milestone, which is at 14 weeks.
+        if ageWeeks == 5 && noRemainingSigns then
+            Just <| Date.add Weeks 14 birthDate
+
+        else
+            Just <| Date.add Weeks 6 birthDate
+
+    else if ageWeeks < 14 then
+        -- Since 14 weeks question appear from age of 13 weeks,
+        -- we check if they were completed then.
+        -- If so, we schedule next ECD visit to following
+        -- milestone, which is at 6 months.
+        if ageWeeks == 13 && noRemainingSigns then
+            Just <| Date.add Months 6 birthDate
+
+        else
+            Just <| Date.add Weeks 14 birthDate
+
+    else
+        let
+            ageMonths =
+                Date.diff Months birthDate currentDate
+        in
+        if ageMonths < 6 then
+            Just <| Date.add Months 6 birthDate
+
+        else if ageMonths < 15 then
+            Just <| Date.add Months 15 birthDate
+
+        else if ageMonths < 18 then
+            Just <| Date.add Months 18 birthDate
+
+        else
+            let
+                ageYears =
+                    Date.diff Years birthDate currentDate
+            in
+            if ageYears < 2 then
+                Just <| Date.add Years 2 birthDate
+
+            else if ageYears < 3 then
+                Just <| Date.add Years 3 birthDate
+
+            else if ageYears < 4 then
+                Just <| Date.add Years 4 birthDate
+
+            else if not noRemainingSigns then
+                Just <| Date.add Months 6 currentDate
+
+            else
+                Nothing
 
 
 generateNextDateForMedicationVisit : NominalDate -> Site -> AssembledData -> Maybe NominalDate


### PR DESCRIPTION
Fixes #1961

## What was wrong

The WellChild ECD next-visit ladder (`generateNextDateForECDVisit`) went from the 15-month rung straight to the years block, so a child assessed between **15 and 17 months** was booked for **24 months**. But `ecdSignsFrom18Months` — a distinct group of five developmental signs — becomes assessable at 18 months (enforced by the `ageMonths < 18` gate in `ecdSignsFromGroupedSignsByAge`), and `Milestone18Months` is a first-class pediatric-care milestone. 18 months was the only sign-group start with no matching visit rung.

Confirmed against the project's pediatric care schedule: 18 Months is a scheduled well-child visit whose five developmental questions map one-to-one onto `ecdSignsFrom18Months`.

## Severity

LOW–MED. The shown next-visit date is `min(ECD, medication)`, and 18 months is also a Vitamin A + deworming point; the medication ladder schedules 6 months after the last dose, so a 15–17 month child is often already pulled back around 18–21 months, partly masking the gap. The full delay only bites a child with no pending medication (medication date absent or later than the ECD date). The fix schedules the ECD screening on its own cadence regardless.

## The fix

Add the missing rung:

```elm
else if ageMonths < 18 then
    Just <| Date.add Months 18 birthDate
```

A child at 15–17 months returns at 18 months; at 18–23 months they still correctly get 24 months. The date ladder is extracted into `resolveNextDateForECDVisit` so it can be unit tested without an `AssembledData` value — matching the existing `resolveNextDateForImmunisationVisit`.

## Verification

`elm make src/elm/Main.elm` — Success. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2843 passed, including 5 new cases on the extracted `resolveNextDateForECDVisit`.

**Discrimination:** removing the 18-month rung fails exactly the two "15-month-old" and "17-month-old → 18 months" cases (both snap to 24 months); the three guards (18mo → 24mo, the 15-month rung, the years ladder) still pass. Restored → all green.

> Note: touches the same two files as the still-open #1958 (B-030), so a trivial conflict is expected on the `Utils.elm` `exposing (…)` line and the `Test.elm` `all` aggregation — additive on both sides. Merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)