### PR TITLE
Dashboard stats: show 0% instead of NaN% for proportions with an empty total

### DIFF
--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -66,6 +66,7 @@ import Pages.Prenatal.Utils exposing (preeclampsiaDiagnoses, severeAnemiaDiagnos
 import Pages.Utils
     exposing
         ( calculatePercentage
+        , percentageOfTotal
         , resolveSelectedDateForMonthSelector
         , viewCustomAction
         , viewCustomSelectListInput
@@ -1449,9 +1450,7 @@ viewGoodNutrition language caseNutritionTotalsThisYear caseNutritionTotalsLastYe
                 |> List.sum
 
         percentageThisYear =
-            (toFloat goodThisYear / toFloat allThisYear)
-                * 100
-                |> round
+            percentageOfTotal goodThisYear allThisYear
 
         percentageLastYear =
             calculatePercentage goodThisYear goodLastYear
@@ -3041,7 +3040,7 @@ viewChildWellnessNutritionPage language dateLastDayOfSelectedMonth assembled =
                     List.filter isGoodNutritionEncounter encountersForSelectedMonth
                         |> List.length
             in
-            round (100 * toFloat goodNutritionEncounters / toFloat totalEncountersCompleted)
+            percentageOfTotal goodNutritionEncounters totalEncountersCompleted
 
         -- Total Nutrition encounters performed during selected month.
         totalEncountersCompleted =

--- a/client/src/elm/Pages/Utils.elm
+++ b/client/src/elm/Pages/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
+module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, percentageOfTotal, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Entities exposing (HealthCenterId, PersonId)
@@ -237,6 +237,18 @@ calculatePercentage now before =
 
         else
             (toFloat diff / toFloat before) * -100
+
+
+{-| The share of `part` in `total`, as a rounded percentage. Returns 0 when
+`total` is 0, so an empty period shows "0%" rather than "NaN%".
+-}
+percentageOfTotal : Int -> Int -> Int
+percentageOfTotal part total =
+    if total == 0 then
+        0
+
+    else
+        round (toFloat part / toFloat total * 100)
 
 
 filterDependentNoResultsMessage : Language -> String -> TranslationId -> String

--- a/client/src/elm/Pages/Utils/Test.elm
+++ b/client/src/elm/Pages/Utils/Test.elm
@@ -1,0 +1,31 @@
+module Pages.Utils.Test exposing (all)
+
+import Expect
+import Pages.Utils exposing (percentageOfTotal)
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "Pages.Utils.percentageOfTotal"
+        [ test "returns 0 when the total is 0, instead of NaN" <|
+            \_ ->
+                percentageOfTotal 0 0
+                    |> Expect.equal 0
+        , test "returns 0 for a positive part over a zero total" <|
+            \_ ->
+                percentageOfTotal 5 0
+                    |> Expect.equal 0
+        , test "computes a rounded proportion" <|
+            \_ ->
+                percentageOfTotal 3 4
+                    |> Expect.equal 75
+        , test "rounds to the nearest whole percent" <|
+            \_ ->
+                percentageOfTotal 1 3
+                    |> Expect.equal 33
+        , test "is 100 when part equals total" <|
+            \_ ->
+                percentageOfTotal 7 7
+                    |> Expect.equal 100
+        ]


### PR DESCRIPTION
Fixes #1965

## What was wrong

Two Good Nutrition dashboard stats computed a proportion with raw division:

- Good Nutrition card: `round (toFloat goodThisYear / toFloat allThisYear * 100)`
- Percent of good-nutrition encounters this month: `round (100 * toFloat goodNutritionEncounters / toFloat totalEncountersCompleted)`

When the denominator is 0 — a brand-new health center, or an empty/quiet month — the division is `0 / 0 = NaN`, and the card rendered literally as **"NaN%"**.

## The fix

Add a zero-guarded proportion helper in `Pages/Utils.elm` and route both sites through it:

```elm
percentageOfTotal : Int -> Int -> Int
percentageOfTotal part total =
    if total == 0 then
        0
    else
        round (toFloat part / toFloat total * 100)
```

Empty data now shows "0%" instead of "NaN%".

The existing `calculatePercentage` helper is deliberately **not** reused here: it computes a percent *change* (`(now - before) / before`), not a proportion, so it would change the displayed numbers. (The nearby `percentageLastYear`, which *is* a change metric, keeps using it.)

## Verification

`elm make src/elm/Main.elm` — Success. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2843 passed, including 5 new cases on the pure `percentageOfTotal` in a new `Pages/Utils/Test.elm`.

**Discrimination:** dropping the `total == 0` guard fails exactly the two zero-total cases (they go NaN/Infinity instead of 0) while the three proportion/rounding cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)