### PR TITLE
Batch scripts: order them by node id

### DIFF
--- a/server/hedley/modules/custom/hedley_ncda/scripts/generate-data-for-all.php
+++ b/server/hedley/modules/custom/hedley_ncda/scripts/generate-data-for-all.php
@@ -33,7 +33,8 @@ $base_query = hedley_general_create_entity_field_query_excluding_deleted();
 $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 if ($exclude_set) {
   $base_query->addTag('exclude_set_ncda_data');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-acute-illness-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-acute-illness-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'acute-illness')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-child-scoreboard-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-child-scoreboard-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'child-scoreboard')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-hiv-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-hiv-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'hiv')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-home-visit-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-home-visit-data.php
@@ -30,7 +30,8 @@ $base_query = hedley_general_create_entity_field_query_excluding_deleted();
 $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 if ($exclude_set) {
   $base_query->addTag('exclude_set_reports_data');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-ncd-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-ncd-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'ncd')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-nutrition-group-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-nutrition-group-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_attended', 'value', TRUE)
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 if ($exclude_set) {
   $base_query->addTag('exclude_set_reports_data');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-nutrition-individual-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-nutrition-individual-data.php
@@ -30,7 +30,8 @@ $base_query = hedley_general_create_entity_field_query_excluding_deleted();
 $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 if ($exclude_set) {
   $base_query->addTag('exclude_set_reports_data');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-prenatal-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-prenatal-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'antenatal')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-tuberculosis-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-tuberculosis-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'tuberculosis')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-well-child-data.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/completion-generate-well-child-data.php
@@ -31,7 +31,8 @@ $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
   ->fieldCondition('field_encounter_type', 'value', 'well-child')
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 $count_query = clone $base_query;
 $count_query->propertyCondition('nid', $nid, '>');

--- a/server/hedley/modules/custom/hedley_reports/scripts/generate-data-for-all.php
+++ b/server/hedley/modules/custom/hedley_reports/scripts/generate-data-for-all.php
@@ -30,7 +30,8 @@ $base_query = hedley_general_create_entity_field_query_excluding_deleted();
 $base_query
   ->entityCondition('entity_type', 'node')
   ->entityCondition('bundle', $type)
-  ->propertyCondition('status', NODE_PUBLISHED);
+  ->propertyCondition('status', NODE_PUBLISHED)
+  ->propertyOrderBy('nid');
 
 if ($exclude_set) {
   $base_query->addTag('exclude_set_reports_data');


### PR DESCRIPTION
Fixes #1975

## Problem

Twelve batch scripts page through nodes with a keyset walk — `propertyCondition('nid', $nid, '>')`, `range(0, $batch)`, then `$nid = end($ids)` — without ever asking the database for an order. Nothing guarantees the last row of a batch carries the highest nid, and if it doesn't, every node between the true maximum and the value `end($ids)` returns is stepped over and never processed, silently.

The base query comes from `hedley_general_create_entity_field_query_excluding_deleted()`, whose tag adds a LEFT JOIN; eight of the completion scripts additionally carry a `fieldCondition`, which routes the query through field storage with the entity table joined in. Both give the planner more latitude in how rows come back.

**Honest status:** the mechanism is clear from the code, but whether it actually occurs on MariaDB 10.5 for these queries **has not been observed** — it is planner-dependent. This is a guard and a consistency correction, not the repair of a reproduced failure. The commit messages say the same.

## Fix

`->propertyOrderBy('nid')` on the base query, in 12 scripts — one line each:

- `hedley_ncda/scripts/generate-data-for-all.php`
- `hedley_reports/scripts/generate-data-for-all.php`
- `hedley_reports/scripts/completion-generate-*.php` (10)

This is the existing majority-of-the-live-scripts pattern rather than a new invention: 14 of the 35 scripts using `propertyCondition('nid')` already order this way, and `hedley_stats/scripts/recalculate-stats.php` is structurally identical to `generate-data-for-all.php` — same base query, same `clone` → `count()`, same keyset loop — and already has the ordering.

## If records have already been skipped

The fix prevents future skips but repairs nothing already missing, so stating the recovery paths explicitly:

- **NCDA** — `generate-data-for-all.php --exclude_set=1` processes only persons whose data was never set, which fills gaps cheaply.
- **Completion reports** — no equivalent flag; closing a gap means a full re-run from nid 0.

Neither is triggered by this change. They are operator decisions if a gap is ever suspected.

## Deliberately not included

Eight other keyset-paging scripts also lack the ordering and are left alone — mostly one-shot migration scripts of unverified liveness, and one already assessed as retired. Recorded in **#1976** rather than left implicit, along with the observation that the batch walk being hand-copied across ~20 scripts is why 21 of 35 ended up missing the ordering in the first place.

`hedley_migrate/scripts/validate-villages-migration.php` uses `propertyCondition('nid')` but does not keyset-page, so it is unaffected.

## Testing

- `php -l` — clean on all 12
- `phpcs --standard=Drupal` and `--standard=DrupalPractice` with the full CI extension list — clean on all 12
- Each changed file verified to have exactly one `propertyOrderBy('nid')`, on the base query, and to genuinely keyset-page via `$nid = end($ids)`

Both EntityFieldQuery engine paths were checked to support property ordering: `field_sql_storage_field_storage_query()` joins the entity base table and orders on it, and `propertyQuery()` applies `$this->order` directly. All 12 scripts set `entityCondition('entity_type', 'node')`, so the `EntityFieldQueryException` for property ordering without an entity type cannot fire. The `clone`d count queries are unaffected, since `finishQuery()` routes counts through `countQuery()`.

Not measured: the ordering cost on the field-storage path for a long backfill over a populated production database.