### PR TITLE
App: throw away a page's elements when another page is shown

### DIFF
--- a/client/src/elm/App/Ports.elm
+++ b/client/src/elm/App/Ports.elm
@@ -67,7 +67,7 @@ port scrollToElement : String -> Cmd msg
 port makeProgressReportScreenshot : { language : String, reportType : String, personId : String, phoneNumber : String } -> Cmd msg
 
 
-port initRollbar : { device : String, token : String } -> Cmd msg
+port initRollbar : { device : String, token : String, version : String } -> Cmd msg
 
 
-port logByRollbar : { source : String, message : String, md5 : String } -> Cmd msg
+port logByRollbar : { source : String, message : String, md5 : String, version : String } -> Cmd msg

--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -140,6 +140,7 @@ import Translate.Utils exposing (languageFromCode, languageToCode)
 import Update.Extra exposing (sequence)
 import Url exposing (Url)
 import Utils.WebData
+import Version
 import ZScore.Model
 import ZScore.Update
 
@@ -1559,6 +1560,7 @@ update msg model =
                                             { source = "sync"
                                             , message = message
                                             , md5 = MD5.hex message
+                                            , version = Version.version.build
                                             }
 
                                     IndexedDB ->
@@ -1566,6 +1568,7 @@ update msg model =
                                             { source = "db"
                                             , message = message
                                             , md5 = ""
+                                            , version = Version.version.build
                                             }
 
                                     ServiceWorker ->
@@ -1573,6 +1576,7 @@ update msg model =
                                             { source = "sw"
                                             , message = message
                                             , md5 = ""
+                                            , version = Version.version.build
                                             }
                         in
                         case errorType of

--- a/client/src/elm/App/View.elm
+++ b/client/src/elm/App/View.elm
@@ -12,7 +12,7 @@ import Config.View
 import Error.View
 import EverySet exposing (EverySet)
 import GeoLocation.Model exposing (GeoInfo, ReverseGeoInfo)
-import Gizra.Html exposing (emptyNode)
+import Gizra.Html exposing (divKeyed, emptyNode)
 import Gizra.NominalDate exposing (fromLocalDateTime)
 import Html exposing (..)
 import Html.Attributes exposing (class, classList)
@@ -107,6 +107,7 @@ import Pages.Prenatal.RecurrentEncounter.Model
 import Pages.Prenatal.RecurrentEncounter.View
 import Pages.Relationship.Model
 import Pages.Relationship.View
+import Pages.Router exposing (pageToFragment)
 import Pages.Session.Model
 import Pages.Session.View
 import Pages.StockManagement.Model
@@ -160,12 +161,21 @@ view model =
 {-| Given some HTML, wrap it in the new flex-box based structure.
 -}
 flexPageWrapper : Config.Model.Model -> Model -> Html Msg -> Html Msg
-flexPageWrapper config model html =
+flexPageWrapper config model =
+    flexPageWrapperKeyed (pageKey model.activePage) config model
+
+
+{-| Like `flexPageWrapper`, for the places that show one page while the app is
+on another. Say which page is really being shown, so that it is keyed as itself
+rather than as the page it stands in for.
+-}
+flexPageWrapperKeyed : String -> Config.Model.Model -> Model -> Html Msg -> Html Msg
+flexPageWrapperKeyed key config model html =
     let
         syncManager =
             if model.activePage == DevicePage then
-                [ Error.View.view model.language model.configuration model.errors
-                , Html.map MsgSyncManager (SyncManager.View.view model.language model.configuration model.indexedDb model.syncManager)
+                [ ( "errors", Error.View.view model.language model.configuration model.errors )
+                , ( "sync-manager", Html.map MsgSyncManager (SyncManager.View.view model.language model.configuration model.indexedDb model.syncManager) )
                 ]
 
             else
@@ -176,20 +186,38 @@ flexPageWrapper config model html =
                 [ class "page-content" ]
                 [ html ]
     in
-    div [ class "page container" ] <|
-        (viewLanguageSwitcherAndVersion config model :: viewStorageWarning model :: syncManager)
-            ++ [ content ]
+    divKeyed [ class "page container" ] <|
+        [ ( "language-switcher", viewLanguageSwitcherAndVersion config model )
+        , ( "storage-warning", viewStorageWarning model )
+        ]
+            ++ syncManager
+            ++ [ ( key, content ) ]
 
 
 {-| Given some HTML, wrap it the old way.
 -}
 oldPageWrapper : Config.Model.Model -> Model -> Html Msg -> Html Msg
 oldPageWrapper config model html =
-    div [ class "container" ]
-        [ viewLanguageSwitcherAndVersion config model
-        , viewStorageWarning model
-        , html
+    divKeyed [ class "container" ]
+        [ ( "language-switcher", viewLanguageSwitcherAndVersion config model )
+        , ( "storage-warning", viewStorageWarning model )
+        , ( pageKey model.activePage, html )
         ]
+
+
+{-| A key for the page being shown, so that moving to another page throws the
+old page's elements away instead of letting the new page reuse them.
+
+Reusing them mixes the two pages up: a text field left over from the page being
+left keeps the handler that reads what is typed into it, while the field now
+belongs to the page being entered. What the field sends is then read as the
+wrong kind of value, which stops the app.
+
+-}
+pageKey : Page -> String
+pageKey page =
+    pageToFragment page
+        |> Maybe.withDefault "page-not-found"
 
 
 {-| A banner warning that the device's local storage is filling up or full.
@@ -333,7 +361,7 @@ viewConfiguredModel model configured =
         -- service worker for the normal operation of the app).
         ServiceWorker.View.view model.currentTime model.language model.serviceWorker
             |> Html.map MsgServiceWorker
-            |> flexPageWrapper configured.config model
+            |> flexPageWrapperKeyed (pageKey ServiceWorkerPage) configured.config model
 
     else if not (RemoteData.isSuccess configured.device) then
         -- If our device is not paired, then the only thing we allow is the pairing
@@ -347,7 +375,7 @@ viewConfiguredModel model configured =
             _ ->
                 Pages.Device.View.view model.language configured.device model configured.devicePage
                     |> Html.map MsgPageDevice
-                    |> flexPageWrapper configured.config model
+                    |> flexPageWrapperKeyed (pageKey DevicePage) configured.config model
 
     else
         let
@@ -1251,7 +1279,7 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
                     configured.pinCodePage
                     model.indexedDb
                     |> Html.map MsgPagePinCode
-                    |> flexPageWrapper configured.config model
+                    |> flexPageWrapperKeyed (pageKey PinCodePage) configured.config model
 
         Nothing ->
             Pages.PinCode.View.view model.language
@@ -1265,4 +1293,4 @@ viewUserPage page deviceName site features geoInfo reverseGeoInfo model configur
                 configured.pinCodePage
                 model.indexedDb
                 |> Html.map MsgPagePinCode
-                |> flexPageWrapper configured.config model
+                |> flexPageWrapperKeyed (pageKey PinCodePage) configured.config model

--- a/client/src/elm/SyncManager/Update.elm
+++ b/client/src/elm/SyncManager/Update.elm
@@ -750,7 +750,11 @@ update currentTime activePage dbVersion device msg model =
                                 -- Init also sends all unsent items from dbErrors table.
                                 initRollbarCmd =
                                     if List.length data.entities < 500 && (not <| String.isEmpty data.rollbarToken) then
-                                        initRollbar { device = data.deviceName, token = data.rollbarToken }
+                                        initRollbar
+                                            { device = data.deviceName
+                                            , token = data.rollbarToken
+                                            , version = Version.version.build
+                                            }
 
                                     else
                                         Cmd.none

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1735,7 +1735,9 @@ elmApp.ports.initRollbar.subscribe(function(data) {
           environment: 'all',
           client: {
             javascript: {
-              code_version: '1.0',
+              // The build the report came from, so a stack trace can be read
+              // against the bundle that produced it.
+              code_version: data.version,
             }
           },
           person: {
@@ -1765,7 +1767,15 @@ elmApp.ports.initRollbar.subscribe(function(data) {
       // Send all items.
       let localIds = [];
       result.forEach(function(row) {
-          rollbar.log(row.error);
+          // The report carries the build that sends it, which is not the build
+          // that recorded it when the app updated in between. Rows written
+          // before this was kept have no build to say.
+          if (row.version) {
+              rollbar.log(row.error, { recordedOnVersion: row.version });
+          }
+          else {
+              rollbar.log(row.error);
+          }
           localIds.push(row.localId);
       })
 
@@ -1805,7 +1815,9 @@ elmApp.ports.logByRollbar.subscribe(function(data) {
             break;
 
         case 'db':
-            await dbSync.dbErrors.add({ error: data.message, isSynced: 0 });
+            // Kept until Rollbar is ready, which can be after the app updates,
+            // so keep the build this was recorded on with it.
+            await dbSync.dbErrors.add({ error: data.message, version: data.version, isSynced: 0 });
             break;
       }
 


### PR DESCRIPTION
Fixes #1989

## What was happening

Moving between pages let the new page reuse the element the old page had in the same place. A text field left over that way keeps the handler that reads what is typed into it, while the field now belongs to the page being entered — so what it sends is read as the wrong kind of value and the app stops.

Rollbar Site-Rwanda [#91](https://app.rollbar.com/a/tipglobalhealth/fix/item/Site-Rwanda/91): 122 occurrences / 102 IPs over a year, still active.

The telemetry on the latest occurrence shows the whole sequence:

```
16:58:57  Dom Input   input.search-input                 "Agan"   ← participant search
16:58:57  Navigation  #individual-participants/nutrition → #person/nutrition/new
16:59:15  Dom Input   div.ten.wide.column > input.field  "Aganze" ← person registration
17:00:06.656  Navigation  #person/nutrition/new → #individual-participants/nutrition
17:00:06.666  Dom Input   div.ten.wide.column > input.field       ← person-form element, 10 ms AFTER leaving that page
17:00:07.186  error       str.trim is not a function
```

520 ms between that stray input and the crash — the search debounce is 500 ms. The person form is `elm-form`, whose text input produces `Input <path> <inputType> <FieldValue>` (`Form/Input.elm:40`), not a string. Paired with the search page's `onInput SetInput`, that reaches `String.trim` as a record.

Searching Rollbar over all time, `#91` is the **only** item matching `trim`, so this is specific to this pairing rather than anything wrong with `String.trim` itself.

## Changes

- Key each page by the fragment it is reached at, so the old page's elements go and the new page builds its own. Both wrappers key the container they already had — **same elements, same classes, nothing changes on screen**.
- The screens shown in place of another page (pairing, PIN, service worker) say which page they really are, so they are not keyed as the page they stand in for. Without this the service-worker gate would share a key with whatever page follows it at every app start.
- Send the build to Rollbar instead of a fixed `1.0`, so a report says which bundle it came from. Errors kept in the browser until Rollbar is ready carry the build they were recorded on, which is not the build that later sends them if the app updated in between.

## Notes

Verified with Elm 0.19.2: `elm make` 548 modules, `elm-test` 2891 passing, `elm-format` and `elm-review` clean, `node --check` clean. Merged `develop` in (clean) so CI runs against the integrated result; both #1991's and #1993's changes to the same files are intact.

DOM element reuse is not observable from Elm unit tests and `pageKey` is a view internal, so this rides on the compiler plus the router's existing key uniqueness — two pages sharing a fragment would already break URL routing.