### PR TITLE
Stock management: show Months of Stock for the current month on the Receive-Stock form

### DIFF
--- a/client/src/elm/Backend/StockUpdate/Test.elm
+++ b/client/src/elm/Backend/StockUpdate/Test.elm
@@ -213,6 +213,36 @@ generateDataTest =
                     |> Maybe.map .consumptionAverage
                     |> Maybe.map (\avg -> Expect.within (Absolute 0.01) 10 avg)
                     |> Maybe.withDefault (Expect.fail "Month not found in result")
+        , test "consumption average for the current month uses its 6 preceding months, not the current partial month" <|
+            \_ ->
+                let
+                    stockUpdates =
+                        [ makeStockUpdate
+                            { dateRecorded = date 2025 Time.May 1
+                            , quantity = 1000
+                            , updateType = UpdateReceivingSupplies
+                            }
+                        ]
+
+                    distributions =
+                        [ { dateMeasured = date 2025 Time.Aug 10, distributedAmount = 12 }
+                        , { dateMeasured = date 2025 Time.Sep 10, distributedAmount = 12 }
+                        , { dateMeasured = date 2025 Time.Oct 10, distributedAmount = 12 }
+                        , { dateMeasured = date 2025 Time.Nov 10, distributedAmount = 12 }
+                        , { dateMeasured = date 2025 Time.Dec 10, distributedAmount = 12 }
+                        , { dateMeasured = date 2026 Time.Jan 10, distributedAmount = 12 }
+
+                        -- The current month is excluded from its own average.
+                        , { dateMeasured = date 2026 Time.Feb 10, distributedAmount = 999 }
+                        ]
+
+                    result =
+                        generateStockManagementDataFromDistributions currentDate distributions stockUpdates
+                in
+                lookupMonth currentMonthYear result
+                    |> Maybe.map .consumptionAverage
+                    |> Maybe.map (\avg -> Expect.within (Absolute 0.01) 12 avg)
+                    |> Maybe.withDefault (Expect.fail "Current month not found in result")
         , test "multiple stock updates across months accumulate correctly" <|
             \_ ->
                 let

--- a/client/src/elm/Backend/StockUpdate/Utils.elm
+++ b/client/src/elm/Backend/StockUpdate/Utils.elm
@@ -109,10 +109,12 @@ generateStockManagementDataFromDistributions currentDate allDistributions allSto
                     (Date.add Date.Months 1 currentDate)
                 |> dateToMonthYear
 
-        -- Average month consumption is calculated by number of distributions issued
-        -- during past 6 months, so we use this data structure to calculate it.
+        -- Average month consumption is the amount distributed during the past 6
+        -- months divided by 6, so we use this data structure to calculate it.
+        -- The current month (gap 0) is included so its own window can be looked
+        -- up here; the window is always the 6 months before the month.
         distributionsByMonth =
-            List.range 1 18
+            List.range 0 18
                 |> List.map
                     (\monthGap ->
                         let


### PR DESCRIPTION
Fixes #1967

## What was wrong

On the Receive-Stock form — where a nurse decides how much stock to receive — the "Months of Stock" projection never rendered.

`distributionsByMonth = List.range 1 18 |> …` covers the past 18 months (gaps 1–18); the **current month (gap 0) is not in it**. `consumptionSixPastMonths` does `findIndex (key == monthYear) distributionsByMonth`, which returns `Nothing` for the current month, so `consumptionAverage = 0`. The form reads the current month's average and hides the indicator when it's 0. Past-month detail views worked, because those months are in the list.

## The fix

`List.range 1 18` → `List.range 0 18`.

The list is `List.reverse`d (oldest-first), so gap 0 lands at the end (newest). The current month is now found, and its window — `splitAt (index - 6) |> take 6` — selects the six months *before* it (gaps 1–6), **excluding** the partial current month. Past months keep their exact indices, so their averages are unchanged.

## Verification

`elm make src/elm/Main.elm` — Success. `elm-format`, `elm-review` (cold) clean. `elm-test` — 2839 passed, including a new current-month case.

**Discrimination:** reverting to `List.range 1 18` fails only the new current-month test (its average drops to 0) while the existing past-month test still passes — confirming the fix changes only current-month behavior. The new test also feeds the current month a distinct `999` distribution and asserts the average stays 12, proving the partial current month is excluded from its own window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)