### PR TITLE
Sync: keep the two-person shard union on linking-record recalculation

### DIFF
--- a/server/hedley/modules/custom/hedley_device/hedley_device.module
+++ b/server/hedley/modules/custom/hedley_device/hedley_device.module
@@ -280,21 +280,10 @@ function hedley_device_assign_shards($node, $wrapper) {
         break;
 
       case 'pmtct_participant':
-        // Participant shards are the union of adult and child shards.
-        $child_id = $wrapper->field_person->getIdentifier();
-        $adult_id = $wrapper->field_adult->getIdentifier();
-        $shards_child = hedley_general_shards_by_person($child_id);
-        $shards_adult = hedley_general_shards_by_person($adult_id);
-        $shards = array_unique(array_merge($shards_child, $shards_adult));
-        break;
-
       case 'relationship':
-        // Relationship shards are the union of adult and child shards.
-        $child_id = $wrapper->field_related_to->getIdentifier();
-        $adult_id = $wrapper->field_person->getIdentifier();
-        $shards_child = hedley_general_shards_by_person($child_id);
-        $shards_adult = hedley_general_shards_by_person($adult_id);
-        $shards = array_unique(array_merge($shards_child, $shards_adult));
+        // Participant and relationship shards are the union of both linked
+        // persons' shards.
+        $shards = hedley_general_two_person_node_shards($node);
         break;
 
       case 'stock_update':

--- a/server/hedley/modules/custom/hedley_general/hedley_general.module
+++ b/server/hedley/modules/custom/hedley_general/hedley_general.module
@@ -532,6 +532,47 @@ function hedley_general_shards_by_person($nid) {
 }
 
 /**
+ * Resolves the shards for a two-person linking node.
+ *
+ * A pmtct_participant or relationship links two people, so it must reach every
+ * device that syncs either of them. Its shards are therefore the union of both
+ * persons' shards.
+ *
+ * @param object $node
+ *   A pmtct_participant or relationship node.
+ *
+ * @return array
+ *   The union of both linked persons' shards.
+ *
+ * @throws \EntityMetadataWrapperException
+ */
+function hedley_general_two_person_node_shards($node) {
+  $wrapper = entity_metadata_wrapper('node', $node);
+
+  // The two person-reference fields differ by bundle.
+  if ($node->type == 'relationship') {
+    $person_ids = [
+      $wrapper->field_person->getIdentifier(),
+      $wrapper->field_related_to->getIdentifier(),
+    ];
+  }
+  else {
+    $person_ids = [
+      $wrapper->field_person->getIdentifier(),
+      $wrapper->field_adult->getIdentifier(),
+    ];
+  }
+
+  $shards = [];
+  foreach ($person_ids as $person_id) {
+    $person_shards = hedley_general_shards_by_person($person_id);
+    $shards = array_merge($shards, $person_shards);
+  }
+
+  return array_unique($shards);
+}
+
+/**
  * Implements hook_file_presave().
  *
  * If file is saved directly into 'private', sets it's uri and

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.module
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.module
@@ -202,8 +202,18 @@ function hedley_patient_recalculate_shards_for_person_content($person_id) {
     $wrapper = entity_metadata_wrapper('node', $node);
     $node_shards = $wrapper->field_shards->value(['identifier' => TRUE]);
 
-    if (!hedley_patient_arrays_equal($person_shards, $node_shards)) {
-      $wrapper->field_shards->set($person_shards);
+    // A pmtct_participant or relationship links two people, so its shards are
+    // the union of both. Setting them to a single person's shards would drop
+    // shards that only the other person carries.
+    if (in_array($node->type, ['pmtct_participant', 'relationship'])) {
+      $correct_shards = hedley_general_two_person_node_shards($node);
+    }
+    else {
+      $correct_shards = $person_shards;
+    }
+
+    if (!hedley_patient_arrays_equal($correct_shards, $node_shards)) {
+      $wrapper->field_shards->set($correct_shards);
       $wrapper->save();
     }
   }

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -372,4 +372,50 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
     );
   }
 
+  /**
+   * A two-person linking record keeps the union of both persons' shards.
+   *
+   * A relationship or pmtct_participant links two people, so its shards must be
+   * the union of both. hedley_patient_recalculate_shards_for_person_content()
+   * propagates one person's shards to their content, and must keep the union
+   * for these records. Otherwise the record drops off a health center that
+   * only the other person belongs to.
+   */
+  public function testLinkingRecordShardsSurviveRecalculation() {
+    $hc1 = $this->createHealthCenter();
+    $hc2 = $this->createHealthCenter();
+
+    // The adult syncs to one health center; the child to two.
+    $adult = $this->createPerson('AdultB057', [$hc1]);
+    $child = $this->createPerson('ChildB057', [$hc1, $hc2]);
+
+    // The relationship presave assigns the union of both persons' shards.
+    $relationship = $this->createRelationship($adult, $child, 'parent');
+
+    $union = [$hc1, $hc2];
+    sort($union);
+    $this->assertEqual(
+      $this->shardsOf($relationship),
+      $union,
+      'The relationship starts with the union of both persons\' shards.'
+    );
+
+    // Recalculating the adult's content must not reset the relationship to the
+    // adult's shards alone, which would drop the child-only health center.
+    hedley_patient_recalculate_shards_for_person_content($adult);
+    $this->assertEqual(
+      $this->shardsOf($relationship),
+      $union,
+      'Recalculating the adult keeps the child-only shard on the relationship.'
+    );
+
+    // Recalculating the child's content likewise leaves the union intact.
+    hedley_patient_recalculate_shards_for_person_content($child);
+    $this->assertEqual(
+      $this->shardsOf($relationship),
+      $union,
+      'Recalculating the child keeps the union on the relationship.'
+    );
+  }
+
 }


### PR DESCRIPTION
Fixes #1963

## What was wrong

`pmtct_participant` and `relationship` are two-person records, so `field_shards` must be the **union** of both linked persons' shards to reach every device that syncs either person. The presave sets that union — but only at insert (`hedley_device_assign_shards` returns early once `field_shards` is populated).

After insert, `hedley_patient_recalculate_shards_for_person_content()` is the sole maintainer, and it did `field_shards->set($person_shards)` — a single person's shards. Running it for one person of a linking record overwrote the union, dropping any health center only the other person carries. On `pmtct_participant` insert, `hedley_patient_node_insert` recalculates both persons, so the **last one (the adult) wins** and the child's extra shards are lost.

**Concrete:** child C in `[HC_A, HC_Y]`, adult A in `[HC_A]`, new participant P → presave `[HC_A, HC_Y]` → recalc overwrites to `[HC_A]` → P never syncs to HC_Y's devices.

Severity LOW–MED: linking records only (not measurements), and needs asymmetric multi-HC enrollment — uncommon but reachable by the official client.

## The fix

Extract the presave's union into `hedley_general_two_person_node_shards()` and use it in **both** places:
- the presave (deduplicating the two identical `pmtct_participant` / `relationship` cases), and
- the content recalc, which now recomputes the union for these two bundles instead of setting one person's shards.

Both persons' recalcs now compute the same union, so the last-writer race disappears. Recomputing (rather than merging with the existing value) keeps the record correct when a person *leaves* a health center — a plain merge would never contract.

## Verification

`php -l` and phpcs (Drupal + DrupalPractice, full CI extensions) clean. New SimpleTest `testLinkingRecordShardsSurviveRecalculation` in `HedleyPatientConsolidation`: enrolls a two-HC child + one-HC adult, links them, and asserts the relationship keeps the union after recalculating each person.

**Discrimination:** the middle assertion fails on the current code (recalculating the adult resets the relationship to `[HC_A]`, dropping the child-only HC) and passes with the fix. The presave's populated-`field_shards` early-return is what makes the clobber stick, so the assertion genuinely exercises the bug. Runs end-to-end in CI's `test_simpletest_linux`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)