### PR TITLE
Group sessions: fetch the session on the pages that filter by it

### DIFF
--- a/client/src/elm/App/Fetch.elm
+++ b/client/src/elm/App/Fetch.elm
@@ -155,12 +155,12 @@ fetch model =
                 Pages.Prenatal.ProgressReport.Fetch.fetch prenatalEncounterId model.indexedDb
                     |> List.map MsgIndexedDb
 
-            UserPage (CreatePersonPage relatedId _) ->
-                Pages.Person.Fetch.fetchForCreateOrEdit relatedId model.indexedDb
+            UserPage (CreatePersonPage relatedId initiator) ->
+                Pages.Person.Fetch.fetchForCreateOrEdit relatedId (Just initiator) model.indexedDb
                     |> List.map MsgIndexedDb
 
             UserPage (EditPersonPage relatedId) ->
-                Pages.Person.Fetch.fetchForCreateOrEdit (Just relatedId) model.indexedDb
+                Pages.Person.Fetch.fetchForCreateOrEdit (Just relatedId) Nothing model.indexedDb
                     |> List.map MsgIndexedDb
 
             UserPage (DemographicsReportPage _ personId) ->
@@ -171,11 +171,11 @@ fetch model =
                 Pages.Person.Fetch.fetch id initiator model.indexedDb
                     |> List.map MsgIndexedDb
 
-            UserPage (PersonsPage relation _) ->
+            UserPage (PersonsPage relation initiator) ->
                 getLoggedInData model
                     |> Maybe.map
                         (\( _, loggedIn ) ->
-                            Pages.People.Fetch.fetch relation loggedIn.personsPage
+                            Pages.People.Fetch.fetch relation initiator loggedIn.personsPage
                                 |> List.map MsgIndexedDb
                         )
                     |> Maybe.withDefault []
@@ -270,8 +270,8 @@ fetch model =
                         )
                     |> Maybe.withDefault []
 
-            UserPage (RelationshipPage id1 id2 _) ->
-                Pages.Relationship.Fetch.fetch id1 id2
+            UserPage (RelationshipPage id1 id2 initiator) ->
+                Pages.Relationship.Fetch.fetch id1 id2 initiator
                     |> List.map MsgIndexedDb
 
             UserPage (FamilyEncounterParticipantsPage _) ->

--- a/client/src/elm/App/Fetch.elm
+++ b/client/src/elm/App/Fetch.elm
@@ -5,6 +5,7 @@ import App.Utils exposing (getLoggedInData)
 import AssocList as Dict
 import Backend.Fetch
 import Backend.NCDEncounter.Types exposing (NCDProgressReportInitiator(..))
+import Backend.Person.Model exposing (Initiator(..))
 import Gizra.NominalDate exposing (fromLocalDateTime)
 import Pages.AcuteIllness.Activity.Fetch
 import Pages.AcuteIllness.Activity.Model
@@ -156,11 +157,11 @@ fetch model =
                     |> List.map MsgIndexedDb
 
             UserPage (CreatePersonPage relatedId initiator) ->
-                Pages.Person.Fetch.fetchForCreateOrEdit relatedId (Just initiator) model.indexedDb
+                Pages.Person.Fetch.fetchForCreateOrEdit relatedId initiator model.indexedDb
                     |> List.map MsgIndexedDb
 
             UserPage (EditPersonPage relatedId) ->
-                Pages.Person.Fetch.fetchForCreateOrEdit (Just relatedId) Nothing model.indexedDb
+                Pages.Person.Fetch.fetchForCreateOrEdit (Just relatedId) ParticipantDirectoryOrigin model.indexedDb
                     |> List.map MsgIndexedDb
 
             UserPage (DemographicsReportPage _ personId) ->

--- a/client/src/elm/Pages/People/Fetch.elm
+++ b/client/src/elm/Pages/People/Fetch.elm
@@ -2,13 +2,15 @@ module Pages.People.Fetch exposing (fetch)
 
 import Backend.Entities exposing (..)
 import Backend.Model exposing (MsgIndexedDb(..))
+import Backend.Person.Model exposing (Initiator)
 import Components.PatientsSearchForm.Fetch
 import Maybe.Extra
 import Pages.People.Model exposing (Model)
+import Pages.Person.Fetch exposing (fetchSessionForInitiator)
 
 
-fetch : Maybe PersonId -> Model -> List MsgIndexedDb
-fetch relation model =
+fetch : Maybe PersonId -> Initiator -> Model -> List MsgIndexedDb
+fetch relation initiator model =
     let
         fetchRelation =
             Maybe.map FetchPerson relation
@@ -17,3 +19,4 @@ fetch relation model =
     Components.PatientsSearchForm.Fetch.fetch model
         ++ fetchRelation
         ++ [ FetchHealthCenters, FetchVillages ]
+        ++ fetchSessionForInitiator initiator

--- a/client/src/elm/Pages/People/Test.elm
+++ b/client/src/elm/Pages/People/Test.elm
@@ -1,0 +1,46 @@
+module Pages.People.Test exposing (all)
+
+import Backend.Entities exposing (SessionId)
+import Backend.Model exposing (MsgIndexedDb(..))
+import Backend.Person.Model exposing (Initiator(..))
+import Expect
+import Pages.People.Fetch exposing (fetch)
+import Pages.People.Model exposing (emptyModel)
+import Restful.Endpoint exposing (toEntityUuid)
+import Test exposing (Test, describe, test)
+
+
+sessionId : SessionId
+sessionId =
+    toEntityUuid "session-1"
+
+
+fetchTest : Test
+fetchTest =
+    describe "Pages.People.Fetch.fetch"
+        [ test "asks for the session when we came from a group encounter" <|
+            -- The search results are filtered by the group's graduating age, which
+            -- needs the session; without it every child is listed.
+            \_ ->
+                fetch Nothing (GroupEncounterOrigin sessionId) emptyModel
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal True
+        , test "does not ask for a session when we came from the participant directory" <|
+            \_ ->
+                fetch Nothing ParticipantDirectoryOrigin emptyModel
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal False
+        , test "still asks for what the page always needed" <|
+            \_ ->
+                fetch Nothing (GroupEncounterOrigin sessionId) emptyModel
+                    |> Expect.all
+                        [ List.member FetchHealthCenters >> Expect.equal True
+                        , List.member FetchVillages >> Expect.equal True
+                        ]
+        ]
+
+
+all : Test
+all =
+    describe "Pages.People"
+        [ fetchTest ]

--- a/client/src/elm/Pages/Person/Fetch.elm
+++ b/client/src/elm/Pages/Person/Fetch.elm
@@ -31,13 +31,10 @@ fetch id initiator db =
                         >> List.map FetchPerson
                     )
                 |> RemoteData.withDefault []
-
-        initiatorDependentContent =
-            fetchSessionForInitiator initiator
     in
     fetchFamilyMembers id db
         ++ participantMembers
-        ++ initiatorDependentContent
+        ++ fetchSessionForInitiator initiator
         ++ [ FetchPerson id
            , FetchRelationshipsForPerson id
            , FetchParticipantsForPerson id
@@ -45,7 +42,7 @@ fetch id initiator db =
            ]
 
 
-fetchForCreateOrEdit : Maybe PersonId -> Maybe Initiator -> ModelIndexedDb -> List MsgIndexedDb
+fetchForCreateOrEdit : Maybe PersonId -> Initiator -> ModelIndexedDb -> List MsgIndexedDb
 fetchForCreateOrEdit related initiator db =
     [ FetchHealthCenters
     , FetchVillages
@@ -55,10 +52,7 @@ fetchForCreateOrEdit related initiator db =
                 |> Maybe.map (\id -> FetchPerson id :: fetchFamilyMembers id db)
                 |> Maybe.withDefault []
            )
-        ++ (initiator
-                |> Maybe.map fetchSessionForInitiator
-                |> Maybe.withDefault []
-           )
+        ++ fetchSessionForInitiator initiator
 
 
 {-| In group encounter context the page needs the session itself, to know which

--- a/client/src/elm/Pages/Person/Fetch.elm
+++ b/client/src/elm/Pages/Person/Fetch.elm
@@ -55,8 +55,9 @@ fetchForCreateOrEdit related initiator db =
         ++ fetchSessionForInitiator initiator
 
 
-{-| In group encounter context the page needs the session itself, to know which
-group it belongs to. Without it the group is missing and the page can't be used.
+{-| Fetches the session a page was opened from, when it was opened from a group
+encounter. The pages that use this read the session to decide what to offer:
+which group to add someone to, and which children are the right age for it.
 -}
 fetchSessionForInitiator : Initiator -> List MsgIndexedDb
 fetchSessionForInitiator initiator =

--- a/client/src/elm/Pages/Person/Fetch.elm
+++ b/client/src/elm/Pages/Person/Fetch.elm
@@ -1,4 +1,4 @@
-module Pages.Person.Fetch exposing (fetch, fetchForCreateOrEdit)
+module Pages.Person.Fetch exposing (fetch, fetchForCreateOrEdit, fetchSessionForInitiator)
 
 import AssocList as Dict
 import Backend.Entities exposing (..)
@@ -33,12 +33,7 @@ fetch id initiator db =
                 |> RemoteData.withDefault []
 
         initiatorDependentContent =
-            case initiator of
-                GroupEncounterOrigin sessionId ->
-                    [ FetchSession sessionId ]
-
-                _ ->
-                    []
+            fetchSessionForInitiator initiator
     in
     fetchFamilyMembers id db
         ++ participantMembers
@@ -50,8 +45,8 @@ fetch id initiator db =
            ]
 
 
-fetchForCreateOrEdit : Maybe PersonId -> ModelIndexedDb -> List MsgIndexedDb
-fetchForCreateOrEdit related db =
+fetchForCreateOrEdit : Maybe PersonId -> Maybe Initiator -> ModelIndexedDb -> List MsgIndexedDb
+fetchForCreateOrEdit related initiator db =
     [ FetchHealthCenters
     , FetchVillages
     , FetchClinics
@@ -60,6 +55,23 @@ fetchForCreateOrEdit related db =
                 |> Maybe.map (\id -> FetchPerson id :: fetchFamilyMembers id db)
                 |> Maybe.withDefault []
            )
+        ++ (initiator
+                |> Maybe.map fetchSessionForInitiator
+                |> Maybe.withDefault []
+           )
+
+
+{-| In group encounter context the page needs the session itself, to know which
+group it belongs to. Without it the group is missing and the page can't be used.
+-}
+fetchSessionForInitiator : Initiator -> List MsgIndexedDb
+fetchSessionForInitiator initiator =
+    case initiator of
+        GroupEncounterOrigin sessionId ->
+            [ FetchSession sessionId ]
+
+        _ ->
+            []
 
 
 fetchFamilyMembers : PersonId -> ModelIndexedDb -> List MsgIndexedDb

--- a/client/src/elm/Pages/Person/Test.elm
+++ b/client/src/elm/Pages/Person/Test.elm
@@ -1,0 +1,56 @@
+module Pages.Person.Test exposing (all)
+
+import Backend.Entities exposing (PersonId, SessionId)
+import Backend.Model exposing (MsgIndexedDb(..), emptyModelIndexedDb)
+import Backend.Person.Model exposing (Initiator(..))
+import Expect
+import Pages.Person.Fetch exposing (fetchForCreateOrEdit)
+import Restful.Endpoint exposing (toEntityUuid)
+import Test exposing (Test, describe, test)
+
+
+sessionId : SessionId
+sessionId =
+    toEntityUuid "session-1"
+
+
+relatedId : PersonId
+relatedId =
+    toEntityUuid "person-1"
+
+
+fetchForCreateOrEditTest : Test
+fetchForCreateOrEditTest =
+    describe "Pages.Person.Fetch.fetchForCreateOrEdit"
+        [ test "asks for the session when we came from a group encounter" <|
+            -- The form limits the birth date by the group's age range, which it
+            -- can only do with the session in hand.
+            \_ ->
+                fetchForCreateOrEdit Nothing (GroupEncounterOrigin sessionId) emptyModelIndexedDb
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal True
+        , test "asks for the session when registering a relative of someone" <|
+            \_ ->
+                fetchForCreateOrEdit (Just relatedId) (GroupEncounterOrigin sessionId) emptyModelIndexedDb
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal True
+        , test "does not ask for a session when we came from the participant directory" <|
+            \_ ->
+                fetchForCreateOrEdit Nothing ParticipantDirectoryOrigin emptyModelIndexedDb
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal False
+        , test "still asks for what the form always needed" <|
+            \_ ->
+                fetchForCreateOrEdit Nothing (GroupEncounterOrigin sessionId) emptyModelIndexedDb
+                    |> Expect.all
+                        [ List.member FetchHealthCenters >> Expect.equal True
+                        , List.member FetchVillages >> Expect.equal True
+                        , List.member FetchClinics >> Expect.equal True
+                        ]
+        ]
+
+
+all : Test
+all =
+    describe "Pages.Person"
+        [ fetchForCreateOrEditTest ]

--- a/client/src/elm/Pages/Relationship/Fetch.elm
+++ b/client/src/elm/Pages/Relationship/Fetch.elm
@@ -2,10 +2,12 @@ module Pages.Relationship.Fetch exposing (fetch)
 
 import Backend.Entities exposing (..)
 import Backend.Model exposing (MsgIndexedDb(..))
+import Backend.Person.Model exposing (Initiator)
+import Pages.Person.Fetch exposing (fetchSessionForInitiator)
 
 
-fetch : PersonId -> PersonId -> List MsgIndexedDb
-fetch id1 id2 =
+fetch : PersonId -> PersonId -> Initiator -> List MsgIndexedDb
+fetch id1 id2 initiator =
     -- FetchRelationshipsForPerson gets both sides, so we don't
     -- need to do it twice.
     [ FetchRelationshipsForPerson id1
@@ -14,3 +16,4 @@ fetch id1 id2 =
     , FetchPerson id2
     , FetchClinics
     ]
+        ++ fetchSessionForInitiator initiator

--- a/client/src/elm/Pages/Relationship/Test.elm
+++ b/client/src/elm/Pages/Relationship/Test.elm
@@ -1,0 +1,58 @@
+module Pages.Relationship.Test exposing (all)
+
+import Backend.Entities exposing (PersonId, SessionId)
+import Backend.Model exposing (MsgIndexedDb(..))
+import Backend.Person.Model exposing (Initiator(..))
+import Expect
+import Pages.Relationship.Fetch exposing (fetch)
+import Restful.Endpoint exposing (toEntityUuid)
+import Test exposing (Test, describe, test)
+
+
+sessionId : SessionId
+sessionId =
+    toEntityUuid "session-1"
+
+
+person1 : PersonId
+person1 =
+    toEntityUuid "person-1"
+
+
+person2 : PersonId
+person2 =
+    toEntityUuid "person-2"
+
+
+fetchTest : Test
+fetchTest =
+    describe "Pages.Relationship.Fetch.fetch"
+        [ test "asks for the session when we came from a group encounter" <|
+            -- The page reads the session to know which group it belongs to. Without
+            -- this the group selector has no options at all and the nurse can't save.
+            \_ ->
+                fetch person1 person2 (GroupEncounterOrigin sessionId)
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal True
+        , test "does not ask for a session when we came from the participant directory" <|
+            \_ ->
+                fetch person1 person2 ParticipantDirectoryOrigin
+                    |> List.member (FetchSession sessionId)
+                    |> Expect.equal False
+        , test "still asks for what the page always needed" <|
+            \_ ->
+                fetch person1 person2 (GroupEncounterOrigin sessionId)
+                    |> Expect.all
+                        [ List.member (FetchRelationshipsForPerson person1) >> Expect.equal True
+                        , List.member (FetchParticipantsForPerson person1) >> Expect.equal True
+                        , List.member (FetchPerson person1) >> Expect.equal True
+                        , List.member (FetchPerson person2) >> Expect.equal True
+                        , List.member FetchClinics >> Expect.equal True
+                        ]
+        ]
+
+
+all : Test
+all =
+    describe "Pages.Relationship"
+        [ fetchTest ]


### PR DESCRIPTION
Fixes #1970

Also closes backlog item **B-074**, which covers all three sites below — same root cause, so they are fixed together as the backlog entry scopes it.

## Problem

Three pages read the session when they were opened from a group encounter, but the fetch dispatch in `App/Fetch.elm` discarded the initiator (`UserPage (RelationshipPage id1 id2 _)` and friends), so `FetchSession` was never issued. All three are masked in normal navigation, because an earlier page has usually loaded the session already — they only bite on a hard refresh, which is why they went unnoticed.

**(a) Relationship page — the worst.** `Pages/Relationship/View.elm`'s `initiatorCondition` is:

```elm
getSession sessionId db
    |> Maybe.map (.clinicId >> (==) clinicId)
    |> Maybe.withDefault False
```

With no session that is `False` for **every** clinic, so the filter excludes all of them — and in `GroupEncounterOrigin` context `emptyOption` is `emptyNode`, so the "Add to Group" select renders with **zero options**. Save is disabled on `isNothing assignToGroup`, leaving the nurse at a dead end with no in-page recovery.

Note this corrects the mechanism described in #1970, which said the dropdown shows one unselectable clinic. It is actually empty.

**(b) People page.** `childAgeCondition` falls back to `True` without the session, so the graduating-age filter is silently off and children too old for the group are listed.

**(c) Create person page.** The birth-date limit falls back to `defaultMaximalAge` (13y), so an over-age child can be registered into a group session.

## Fix

Thread the initiator through to the three fetches and ask for the session, reusing the pattern `Pages/Person/Fetch.elm` already used for `PersonPage` — extracted as `fetchSessionForInitiator` rather than copied four times.

`fetchForCreateOrEdit` takes a plain `Initiator`; the edit page passes `ParticipantDirectoryOrigin`, matching what `App/View.elm` already hands its view.

`FetchSession` is gated on `isNotAsked` in `Backend/Fetch.elm`, so this adds one fetch per page entry and cannot loop. Because these pages now *want* the session, `forget` also stops pruning it out from under them after the five-minute window.

## Testing

- `elm make src/elm/Main.elm` — 548 modules
- `elm-test` — **2876 passing**, 0 failing (up 10 from the 2866 baseline)
- `elm-review` (cold) — no errors
- `elm-format --validate` — clean

New tests cover all three fixed sites (`Pages/Relationship/Test.elm`, `Pages/People/Test.elm`, `Pages/Person/Test.elm`). Verified discriminating rather than vacuous: neutering `fetchSessionForInitiator` fails 4 tests across all three files, and restoring it returns to green.