### PR TITLE
Measurements: show prenatal MUAC in the unit the site uses

### DIFF
--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -663,7 +663,7 @@ update msg model =
                                     data.prenatalActivityPages
                                         |> Dict.get ( id, activity )
                                         |> Maybe.withDefault Pages.Prenatal.Activity.Model.emptyModel
-                                        |> Pages.Prenatal.Activity.Update.update currentDate id model.indexedDb subMsg
+                                        |> Pages.Prenatal.Activity.Update.update currentDate site id model.indexedDb subMsg
                             in
                             ( { data | prenatalActivityPages = Dict.insert ( id, activity ) subModel data.prenatalActivityPages }
                             , Cmd.map (MsgLoggedIn << MsgPagePrenatalActivity id activity) subCmd

--- a/client/src/elm/Pages/Prenatal/Activity/Model.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Model.elm
@@ -112,6 +112,7 @@ type Msg
     | SaveVitals PersonId (Maybe ( VitalsId, Vitals )) (Maybe ExaminationTask)
       -- ExaminationMsgs, Nutrition Assessment
     | SetNutritionAssessmentMeasurement (Maybe Float -> NutritionAssessmentForm -> NutritionAssessmentForm) String
+    | SetNutritionAssessmentMuac String
     | SaveNutritionAssessment PersonId (Maybe ( PrenatalNutritionId, PrenatalNutrition )) (Maybe Float) (Maybe Bool) (Maybe ExaminationTask)
       -- ExaminationMsgs, Core Physical Exam
     | SetCorePhysicalExamBoolInput (Bool -> CorePhysicalExamForm -> CorePhysicalExamForm) Bool

--- a/client/src/elm/Pages/Prenatal/Activity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Update.elm
@@ -72,12 +72,13 @@ import Pages.Prenatal.Activity.Model exposing (Model, Msg(..), emptyPregnancyDat
 import Pages.Prenatal.Activity.Types exposing (ImmunisationTask(..), ObstetricHistoryStep(..), SymptomReviewStep(..), WarningPopupType(..))
 import Pages.Prenatal.Activity.Utils exposing (birthPlanFormWithDefault, breastExamFormWithDefault, dangerSignsFormWithDefault, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, guExamFormWithDefault, medicalHistoryFormWithDefault, mentalHealthFormWithDefault, obstetricHistoryStep2FormWithDefault, obstetricalExamFormWithDefault, symptomReviewFormWithDefault, toAppointmentConfirmationValueWithDefault, toBirthPlanValueWithDefault, toBreastExamValueWithDefault, toBreastfeedingValueWithDefault, toDangerSignsValueWithDefault, toFollowUpValueWithDefault, toGUExamValueWithDefault, toHealthEducationValueWithDefault, toLastMenstrualPeriodValueWithDefault, toMedicalHistoryValueWithDefault, toMedicationValueWithDefault, toObstetricHistoryStep2ValueWithDefault, toObstetricHistoryValueWithDefault, toObstetricalExamValueWithDefault, toPregnancyTestValueWithDefault, toPrenatalMentalHealthValueWithDefault, toPrenatalNutritionValueWithDefault, toSocialHistoryValueWithDefault, toSpecialityCareValueWithDefault, toSymptomReviewValueWithDefault, toUltrasoundValueWithDefault, updateSymptomReviewFormWithSymptoms, updateVaccinationFormByVaccineType)
 import Pages.Prenatal.Utils exposing (medicationDistributionFormWithDefaultInitialPhase, referralFormWithDefault, toMalariaPreventionValueWithDefault, toMedicationDistributionValueWithDefaultInitialPhase, toPrenatalReferralValueWithDefault)
-import Pages.Utils exposing (insertIntoSet, nonAdministrationReasonToSign, saveMeasurementMsgs, setMultiSelectInputValue, tasksBarId)
+import Pages.Utils exposing (insertIntoSet, nonAdministrationReasonToSign, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, tasksBarId)
 import RemoteData exposing (RemoteData(..))
+import SyncManager.Model exposing (Site)
 
 
-update : NominalDate -> PrenatalEncounterId -> ModelIndexedDb -> Msg -> Model -> ( Model, Cmd Msg, List App.Model.Msg )
-update currentDate id db msg model =
+update : NominalDate -> Site -> PrenatalEncounterId -> ModelIndexedDb -> Msg -> Model -> ( Model, Cmd Msg, List App.Model.Msg )
+update currentDate site id db msg model =
     let
         medicalHistoryForm =
             Dict.get id db.prenatalMeasurements
@@ -581,7 +582,7 @@ update currentDate id db msg model =
             , Cmd.none
             , appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetCSectionReason reason ->
             let
@@ -716,7 +717,7 @@ update currentDate id db msg model =
             , Cmd.none
             , App.Model.ScrollToElement tasksBarId :: appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetMedicalHistorySigns value ->
             let
@@ -828,7 +829,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveMedicalHistory personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateHistoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateHistoryMsgs nextTask)
 
         SetSocialBoolInput formUpdateFunc value ->
             let
@@ -854,7 +855,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveSocialHistory personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateHistoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateHistoryMsgs nextTask)
 
         SetOutsideCareStep step ->
             let
@@ -1002,7 +1003,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveOutsideCare personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateHistoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateHistoryMsgs nextTask)
 
         SetActiveExaminationTask task ->
             let
@@ -1054,7 +1055,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveVitals personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateExaminationMsgs nextTask)
 
         SetNutritionAssessmentMeasurement formUpdateFunc value ->
             let
@@ -1062,6 +1063,22 @@ update currentDate id db msg model =
                     let
                         updatedForm =
                             formUpdateFunc (String.toFloat value) model.examinationData.nutritionAssessmentForm
+                    in
+                    model.examinationData
+                        |> (\data -> { data | nutritionAssessmentForm = updatedForm })
+            in
+            ( { model | examinationData = updatedData }
+            , Cmd.none
+            , []
+            )
+
+        SetNutritionAssessmentMuac string ->
+            let
+                updatedData =
+                    let
+                        updatedForm =
+                            model.examinationData.nutritionAssessmentForm
+                                |> (\form -> { form | muac = setMuacValueForSite site string, muacDirty = True })
                     in
                     model.examinationData
                         |> (\data -> { data | nutritionAssessmentForm = updatedForm })
@@ -1113,7 +1130,7 @@ update currentDate id db msg model =
             , Cmd.none
             , saveMsg ++ setAdequateGWGMsg
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetCorePhysicalExamBoolInput formUpdateFunc value ->
             let
@@ -1259,7 +1276,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveCorePhysicalExam personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateExaminationMsgs nextTask)
 
         SetObstetricalExamBoolInput formUpdateFunc value ->
             let
@@ -1412,7 +1429,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveObstetricalExam personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateExaminationMsgs nextTask)
 
         SetBreastExamBoolInput formUpdateFunc value ->
             let
@@ -1487,7 +1504,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveBreastExam personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateExaminationMsgs nextTask)
 
         SetGUExamBoolInput formUpdateFunc value ->
             let
@@ -1548,7 +1565,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveGUExam personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateExaminationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateExaminationMsgs nextTask)
 
         SetFamilyPlanningSign sign ->
             let
@@ -1655,7 +1672,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveAspirin personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetCalciumAdministered value ->
             let
@@ -1696,7 +1713,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveCalcium personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetFefolAdministered value ->
             let
@@ -1737,7 +1754,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveFefol personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetFolateAdministered value ->
             let
@@ -1778,7 +1795,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveFolate personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetIronAdministered value ->
             let
@@ -1819,7 +1836,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveIron personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetMMSAdministered value ->
             let
@@ -1860,7 +1877,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveMMS personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetMebendazoleAdministered value ->
             let
@@ -1901,7 +1918,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveMebendazole personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationMsgs nextTask)
 
         SetMalariaPreventionBoolInput formUpdateFunc value ->
             let
@@ -2267,7 +2284,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveHIVTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetSyphilisTestFormBoolInput formUpdateFunc value ->
             let
@@ -2357,7 +2374,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveSyphilisTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetHepatitisBTestFormBoolInput formUpdateFunc value ->
             let
@@ -2419,7 +2436,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveHepatitisBTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetMalariaTestFormBoolInput formUpdateFunc value ->
             let
@@ -2503,7 +2520,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveMalariaTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetBloodGpRsTestFormBoolInput formUpdateFunc value ->
             let
@@ -2582,7 +2599,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveBloodGpRsTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetUrineDipstickTestFormBoolInput formUpdateFunc value ->
             let
@@ -2818,7 +2835,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveUrineDipstickTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetHemoglobinTestFormBoolInput formUpdateFunc value ->
             let
@@ -2880,7 +2897,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveHemoglobinTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetRandomBloodSugarTestFormBoolInput formUpdateFunc value ->
             let
@@ -2942,7 +2959,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveRandomBloodSugarTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetHIVPCRTestFormBoolInput formUpdateFunc value ->
             let
@@ -3028,7 +3045,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveHIVPCRTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetPartnerHIVTestFormBoolInput formUpdateFunc value ->
             let
@@ -3096,7 +3113,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SavePartnerHIVTest personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateLaboratoryMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateLaboratoryMsgs nextTask)
 
         SetLabsHistoryCompleted value ->
             let
@@ -3203,7 +3220,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveHealthEducation personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SetFollowUpOption option ->
             let
@@ -3250,7 +3267,7 @@ update currentDate id db msg model =
             , Cmd.none
             , appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SaveNewbornEnrollment secondPhaseRequired nextTask ->
             let
@@ -3261,7 +3278,7 @@ update currentDate id db msg model =
             , Cmd.none
             , []
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetReferralBoolInput updateFunc value ->
             let
@@ -3344,7 +3361,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveSendToHC personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SetAppointmentDateSelectorState state ->
             let
@@ -3385,7 +3402,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveAppointmentConfirmation personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SetMedicationDistributionBoolInput formUpdateFunc value ->
             let
@@ -3487,7 +3504,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveMedicationDistribution personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateNextStepsMsgs secondPhaseRequired nextTask)
 
         SaveWait personId measurementId updatedValue ->
             let
@@ -3509,7 +3526,7 @@ update currentDate id db msg model =
             , Cmd.none
             , appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SaveNextVisitDate date secondPhaseRequired nextTask ->
             let
@@ -3526,7 +3543,7 @@ update currentDate id db msg model =
             , Cmd.none
             , appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetSymptomReviewStep step ->
             let
@@ -3565,7 +3582,7 @@ update currentDate id db msg model =
             , Cmd.none
             , []
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetPrenatalSymptom symptom ->
             let
@@ -3708,7 +3725,7 @@ update currentDate id db msg model =
                 (Backend.PrenatalEncounter.Model.SaveMedication personId)
                 toIndexedDbMsg
             )
-                |> sequenceExtra (update currentDate id db) (generateMedicationSubActivityMsgs nextTask)
+                |> sequenceExtra (update currentDate site id db) (generateMedicationSubActivityMsgs nextTask)
 
         SetMentalHealthStep step ->
             let
@@ -3801,7 +3818,7 @@ update currentDate id db msg model =
             , Cmd.none
             , appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetActiveImmunisationTask task ->
             let
@@ -4046,7 +4063,7 @@ update currentDate id db msg model =
             , Cmd.none
             , appMsgs
             )
-                |> sequenceExtra (update currentDate id db) extraMsgs
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SetPostpartumTreatmentReviewBoolInput formUpdateFunc value ->
             let

--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -8,7 +8,7 @@ import Backend.Measurement.Utils
         ( getHeightValue
         , getMeasurementValueFunc
         , muacValueForSite
-        , muacValueFunc
+        , muacValueFuncForSite
         , pregnancyTestResultToString
         , weightValueFunc
         )
@@ -3229,7 +3229,7 @@ viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores site is
 
         muacPreviousValue =
             resolvePreviousValue assembled .nutrition .muac
-                |> Maybe.map (muacValueFunc >> muacValueForSite site)
+                |> Maybe.map (muacValueFuncForSite site)
 
         calculatedBmi =
             calculateBmi form.height form.weight

--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -7,6 +7,7 @@ import Backend.Measurement.Utils
     exposing
         ( getHeightValue
         , getMeasurementValueFunc
+        , muacValueForSite
         , muacValueFunc
         , pregnancyTestResultToString
         , weightValueFunc
@@ -126,7 +127,7 @@ import Pages.Utils
         , viewYellowAlertForSelect
         )
 import Round
-import SyncManager.Model exposing (Site, SiteFeature)
+import SyncManager.Model exposing (Site(..), SiteFeature)
 import Translate exposing (Language, TranslationId, translate)
 import Utils.Html exposing (viewModal)
 import Utils.WebData exposing (viewWebData)
@@ -324,7 +325,7 @@ viewActivity language currentDate zscores site features isChw activity assembled
             viewHistoryContent language assembled model.historyData
 
         Examination ->
-            viewExaminationContent language currentDate zscores features assembled model.examinationData
+            viewExaminationContent language currentDate zscores site features assembled model.examinationData
 
         FamilyPlanning ->
             viewFamilyPlanningContent language assembled model.familyPlanningData
@@ -868,8 +869,8 @@ viewHistoryContent language assembled data =
     ]
 
 
-viewExaminationContent : Language -> NominalDate -> ZScore.Model.Model -> EverySet SiteFeature -> AssembledData -> ExaminationData -> List (Html Msg)
-viewExaminationContent language currentDate zscores features assembled data =
+viewExaminationContent : Language -> NominalDate -> ZScore.Model.Model -> Site -> EverySet SiteFeature -> AssembledData -> ExaminationData -> List (Html Msg)
+viewExaminationContent language currentDate zscores site features assembled data =
     let
         tasks =
             resolveExaminationTasks assembled
@@ -989,7 +990,7 @@ viewExaminationContent language currentDate zscores features assembled data =
                     healthyStartEnabled features
 
                 formWithIndicator =
-                    viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores isHealthyStart assembled formWithMeasuredHeight previouslyMeasuredHeight prePregnancyWeight
+                    viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores site isHealthyStart assembled formWithMeasuredHeight previouslyMeasuredHeight prePregnancyWeight
             in
             ( Tuple.first formWithIndicator, Tuple.second formWithIndicator )
 
@@ -3185,8 +3186,8 @@ viewVitalsForm language currentDate assembled form =
     Measurement.View.viewVitalsForm language currentDate formConfig form
 
 
-viewNutritionAssessmentFormWithGWGIndicator : Language -> NominalDate -> ZScore.Model.Model -> Bool -> AssembledData -> NutritionAssessmentForm -> Maybe Float -> Maybe Float -> ( Html Msg, Maybe Bool )
-viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores isHealthyStart assembled form previouslyMeasuredHeight prePregnancyWeight =
+viewNutritionAssessmentFormWithGWGIndicator : Language -> NominalDate -> ZScore.Model.Model -> Site -> Bool -> AssembledData -> NutritionAssessmentForm -> Maybe Float -> Maybe Float -> ( Html Msg, Maybe Bool )
+viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores site isHealthyStart assembled form previouslyMeasuredHeight prePregnancyWeight =
     let
         hideHeightInput =
             isJust previouslyMeasuredHeight
@@ -3200,8 +3201,17 @@ viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores isHealt
         bmiUpdateFunc _ form_ =
             form_
 
-        muacUpdateFunc value form_ =
-            { form_ | muac = value, muacDirty = True }
+        -- MUAC is stored in cm; show it in mm at Burundi.
+        muacForView =
+            Maybe.map (muacValueForSite site) form.muac
+
+        muacUnitTransId =
+            case site of
+                SiteBurundi ->
+                    Translate.UnitMillimeter
+
+                _ ->
+                    Translate.UnitCentimeter
 
         heightPreviousValue =
             resolvePreviousValue assembled .nutrition .height
@@ -3219,7 +3229,7 @@ viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores isHealt
 
         muacPreviousValue =
             resolvePreviousValue assembled .nutrition .muac
-                |> Maybe.map muacValueFunc
+                |> Maybe.map (muacValueFunc >> muacValueForSite site)
 
         calculatedBmi =
             calculateBmi form.height form.weight
@@ -3441,16 +3451,16 @@ viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores isHealt
                     [ div [ class "twelve wide column" ]
                         [ viewMeasurementInput
                             language
-                            form.muac
-                            (SetNutritionAssessmentMeasurement muacUpdateFunc)
+                            muacForView
+                            SetNutritionAssessmentMuac
                             "muac"
-                            Translate.UnitCentimeter
+                            muacUnitTransId
                         ]
                     , div [ class "four wide column" ]
                         [ nutritionalSupplementAlert
                         ]
                     ]
-               , viewPreviousMeasurement language muacPreviousValue Translate.UnitCentimeter
+               , viewPreviousMeasurement language muacPreviousValue muacUnitTransId
                ]
     , isAdequateGWG
     )

--- a/client/src/elm/Pages/Utils/Test.elm
+++ b/client/src/elm/Pages/Utils/Test.elm
@@ -1,12 +1,51 @@
 module Pages.Utils.Test exposing (all)
 
+import Backend.Measurement.Utils exposing (muacValueForSite)
 import Expect
-import Pages.Utils exposing (percentageOfTotal)
+import Pages.Utils exposing (percentageOfTotal, setMuacValueForSite)
+import SyncManager.Model exposing (Site(..))
 import Test exposing (Test, describe, test)
 
 
-all : Test
-all =
+muacValueForSiteTest : Test
+muacValueForSiteTest =
+    -- MUAC is stored in cm everywhere. Burundi enters and reads it in mm, so the
+    -- two conversions have to agree: whatever is typed must come back unchanged.
+    describe "MUAC conversions between what is stored and what is shown"
+        [ test "Burundi: 220 typed is stored as 22 cm" <|
+            \_ ->
+                setMuacValueForSite SiteBurundi "220"
+                    |> Expect.equal (Just 22)
+        , test "Burundi: 22 cm is shown as 220" <|
+            \_ ->
+                muacValueForSite SiteBurundi 22
+                    |> Expect.equal 220
+        , test "Burundi: what is typed comes back the same" <|
+            \_ ->
+                setMuacValueForSite SiteBurundi "225"
+                    |> Maybe.map (muacValueForSite SiteBurundi)
+                    |> Expect.equal (Just 225)
+        , test "Rwanda: the value is left alone in both directions" <|
+            \_ ->
+                ( setMuacValueForSite SiteRwanda "22.5"
+                , muacValueForSite SiteRwanda 22.5
+                )
+                    |> Expect.equal ( Just 22.5, 22.5 )
+        , test "Somalia and unknown sites are left alone too" <|
+            \_ ->
+                ( muacValueForSite SiteSomalia 22.5
+                , muacValueForSite SiteUnknown 22.5
+                )
+                    |> Expect.equal ( 22.5, 22.5 )
+        , test "a value that isn't a number gives nothing" <|
+            \_ ->
+                setMuacValueForSite SiteBurundi ""
+                    |> Expect.equal Nothing
+        ]
+
+
+percentageOfTotalTest : Test
+percentageOfTotalTest =
     describe "Pages.Utils.percentageOfTotal"
         [ test "returns 0 when the total is 0, instead of NaN" <|
             \_ ->
@@ -28,4 +67,12 @@ all =
             \_ ->
                 percentageOfTotal 7 7
                     |> Expect.equal 100
+        ]
+
+
+all : Test
+all =
+    describe "Pages.Utils"
+        [ percentageOfTotalTest
+        , muacValueForSiteTest
         ]


### PR DESCRIPTION
Fixes #1982

## Problem

MUAC is stored in centimetres everywhere. Burundi enters and reads it in millimetres, so every MUAC input converts for the site and labels itself accordingly — `muacValueForSite` on the way out, `setMuacValueForSite` on the way in, and the unit label switched by site.

The prenatal nutrition assessment did none of that. It showed the stored centimetres under a `UnitCentimeter` label unconditionally; a grep for `muacValueForSite` or `SiteBurundi` across `Pages/Prenatal/Activity/View.elm` returned zero hits. A Burundi nurse who enters millimetres in every other MUAC field met one that wanted something else, with no range check to catch a value ten times out.

## Changes

- **`site` threaded into `Pages.Prenatal.Activity.Update.update`.** Its signature was the odd one out; the six other modules doing site-aware MUAC already take `site`. `site` was already in scope at the dispatch in `App/Update.elm` — the WellChild dispatch two lines away uses it.
- **New `SetNutritionAssessmentMuac` msg** applying `setMuacValueForSite`, matching the `SetMuac` pattern used elsewhere. The generic `SetNutritionAssessmentMeasurement` hardcodes `String.toFloat`, which is correct for height, weight and BMI but not MUAC.
- **Display converted and labelled by site**, including the **previous measurement** shown beneath the input — without that it would have read "22.0 cm" directly under "220 mm".

**The alerts are deliberately unchanged.** `nutritionalSupplementAlert` (`muac < 22`) and the `viewConditionalAlert` thresholds (18.5, 22) read the *stored* centimetres, and storage is centimetres on every site, so they were already correct. The same applies to `resolvePrePregnancyClassification` (`muac < 21`) and the diagnosis logic in `Pages/Prenatal/Encounter/Utils.elm` — both verified.

## Why this is safe to ship

The change alters what a number typed into this field means on the Burundi site. That would be a migration problem if anyone were using it — **but there are zero prenatal nutrition-assessment records on vhw.live**, against 1,405 prenatal encounters, so the task is not in use there and no one is habituated to the old behaviour. Checked directly against the live database.

That also makes this the right time to fix it: once records exist, a stored 22 cannot be distinguished from an intended 220.

## Testing

- `elm make src/elm/Main.elm` — 548 modules
- `elm-test` — **2882 passing** (+6), 0 failing
- `elm-review` (cold) — no errors
- `elm-format --validate` — clean

`muacValueForSite` and `setMuacValueForSite` had **no tests at all**, and this fix depends on the two agreeing, so there are now six covering both directions, the round trip, the non-Burundi sites and a non-numeric input. Verified discriminating: breaking the conversion fails 6 tests, including the round-trip ones.

Worth being precise about what that covers — the tests protect the conversion helpers, not the wiring. Restoring the old view code would leave the suite green.

## Not included

The field still has no range check, so a habitual centimetre entry stores a value ten times too small and displays back consistently. That is tracked in #1980.

The `case site of SiteBurundi -> UnitMillimeter; _ -> UnitCentimeter` label logic is now inline in five places across the codebase, and every site-aware MUAC input hand-assembles the same three conversions. Filed separately rather than expanding this change.