### PR TITLE
Service worker: catch reg.update() rejection in the SW 'Update' port handler

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1981,11 +1981,15 @@ elmApp.ports.serviceWorkerOut.subscribe(function(message) {
       break;
 
     case 'Update':
-      // This happens on its own every 24 hours or so, but we can force a
-      // check for updates if we like.
+      // Checked automatically every hour, and on demand from the version UI.
+      // The check fetches service-worker.js, which rejects when the device is
+      // offline -- routine for an offline-first app, so ignore it. The hourly
+      // timer checks again anyway.
       navigator.serviceWorker.getRegistration().then(function(reg) {
-        reg.update();
-      });
+        if (reg) {
+          return reg.update();
+        }
+      }).catch(function() {});
       break;
 
     case 'SkipWaiting':
@@ -1996,10 +2000,10 @@ elmApp.ports.serviceWorkerOut.subscribe(function(message) {
       // provide. So we make this explicit rather than automatic -- we don't
       // want to reload at some moment the user isn't expecting.
       navigator.serviceWorker.getRegistration().then(function(reg) {
-        if (reg.waiting) {
+        if (reg && reg.waiting) {
           reg.waiting.postMessage('SkipWaiting');
         }
-      });
+      }).catch(function() {});
       break;
   }
 });


### PR DESCRIPTION
Fixes #1988

An offline update check fetches `service-worker.js` and rejects with `TypeError: Failed to fetch`; nothing caught it, so it became the top JS-side Rollbar noise after the 2026-07-07 deploy (Rwanda #113: 24 occurrences / 23 IPs / 20 devices, Jul 9–21; Burundi #27).

## Fix

In the `serviceWorkerOut` `case 'Update':` handler, return the `reg.update()` promise into a `.catch` that ignores the rejection — an offline update check is routine for an offline-first app and the hourly timer retries anyway — and guard the registration being `undefined`. The neighbouring `SkipWaiting` handler gets the same `undefined` guard and `.catch`, since it shared the latent `reg`-undefined bug.

Also corrected the stale comment (the check runs hourly, not "every 24 hours").

JS-only change; `node --check` clean.