### PR TITLE
Sync: reply to Elm when bulkPhotos.js is missing

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -598,8 +598,24 @@ elmApp.ports.sendSyncSpeed.subscribe(function(syncSpeed) {
 elmApp.ports.bulkPhotoFetch.subscribe(async function(params) {
   // Belt and braces: the handler guards its own failure paths, but a reply
   // must reach Elm on every exit, or the photos lane stays Loading forever.
-  const outcome = await self.bulkPhotos.handleBulkPhotoFetch(params)
-    .catch((e) => ({ 'batchError': 0, 'error': String(e) }));
+  // bulkPhotos.js can be absent while the app updates, when a new app.js
+  // runs against a stale cache. Reading the handler off a missing module
+  // throws before a catch can attach, so check for it first, and take the
+  // whole call through try/catch so a handler of any shape still replies.
+  let outcome;
+  if (self.bulkPhotos && typeof self.bulkPhotos.handleBulkPhotoFetch === 'function') {
+    try {
+      outcome = await self.bulkPhotos.handleBulkPhotoFetch(params);
+    } catch (e) {
+      outcome = { 'batchError': 0, 'error': String(e) };
+    }
+  } else {
+    // The file cannot turn up later in this session, so send what a server
+    // without the bulk endpoint sends. Photos are then fetched one at a
+    // time from the next cycle, rather than after three whole-batch
+    // errors. 404 is the signal Elm reads for that, not an HTTP status.
+    outcome = { 'batchError': 404, 'error': 'bulkPhotos.js not loaded' };
+  }
   elmApp.ports.bulkPhotoFetchHandle.send(outcome);
 });
 


### PR DESCRIPTION
Fixes #1990

While the app updates, a new `app.js` can run against a stale cache that has no `bulkPhotos.js`. Reading the handler off the missing module threw **before** the `.catch` could attach, so no reply reached Elm and the photos lane stayed `Loading` until the app was reloaded — the exact wedge the existing `.catch` was added to prevent.

Rollbar: Site-Rwanda #114 (2026-07-09, 1 device). A scratchpad harness reproduces the reported message verbatim: `TypeError: Cannot read properties of undefined (reading 'handleBulkPhotoFetch')`, with nothing sent to Elm.

## Changes

- **Check for the handler first.** When it is missing, reply `batchError: 404` — the signal Elm already reads as "bulk mode unavailable, fall back for the rest of the session" (`SyncManager/Update.elm`, `Err 404`). The file cannot turn up later in the same session, so photos are fetched one at a time from the **next** cycle rather than after three whole-batch errors. It is not an HTTP status, and the comment says so.
- **Take the call through `try`/`catch`** rather than `.catch` on its return value, so a handler that does not return a promise still gets a reply back to Elm instead of throwing `.catch is not a function`.

Neither path bumps per-row attempts, so no photo is dropped or marked terminal.

## Notes

- `photoCache.js` needs no guard: `bulkPhotos.js` already reads it inside a `try`/`catch` that returns `batchError: 0`.
- Verified with Elm 0.19.2: `elm make` 548 modules, `elm-test` 2891 passing, `elm-format` and `elm-review` clean, `node --check` clean.