### PR TITLE
Stock management: clear the form when entering the page

### DIFF
--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -1224,6 +1224,20 @@ update msg model =
                                     |> MsgLoggedIn
                                     |> List.singleton
 
+                        -- Clear the (singleton) stock management forms on entry, so a
+                        -- signed but abandoned form isn't shown again -- with its old
+                        -- signature and quantities -- and saved with today's date.
+                        -- Only on a genuine page change, not when already on the page.
+                        UserPage StockManagementPage ->
+                            if model.activePage == page then
+                                []
+
+                            else
+                                Pages.StockManagement.Model.Reset
+                                    |> MsgPageStockManagement
+                                    |> MsgLoggedIn
+                                    |> List.singleton
+
                         _ ->
                             []
             in

--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -1147,6 +1147,17 @@ update msg model =
                 cmd =
                     Nav.pushUrl model.navigationKey (Url.toString redirectUrl)
 
+                -- Messages to run only when we actually arrive at the page,
+                -- not when we're already on it. Pages that clear a form on
+                -- entry use this, so navigating within a page doesn't wipe
+                -- what the user is typing.
+                onEntry msgs =
+                    if model.activePage == page then
+                        []
+
+                    else
+                        msgs
+
                 extraMsgs =
                     case page of
                         -- When navigating to Device page (which is used for Sync management), trigger Sync.
@@ -1161,10 +1172,7 @@ update msg model =
                         UserPage (RelationshipPage id1 id2 initiator) ->
                             let
                                 resetMsgs =
-                                    if model.activePage == page then
-                                        []
-
-                                    else
+                                    onEntry
                                         [ Pages.Relationship.Model.Reset initiator
                                             |> MsgPageRelationship id1 id2
                                             |> MsgLoggedIn
@@ -1198,45 +1206,35 @@ update msg model =
 
                         -- When starting a new person registration, clear the (singleton)
                         -- create form, so a previous patient's abandoned entry can't
-                        -- pre-fill the next person's form. Only on a genuine page change,
-                        -- not when already on the page.
+                        -- pre-fill the next person's form.
                         UserPage (CreatePersonPage _ _) ->
-                            if model.activePage == page then
-                                []
-
-                            else
-                                Pages.Person.Model.ResetCreateForm
+                            onEntry
+                                [ Pages.Person.Model.ResetCreateForm
                                     |> MsgPageCreatePerson
                                     |> MsgLoggedIn
-                                    |> List.singleton
+                                ]
 
                         -- Likewise clear the (per-person) edit form on entry, so a
                         -- previously abandoned, unsaved edit isn't shown as the current
                         -- value and can't clobber a value synced from another device --
                         -- with the form empty, the view re-seeds it from the DB.
                         UserPage (EditPersonPage id) ->
-                            if model.activePage == page then
-                                []
-
-                            else
-                                Pages.Person.Model.ResetEditForm
+                            onEntry
+                                [ Pages.Person.Model.ResetEditForm
                                     |> MsgPageEditPerson id
                                     |> MsgLoggedIn
-                                    |> List.singleton
+                                ]
 
-                        -- Clear the (singleton) stock management forms on entry, so a
+                        -- Clear the (singleton) stock management page on entry, so a
                         -- signed but abandoned form isn't shown again -- with its old
-                        -- signature and quantities -- and saved with today's date.
-                        -- Only on a genuine page change, not when already on the page.
+                        -- signature and quantities -- and saved with today's date. Also
+                        -- returns the page to its main view and the current month.
                         UserPage StockManagementPage ->
-                            if model.activePage == page then
-                                []
-
-                            else
-                                Pages.StockManagement.Model.Reset
+                            onEntry
+                                [ Pages.StockManagement.Model.Reset
                                     |> MsgPageStockManagement
                                     |> MsgLoggedIn
-                                    |> List.singleton
+                                ]
 
                         _ ->
                             []

--- a/client/src/elm/Pages/StockManagement/Model.elm
+++ b/client/src/elm/Pages/StockManagement/Model.elm
@@ -124,7 +124,8 @@ type CorrectionEntryType
 
 
 type Msg
-    = SetActivePage Page
+    = Reset
+    | SetActivePage Page
     | SetDisplayMode DisplayMode
     | StoreSignature
     | ClearSignaturePad

--- a/client/src/elm/Pages/StockManagement/Update.elm
+++ b/client/src/elm/Pages/StockManagement/Update.elm
@@ -33,6 +33,12 @@ update currentDate context msg model =
                     Nothing
     in
     case msg of
+        Reset ->
+            ( emptyModel
+            , Cmd.none
+            , []
+            )
+
         SetActivePage page ->
             ( model
             , Cmd.none


### PR DESCRIPTION
Fixes #1969

## Problem

`stockManagementPage` is a singleton on the logged-in model, reset **only** by a validated save (`SaveReceiveStock` / `SaveCorrectEntry` return `emptyModel`). Nothing reset it on page entry: the page's own `SetActivePage` is a passthrough, and `App/Update.elm`'s `SetActivePage` entry messages had arms for `RelationshipPage`, `AcuteIllnessParticipantPage`, `CreatePersonPage` and `EditPersonPage` but none for `StockManagementPage`.

So a form filled in and signed but never saved survived leaving the page. On re-entry the stored signature is rendered again and the form is one tap from being saved as a fresh record — stale quantities and dates, but a **new** `dateMeasured`. Same stale-singleton-form class as #1838 / #1873.

Not an audit hole: a different nurse's signature can't be saved, because every nurse change goes through `SetLoggedIn`, which rebuilds `LoggedInModel` via `emptyLoggedInModel`.

## Changes

**1. Clear the form on entry** — a `Reset` msg on `Pages/StockManagement/Model.elm`, handled as `( emptyModel, Cmd.none, [] )`, dispatched from a guarded `UserPage StockManagementPage` arm. Whole-model reset matches what a successful save already does, and lands the nurse on the main view for the current month.

**2. Extract the entry guard** — `if model.activePage == page then [] else ...` was repeated in four arms; it is now a named `onEntry` used by all of them. Net fewer lines, and a new arm can't silently omit the guard, which would wipe a form on in-page navigation.

Navigation *within* the page is unaffected: the sub-page back buttons use `SetDisplayMode`, not `SetActivePage`.

## Review notes

A `high` review raised two points that were adjudicated rather than coded:

- **Entering through browser/device history still skips the reset** — `UrlChanged` assigns `activePage` and runs no entry messages. A fix was implemented and then withdrawn: because the client has essentially no `<a href>` navigation, it amounted to "Back/Forward now wipes forms" app-wide, destroying in-progress work and making #1970 reachable through ordinary navigation. Split out to **#1972** with the findings recorded.
- **The reset also discards partly filled, unsigned forms.** Kept deliberately, matching the `CreatePersonPage` precedent from #1837 and the save-success behaviour in this same file.

Two pre-existing bugs surfaced by the review are filed separately: **#1970** (relationship form unsavable when the session isn't cached) and **#1971** (abandoned signatures orphan blobs in the `photos-upload` cache).

## Testing

- `elm make src/elm/Main.elm` — 548 modules, matching the develop baseline
- `elm-test` — 2866 passing, 0 failing
- `elm-review` (cold) — no errors
- `elm-format --validate` — clean

No new tests: the three sibling reset arms have none and `Pages/StockManagement/` has no `Test.elm`, so this stayed consistent with the #1838 / #1873 precedent.