### PR TITLE
Measurements: guard the group child-measurement form against negative values

### DIFF
--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -52,6 +52,7 @@ import Measurement.Utils exposing (contributingFactorsFormWithDefault, fbfFormTo
 import Pages.Utils
     exposing
         ( concatInputsAndTasksSections
+        , dropLeadingMinus
         , isTaskCompleted
         , maybeToBoolTask
         , taskCompleted
@@ -272,7 +273,7 @@ viewFloatForm config language currentDate isChw child measurements previousValue
             , name config.blockName
             , Attr.min <| String.fromFloat config.constraints.minVal
             , Attr.max <| String.fromFloat config.constraints.maxVal
-            , onInput config.updateMsg
+            , onInput (dropLeadingMinus >> config.updateMsg)
             , value inputValue
             ]
 

--- a/client/src/elm/SyncManager/View.elm
+++ b/client/src/elm/SyncManager/View.elm
@@ -14,6 +14,7 @@ import Json.Encode
 import List.Extra
 import List.Zipper as Zipper
 import Maybe.Extra exposing (isJust)
+import Pages.Utils exposing (dropLeadingMinus)
 import RemoteData exposing (RemoteData, WebData)
 import Restful.Endpoint exposing (fromEntityUuid, toEntityUuid)
 import SyncManager.Model
@@ -133,7 +134,7 @@ viewSyncSettings model =
                     , Html.Attributes.max (String.fromInt <| 5 * 60 * 1000)
                     , Html.Attributes.required True
                     , value <| String.fromInt syncSpeed.idle
-                    , onInput SetSyncSpeedIdle
+                    , onInput (dropLeadingMinus >> SetSyncSpeedIdle)
                     ]
                     []
                 , div [ class "ui basic label" ] [ text "ms" ]
@@ -150,7 +151,7 @@ viewSyncSettings model =
                     , Html.Attributes.max (String.fromInt <| 5 * 60 * 1000)
                     , Html.Attributes.required True
                     , value <| String.fromInt syncSpeed.cycle
-                    , onInput SetSyncSpeedCycle
+                    , onInput (dropLeadingMinus >> SetSyncSpeedCycle)
                     ]
                     []
                 , div [ class "ui basic label" ] [ text "ms" ]
@@ -167,7 +168,7 @@ viewSyncSettings model =
                     , Html.Attributes.max (String.fromInt <| 5 * 60 * 1000)
                     , Html.Attributes.required True
                     , value <| String.fromInt syncSpeed.offline
-                    , onInput SetSyncSpeedOffline
+                    , onInput (dropLeadingMinus >> SetSyncSpeedOffline)
                     ]
                     []
                 , div [ class "ui basic label" ] [ text "ms" ]


### PR DESCRIPTION
Fixes #1992

Follow-up to #1978 / #1979, surfaced by code review of #1988.

#1979 wired `dropLeadingMinus` into the shared `Pages.Utils` helpers (`viewNumberInput`, `viewMeasurementInput`) and the Prenatal-local input, but the **group** child-measurement form (`Measurement/View.elm` `viewFloatForm`) builds its own `type_ "number"` field and bypassed them — so **height, weight and MUAC still accepted a typed or pasted negative** on the group path, the same anthropometrics #1979 guarded on the individual-encounter path.

## Changes

- `viewFloatForm` — `onInput (dropLeadingMinus >> config.updateMsg)` (import added).
- The three `SyncManager/View.elm` sync-speed settings (Idle/Cycle/Offline, ms) — same wrapper; admin-only dev panel, low stakes but negatives are meaningless there too.

No signed-quantity number inputs exist in the client (no latitude/longitude/temperature fields), so blocking negatives everywhere is safe. Completes #1978.

`elm make` clean, 2889 tests pass, elm-format clean.

Known follow-up (out of scope here): the sync-speed inputs still accept sub-minimum *positive* values (no save-time clamp against the documented ms `min`) — tracked separately.