### PR TITLE
Measurements: say the MUAC unit in one place

### DIFF
--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -54,6 +54,8 @@ import Pages.Utils
         ( concatInputsAndTasksSections
         , isTaskCompleted
         , maybeToBoolTask
+        , muacUnitTransIdForSite
+        , setMuacValueForSite
         , taskCompleted
         , tasksBarId
         , viewBoolInput
@@ -179,19 +181,11 @@ heightFormConfig =
 muacFormConfig : Site -> FloatFormConfig MuacId Muac
 muacFormConfig site =
     let
-        ( toBackendValue, unit ) =
-            case site of
-                SiteBurundi ->
-                    ( -- At Burundi, value is entered as mm, but we need to store it
-                      -- as cm. Therefore, we multiply by 0.1.
-                      String.toFloat >> Maybe.map ((*) 0.1 >> Round.roundNum 1)
-                    , Translate.UnitMillimeter
-                    )
+        toBackendValue =
+            setMuacValueForSite site
 
-                _ ->
-                    ( String.toFloat
-                    , Translate.UnitCentimeter
-                    )
+        unit =
+            muacUnitTransIdForSite site
     in
     { blockName = "muac"
     , activity = ChildActivity Muac
@@ -3329,12 +3323,7 @@ ncdaFormInputsAndTasks language currentDate site personId person config form cur
                                                             form.muac
 
                                                     unitTransId =
-                                                        case site of
-                                                            SiteBurundi ->
-                                                                Translate.UnitMillimeter
-
-                                                            _ ->
-                                                                Translate.UnitCentimeter
+                                                        muacUnitTransIdForSite site
                                                 in
                                                 [ div [ class "ui grid" ]
                                                     [ div [ class "eleven wide column" ]
@@ -4328,12 +4317,7 @@ muacFormInputsAndTasks language currentDate site person previousValue setMuacMsg
             Maybe.map (muacValueForSite site) form.muac
 
         unitTransId =
-            case site of
-                SiteBurundi ->
-                    Translate.UnitMillimeter
-
-                _ ->
-                    Translate.UnitCentimeter
+            muacUnitTransIdForSite site
 
         rangeHelper =
             if showRangeHelper then

--- a/client/src/elm/Pages/FamilyNutrition/ProgressReport/Svg.elm
+++ b/client/src/elm/Pages/FamilyNutrition/ProgressReport/Svg.elm
@@ -2,6 +2,7 @@ module Pages.FamilyNutrition.ProgressReport.Svg exposing (viewMuacChart)
 
 import Html exposing (Html)
 import Pages.Report.Svg exposing (dimensionsPx, drawPoints, drawPolygon, drawPolyline, heightPx, referenceHorizontalLines, referenceVerticalLines, referenceVerticalNumbers, widthPx, withinRange)
+import Pages.Utils exposing (muacUnitTransIdForSite)
 import Svg exposing (..)
 import Svg.Attributes exposing (..)
 import SyncManager.Model exposing (Site(..))
@@ -52,11 +53,7 @@ viewMuacChart language site isAdult anchorAge muacPoints =
             2 * displayFactor
 
         unitTransId =
-            if isBurundi then
-                Translate.UnitMillimeter
-
-            else
-                Translate.UnitCentimeter
+            muacUnitTransIdForSite site
 
         yAxisLabel =
             translate language Translate.MUAC

--- a/client/src/elm/Pages/FamilyNutrition/ProgressReport/Svg.elm
+++ b/client/src/elm/Pages/FamilyNutrition/ProgressReport/Svg.elm
@@ -1,27 +1,22 @@
 module Pages.FamilyNutrition.ProgressReport.Svg exposing (viewMuacChart)
 
+import Backend.Measurement.Utils exposing (muacValueForSite)
 import Html exposing (Html)
 import Pages.Report.Svg exposing (dimensionsPx, drawPoints, drawPolygon, drawPolyline, heightPx, referenceHorizontalLines, referenceVerticalLines, referenceVerticalNumbers, widthPx, withinRange)
 import Pages.Utils exposing (muacUnitTransIdForSite)
 import Svg exposing (..)
 import Svg.Attributes exposing (..)
-import SyncManager.Model exposing (Site(..))
+import SyncManager.Model exposing (Site)
 import Translate exposing (Language, translate)
 
 
 viewMuacChart : Language -> Site -> Bool -> { years : Int, months : Int } -> List ( Float, Float ) -> Html any
 viewMuacChart language site isAdult anchorAge muacPoints =
     let
-        isBurundi =
-            site == SiteBurundi
-
-        -- Factor to convert cm values to display units (mm for Burundi).
+        -- The chart is drawn in cm. muacValueForSite says what a value reads
+        -- as at this site, so what one cm reads as is what to scale by.
         displayFactor =
-            if isBurundi then
-                10
-
-            else
-                1
+            round (muacValueForSite site 1)
 
         horizontalParts =
             36
@@ -44,10 +39,10 @@ viewMuacChart language site isAdult anchorAge muacPoints =
 
         ( redThreshold, yellowThreshold ) =
             if isAdult then
-                ( 18.5 * toFloat displayFactor, 22 * toFloat displayFactor )
+                ( muacValueForSite site 18.5, muacValueForSite site 22 )
 
             else
-                ( 11.5 * toFloat displayFactor, 12.5 * toFloat displayFactor )
+                ( muacValueForSite site 11.5, muacValueForSite site 12.5 )
 
         verticalNumberGap =
             2 * displayFactor
@@ -91,16 +86,13 @@ viewMuacChart language site isAdult anchorAge muacPoints =
         verticalMaxFloat =
             toFloat verticalMax
 
-        displayFactorFloat =
-            toFloat displayFactor
-
         measurements =
             muacPoints
                 |> List.filterMap
                     (\( monthOffset, muacCm ) ->
                         let
                             muacDisplay =
-                                muacCm * displayFactorFloat
+                                muacValueForSite site muacCm
 
                             gridPos =
                                 monthOffset + 3

--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -99,6 +99,7 @@ import Pages.Utils
     exposing
         ( customButton
         , maybeToBoolTask
+        , muacUnitTransIdForSite
         , resolveActiveTask
         , resolveNextTask
         , resolveTasksCompletedFromTotal
@@ -127,7 +128,7 @@ import Pages.Utils
         , viewYellowAlertForSelect
         )
 import Round
-import SyncManager.Model exposing (Site(..), SiteFeature)
+import SyncManager.Model exposing (Site, SiteFeature)
 import Translate exposing (Language, TranslationId, translate)
 import Utils.Html exposing (viewModal)
 import Utils.WebData exposing (viewWebData)
@@ -3206,12 +3207,7 @@ viewNutritionAssessmentFormWithGWGIndicator language currentDate zscores site is
             Maybe.map (muacValueForSite site) form.muac
 
         muacUnitTransId =
-            case site of
-                SiteBurundi ->
-                    Translate.UnitMillimeter
-
-                _ ->
-                    Translate.UnitCentimeter
+            muacUnitTransIdForSite site
 
         heightPreviousValue =
             resolvePreviousValue assembled .nutrition .height

--- a/client/src/elm/Pages/Utils.elm
+++ b/client/src/elm/Pages/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, nonAdministrationReasonToSign, normalizeFilter, percentageOfTotal, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
+module Pages.Utils exposing (calculatePercentage, concatInputsAndTasksSections, customButton, customPopup, emptySelectOption, filterDependentNoResultsMessage, getCurrentReasonForMedicationNonAdministration, ifEverySetEmpty, ifNullableTrue, ifTrue, insertIntoSet, isAboveAgeOf2Years, isTaskCompleted, matchFilter, matchMotherAndHerChildren, maybeToBoolTask, maybeValueConsideringIsDirtyField, muacUnitTransIdForSite, nonAdministrationReasonToSign, normalizeFilter, percentageOfTotal, resolveActiveTask, resolveNextTask, resolveSelectedDateForMonthSelector, resolveTasksCompletedFromTotal, saveButton, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, taskAllCompleted, taskAnyCompleted, taskCompleted, taskCompletedWithException, tasksBarId, unique, valueConsideringIsDirtyField, viewBoolInput, viewBoolInputReverted, viewBySyncStatus, viewCheckBoxMultipleSelectCustomInput, viewCheckBoxMultipleSelectInput, viewCheckBoxMultipleSelectSectionsInput, viewCheckBoxSelectCustomInput, viewCheckBoxSelectInput, viewCheckBoxValueInput, viewConditionalAlert, viewConfirmationDialog, viewCustomAction, viewCustomBoolInput, viewCustomLabel, viewCustomNameFilter, viewCustomSelectListInput, viewEncounterActionButton, viewEndEncounterButton, viewEndEncounterButtonCustomColor, viewEndEncounterMenuForProgressReport, viewInstructionsLabel, viewLabel, viewMeasurementInput, viewMonthSelector, viewNameFilter, viewNumberInput, viewPersonDetails, viewPersonDetailsExtended, viewPhotoThumbFromImageUrl, viewPreviousMeasurement, viewPreviousMeasurementCustom, viewQuestionLabel, viewRedAlertForBool, viewRedAlertForSelect, viewReportLink, viewSaveAction, viewSelectListInput, viewSkipNCDADialog, viewStartEncounterButton, viewTasksCount, viewTextInput, viewYellowAlertForSelect)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Entities exposing (HealthCenterId, PersonId)
@@ -1432,6 +1432,20 @@ viewBySyncStatus language healthCenterId syncInfoAuthorities contentForView =
             )
         |> Maybe.withDefault
             (showWarningMessage Translate.SelectedHCNotSynced Translate.PleaseSync)
+
+
+{-| The unit a MUAC is entered and read in, which is mm at the Burundi site and
+cm everywhere else. The value itself is always stored in cm -- use
+`muacValueForSite` to show it and `setMuacValueForSite` to store what was typed.
+-}
+muacUnitTransIdForSite : Site -> TranslationId
+muacUnitTransIdForSite site =
+    case site of
+        SiteBurundi ->
+            Translate.UnitMillimeter
+
+        _ ->
+            Translate.UnitCentimeter
 
 
 setMuacValueForSite : Site -> String -> Maybe Float

--- a/client/src/elm/Pages/Utils/Test.elm
+++ b/client/src/elm/Pages/Utils/Test.elm
@@ -2,9 +2,10 @@ module Pages.Utils.Test exposing (all)
 
 import Backend.Measurement.Utils exposing (muacValueForSite)
 import Expect
-import Pages.Utils exposing (percentageOfTotal, setMuacValueForSite)
+import Pages.Utils exposing (muacUnitTransIdForSite, percentageOfTotal, setMuacValueForSite)
 import SyncManager.Model exposing (Site(..))
 import Test exposing (Test, describe, test)
+import Translate
 
 
 muacValueForSiteTest : Test
@@ -70,9 +71,33 @@ percentageOfTotalTest =
         ]
 
 
+muacUnitTransIdForSiteTest : Test
+muacUnitTransIdForSiteTest =
+    -- The label has to say the same unit the value is entered and read in, or
+    -- the number on screen means something other than what it says.
+    describe "muacUnitTransIdForSite"
+        [ test "Burundi reads MUAC in millimetres" <|
+            \_ ->
+                muacUnitTransIdForSite SiteBurundi
+                    |> Expect.equal Translate.UnitMillimeter
+        , test "everywhere else reads it in centimetres" <|
+            \_ ->
+                ( muacUnitTransIdForSite SiteRwanda
+                , muacUnitTransIdForSite SiteSomalia
+                , muacUnitTransIdForSite SiteUnknown
+                )
+                    |> Expect.equal
+                        ( Translate.UnitCentimeter
+                        , Translate.UnitCentimeter
+                        , Translate.UnitCentimeter
+                        )
+        ]
+
+
 all : Test
 all =
     describe "Pages.Utils"
         [ percentageOfTotalTest
         , muacValueForSiteTest
+        , muacUnitTransIdForSiteTest
         ]


### PR DESCRIPTION
Part of #1985 — this is the first of the two steps in that issue. It does not close it; the second step is discussed below.

## Problem

MUAC is stored in centimetres everywhere and read in millimetres at Burundi, so every place that shows it has to pick the right label. Five places worked that out independently, each with its own copy of the same two-line case:

- `Measurement/View.elm:188` — the float form config
- `Measurement/View.elm:3334` — the NCDA form
- `Measurement/View.elm:4333` — the standalone MUAC form
- `Pages/Prenatal/Activity/View.elm:3211` — the nutrition assessment
- `Pages/FamilyNutrition/ProgressReport/Svg.elm:56` — the chart axis

## Changes

`muacUnitTransIdForSite` in `Pages/Utils.elm`, next to `setMuacValueForSite` so the site-aware MUAC helpers sit together. `Translate.UnitMillimeter` now appears exactly once in the codebase.

**One site was duplicating more than the label.** `Measurement/View.elm:182` also open-coded the input conversion:

```elm
String.toFloat >> Maybe.map ((*) 0.1 >> Round.roundNum 1)
```

which is exactly `setMuacValueForSite site`. That is now called rather than repeated, so the rounding rule lives in one place too.

Net effect is 13 fewer lines.

## Testing

- `elm make src/elm/Main.elm` — 548 modules
- `elm-test` — **2884 passing** (+2), 0 failing
- `elm-review` (cold) — no errors
- `elm-format --validate` — clean

The new tests pin the mapping in both directions: Burundi reads millimetres, and Rwanda, Somalia and unknown all read centimetres. `elm-review` also caught that `Site(..)`'s constructors became unused in the prenatal view once its case disappeared, so that import is narrowed back to `Site`.

## On the second step

#1985 also proposes a MUAC-aware input owning all three conversions, so an incomplete version cannot be written. Having now read all five sites, that is a larger design exercise than the issue implies, because they are not the same shape:

- the float form config is a **record** consumed by a generic form
- the NCDA one is inside a **stepped form**, with not-taken handling and an age condition
- the standalone MUAC form has a **range helper**
- the prenatal one is inline in a nutrition assessment with **its own alerts**
- the chart axis is **not an input at all**

A single component would have to absorb four different surrounding structures. Left on the issue with that noted, rather than attempted here.

## Note

This narrows how a MUAC label can go wrong; it does not add a range check, so a value in the wrong magnitude is still enterable. That is tracked in #1980.