### PR TITLE
Measurements: don't let number inputs take a negative

### DIFF
--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -97,6 +97,7 @@ import Pages.Prenatal.View
 import Pages.Utils
     exposing
         ( customButton
+        , dropLeadingMinus
         , maybeToBoolTask
         , resolveActiveTask
         , resolveNextTask
@@ -4383,7 +4384,7 @@ viewNumberInput language maybeCurrentValue setMsg inputClass labelTranslationId 
                     [ type_ "number"
                     , Html.Attributes.min "0"
                     , Html.Attributes.max "99"
-                    , onInput setMsg
+                    , onInput (dropLeadingMinus >> setMsg)
                     , value currentValue
                     ]
                     []

--- a/client/src/elm/Pages/Utils.elm
+++ b/client/src/elm/Pages/Utils.elm
@@ -711,8 +711,12 @@ viewCheckBoxSelectInputItem checkedOptions setMsg viewOptionFunc option =
 Everything these inputs collect -- lengths, weights, counts, lab values -- is a
 quantity that can't be negative. The `min` attribute only points the spinner
 arrows the right way; a minus that is typed or pasted still reaches the message
-and parses. Dropping it keeps the digits, so what the field shows and what is
-stored stay the same.
+and parses. Dropping it keeps the digits, so what is stored is never negative.
+
+A minus put in front of a number the field already holds still shows in the
+field: what is left after dropping it is the value already there, so nothing
+re-renders. The positive number is what gets stored, and the next keystroke
+brings the two back together.
 
 -}
 dropLeadingMinus : String -> String

--- a/client/src/elm/Pages/Utils.elm
+++ b/client/src/elm/Pages/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, percentageOfTotal, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
+module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, dropLeadingMinus, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, percentageOfTotal, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Entities exposing (HealthCenterId, PersonId)
@@ -706,6 +706,24 @@ viewCheckBoxSelectInputItem checkedOptions setMsg viewOptionFunc option =
         ]
 
 
+{-| Drops a minus sign typed at the front of a number.
+
+Everything these inputs collect -- lengths, weights, counts, lab values -- is a
+quantity that can't be negative. The `min` attribute only points the spinner
+arrows the right way; a minus that is typed or pasted still reaches the message
+and parses. Dropping it keeps the digits, so what the field shows and what is
+stored stay the same.
+
+-}
+dropLeadingMinus : String -> String
+dropLeadingMinus value =
+    if String.startsWith "-" value then
+        String.dropLeft 1 value
+
+    else
+        value
+
+
 viewNumberInput : Maybe Int -> (String -> msg) -> String -> Html msg
 viewNumberInput maybeCurrentValue setMsg inputClass =
     let
@@ -716,7 +734,7 @@ viewNumberInput maybeCurrentValue setMsg inputClass =
         inputAttrs =
             [ type_ "number"
             , Html.Attributes.min "0"
-            , onInput setMsg
+            , onInput (dropLeadingMinus >> setMsg)
             , value currentValue
             ]
     in
@@ -735,7 +753,7 @@ viewMeasurementInput language maybeCurrentValue setMsg inputClass unitTranslatio
         inputAttrs =
             [ type_ "number"
             , Html.Attributes.min "0"
-            , onInput setMsg
+            , onInput (dropLeadingMinus >> setMsg)
             , value currentValue
             ]
     in

--- a/client/src/elm/Pages/Utils/Test.elm
+++ b/client/src/elm/Pages/Utils/Test.elm
@@ -1,12 +1,12 @@
 module Pages.Utils.Test exposing (all)
 
 import Expect
-import Pages.Utils exposing (percentageOfTotal)
+import Pages.Utils exposing (dropLeadingMinus, percentageOfTotal)
 import Test exposing (Test, describe, test)
 
 
-all : Test
-all =
+percentageOfTotalTest : Test
+percentageOfTotalTest =
     describe "Pages.Utils.percentageOfTotal"
         [ test "returns 0 when the total is 0, instead of NaN" <|
             \_ ->
@@ -28,4 +28,48 @@ all =
             \_ ->
                 percentageOfTotal 7 7
                     |> Expect.equal 100
+        ]
+
+
+dropLeadingMinusTest : Test
+dropLeadingMinusTest =
+    describe "Pages.Utils.dropLeadingMinus"
+        [ test "drops a minus typed in front of a number" <|
+            \_ ->
+                dropLeadingMinus "-5"
+                    |> Expect.equal "5"
+        , test "keeps the digits, so the amount typed is not lost" <|
+            \_ ->
+                dropLeadingMinus "-37.5"
+                    |> Expect.equal "37.5"
+        , test "leaves a positive number alone" <|
+            \_ ->
+                dropLeadingMinus "37.5"
+                    |> Expect.equal "37.5"
+        , test "leaves an empty field alone, so it can still be cleared" <|
+            \_ ->
+                dropLeadingMinus ""
+                    |> Expect.equal ""
+        , test "leaves a lone minus as nothing, rather than as a value" <|
+            \_ ->
+                dropLeadingMinus "-"
+                    |> Expect.equal ""
+        , test "does not touch a minus that is part of the number, such as an exponent" <|
+            -- A number field accepts 1e-5. Removing every minus would turn that
+            -- into 1e5, which is a much larger number rather than a smaller one.
+            \_ ->
+                dropLeadingMinus "1e-5"
+                    |> Expect.equal "1e-5"
+        , test "drops only the leading minus of a negative exponent value" <|
+            \_ ->
+                dropLeadingMinus "-1e-5"
+                    |> Expect.equal "1e-5"
+        ]
+
+
+all : Test
+all =
+    describe "Pages.Utils"
+        [ percentageOfTotalTest
+        , dropLeadingMinusTest
         ]


### PR DESCRIPTION
Fixes #1978

## Problem

`Html.Attributes.min "0"` on the shared numeric inputs only points the spinner arrows the right way. It blocks nothing: `-5` is a valid number to the DOM, `onInput` fires with it, and every consumer parses it with a bare `String.toInt` / `String.toFloat`. A weight of `-37.5` is stored, and `taskCompleted` being `isJust` means the task also counts as done.

Everything these inputs collect is a quantity that cannot be negative — lengths, weights, counts, lab values. I checked the unit translation ID at all 36 `viewMeasurementInput` call sites: cm, mm, kg, g, BMI, mmHg, Celsius, bpm, breaths/min, mg/dL, g/dL, copies/mm³, IU/L, %, Apgar 0-10. **No consumer legitimately needs a negative**, so sanitising in the shared helper cannot break one.

Today only 2½ of those 36 guard the sign: EDD weeks and days (range checks that happen to have a lower bound) and Aheza. Fetal heart rate filters out `0` but lets `-5` through.

## Changes

`dropLeadingMinus` in `Pages/Utils.elm`, wired into all three copies of the pattern:

- `viewNumberInput` (4 call sites — two stock quantities, two NCD social-history counts)
- `viewMeasurementInput` (36 call sites — 12 lab-result fields, 5 vitals fields reached from six modules, plus anthropometrics)
- `Pages/Prenatal/Activity/View.elm`'s local `viewNumberInput` (6 call sites) — found by grepping the pattern rather than trusting the issue; fixing two of three would have been odd

**Why drop the sign rather than reject to empty:** `value` is bound to the model, so forwarding `""` when the model is already `Nothing` produces no virtual-DOM change — the typed `-5` would stay visible while nothing was stored. Dropping the sign keeps display and model in agreement. Only the *leading* minus goes, so `1e-5` is not turned into `1e5`.

## Two limitations, stated rather than hidden

**1. Prepending a minus to an existing value still displays wrong.** If the field holds `5` and a minus is typed in front, the sanitized string is `"5"` — the value the model already has — so Elm emits no patch and the field keeps showing `-5` while `5` is stored. The model is authoritative: the saved value is always sanitized, and the display corrects on the next keystroke. Strictly better than today, where the negative is both shown and stored, but not a complete fix for the display. A clean fix needs either a no-op message the helper can send or a signature change across all 46 call sites.

**2. The wiring is untested.** The 7 new tests exercise `dropLeadingMinus` directly. Nothing asserts that the three inputs call it, so silently unwiring one would keep the suite green. Elm makes view assertions awkward enough that I did not reach for elm-program-test on a 3-line change.

## Not included

This closes the negative hole only. `max` is unenforced in exactly the same way, and a sweep found that Prenatal (height/weight/BMI/MUAC), the shared NCDA form (weight/MUAC/birth weight, reached from four modules), ChildScoreboard, WellChild birth weight/length, and WellChild head circumference have **no range gate at all** — a height of 1050 cm is typeable and saveable there. Filed separately, since adding range gates changes what can be saved and wants clinical sign-off.

## Testing

- `elm make src/elm/Main.elm` — 548 modules
- `elm-test` — **2873 passing** (+7), 0 failing
- `elm-review` (cold) — no errors
- `elm-format --validate` — clean

Discrimination checked: making `dropLeadingMinus` the identity function fails 4 tests; restoring returns to green.