### PR TITLE
E2E tests: keep the recording of a test run when the next run happens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ ci-scripts/test_shell.sh
 # E2E tests (Playwright, from client/)
 ./node_modules/.bin/playwright test              # Headless, fast
 RECORD=1 ./node_modules/.bin/playwright test     # Headed, with video recording and visual cursor
-# Video saved to client/test-results/*/video.webm
+# Video saved to client/test-results/*/video.webm, and copied to
+# client/e2e-recordings/<run>/ so the next run does not delete it (last 10 runs kept,
+# converted to .mp4 where ffmpeg is installed)
 ```
 
 ### Deployment

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -18,4 +18,5 @@ package-lock.json
 wdio.local.conf.js
 vendor
 test-results/
+e2e-recordings/
 playwright-report/

--- a/client/e2e/global-teardown.ts
+++ b/client/e2e/global-teardown.ts
@@ -1,5 +1,5 @@
 import { FullConfig } from '@playwright/test';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync } from 'fs';
 import { dirname, join, relative } from 'path';
 
@@ -12,7 +12,7 @@ const RUNS_KEPT = 10;
 
 // Names this file gives the runs it keeps: the time the run ended. Anything
 // else in the directory was put there by hand and is left alone.
-const RUN_NAME = /^\d{4}-\d{2}-\d{2}T[\d-]+Z$/;
+const RUN_NAME = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
 
 /**
  * Playwright global teardown, run when RECORD=1 is set.
@@ -69,7 +69,7 @@ function keep(video: string, destination: string): boolean {
 
   const mp4 = destination.replace(/\.webm$/, '.mp4');
   try {
-    execSync(`ffmpeg -i "${destination}" -c:v libx264 -y "${mp4}"`, {
+    execFileSync('ffmpeg', ['-i', destination, '-c:v', 'libx264', '-y', mp4], {
       stdio: 'ignore',
       timeout: 60000,
     });
@@ -82,7 +82,13 @@ function keep(video: string, destination: string): boolean {
   }
 
   // Keeping both formats of the same video would double what is on disk.
-  unlinkSync(destination);
+  // The video is kept either way, so a delete that fails is said and passed
+  // over rather than taking the videos after it with it.
+  try {
+    unlinkSync(destination);
+  } catch (error) {
+    console.error(`Could not remove ${destination}: ${error}`);
+  }
   console.log(`Kept: ${mp4}`);
   return true;
 }

--- a/client/e2e/global-teardown.ts
+++ b/client/e2e/global-teardown.ts
@@ -1,38 +1,106 @@
+import { FullConfig } from '@playwright/test';
 import { execSync } from 'child_process';
-import { readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync } from 'fs';
+import { dirname, join, relative } from 'path';
+
+// The directory beside the output directory where past runs are kept.
+const KEPT_IN = 'e2e-recordings';
+
+// How many runs to keep there. A video is several megabytes, and without a
+// limit the directory grows until someone notices the disk.
+const RUNS_KEPT = 10;
+
+// Names this file gives the runs it keeps: the time the run ended. Anything
+// else in the directory was put there by hand and is left alone.
+const RUN_NAME = /^\d{4}-\d{2}-\d{2}T[\d-]+Z$/;
 
 /**
- * Playwright global teardown: converts recorded .webm videos to .mp4
- * using ffmpeg (when RECORD=1 is set).
+ * Playwright global teardown, run when RECORD=1 is set.
+ *
+ * Playwright empties its output directory when a run starts, so the video of a
+ * recorded run was deleted by the run after it. Copy the videos somewhere no
+ * run empties, and convert them to .mp4 there if ffmpeg is about.
+ *
+ * The videos are copied rather than moved. Reporters run after this and print
+ * where they left each video, and the HTML report copies them out of the output
+ * directory, so what is in there has to stay where it was written.
  */
-export default function globalTeardown() {
+export default function globalTeardown(config: FullConfig) {
   if (!process.env.RECORD) return;
 
-  const resultsDir = join(__dirname, '..', 'test-results');
-  try {
-    convertWebmFiles(resultsDir);
-  } catch {
-    // Don't fail the test run if conversion fails.
-  }
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+  new Set(config.projects.map((project) => project.outputDir)).forEach((dir) => {
+    try {
+      const videos = existsSync(dir) ? findVideos(dir) : [];
+      if (videos.length === 0) {
+        console.log(`No videos to keep from ${dir}`);
+        return;
+      }
+      const keptIn = join(dirname(dir), KEPT_IN);
+      const runDir = join(keptIn, stamp);
+      const kept = videos.filter((video) => keep(video, join(runDir, relative(dir, video))));
+      if (kept.length === 0) {
+        // An empty directory would take one of the places kept for a run.
+        rmSync(runDir, { recursive: true, force: true });
+        return;
+      }
+      console.log(`Recordings kept in ${runDir}`);
+      dropOldestRuns(keptIn);
+    } catch (error) {
+      console.error(`Could not keep the recordings from ${dir}: ${error}`);
+    }
+  });
 }
 
-function convertWebmFiles(dir: string) {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) {
-      convertWebmFiles(full);
-    } else if (entry.endsWith('.webm')) {
-      const mp4 = full.replace(/\.webm$/, '.mp4');
-      try {
-        execSync(`ffmpeg -i "${full}" -c:v libx264 -y "${mp4}"`, {
-          stdio: 'ignore',
-          timeout: 60000,
-        });
-        console.log(`Converted: ${full} → ${mp4}`);
-      } catch {
-        console.error(`Failed to convert: ${full}`);
-      }
-    }
+/**
+ * Copies one video, and converts the copy to .mp4 when ffmpeg can.
+ * Says whether the video was kept, so one that could not be does not stop
+ * the rest.
+ */
+function keep(video: string, destination: string): boolean {
+  try {
+    mkdirSync(dirname(destination), { recursive: true });
+    copyFileSync(video, destination);
+  } catch (error) {
+    console.error(`Could not keep ${video}: ${error}`);
+    return false;
   }
+
+  const mp4 = destination.replace(/\.webm$/, '.mp4');
+  try {
+    execSync(`ffmpeg -i "${destination}" -c:v libx264 -y "${mp4}"`, {
+      stdio: 'ignore',
+      timeout: 60000,
+    });
+  } catch {
+    // ffmpeg makes the file it is asked for before it reads anything, so a
+    // conversion that stops part way leaves one that will not play.
+    rmSync(mp4, { force: true });
+    console.log(`Kept: ${destination} (no .mp4: ffmpeg is missing, or could not convert it)`);
+    return true;
+  }
+
+  // Keeping both formats of the same video would double what is on disk.
+  unlinkSync(destination);
+  console.log(`Kept: ${mp4}`);
+  return true;
+}
+
+function dropOldestRuns(keptIn: string) {
+  const runs = readdirSync(keptIn)
+    .filter((entry) => RUN_NAME.test(entry) && statSync(join(keptIn, entry)).isDirectory())
+    .sort();
+  runs.slice(0, Math.max(0, runs.length - RUNS_KEPT)).forEach((run) => {
+    rmSync(join(keptIn, run), { recursive: true, force: true });
+    console.log(`Removed older recording: ${join(keptIn, run)}`);
+  });
+}
+
+function findVideos(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return findVideos(full);
+    return entry.endsWith('.webm') ? [full] : [];
+  });
 }

--- a/client/e2e/recordings-kept.spec.ts
+++ b/client/e2e/recordings-kept.spec.ts
@@ -31,6 +31,12 @@ const CONVERTS = ffmpegThat('converts', `${NAME_OF_OUTPUT}\necho mp4 > "$out"`);
 // ffmpeg makes the file it is asked for before it reads anything.
 const GIVES_UP = ffmpegThat('gives-up', `${NAME_OF_OUTPUT}\necho half > "$out"\nexit 1`);
 const IS_MISSING = ffmpegThat('is-missing', 'exit 127');
+// Converts, and leaves the directory it wrote into read-only, so that removing
+// the .webm beside the .mp4 fails the way a full or read-only disk would.
+const LOCKS_THE_DIRECTORY = ffmpegThat(
+  'locks-the-directory',
+  `${NAME_OF_OUTPUT}\necho mp4 > "$out"\nchmod 555 "$(dirname "$out")"`,
+);
 
 /** A run that recorded a video for each of the named tests. */
 function aRunThatRecorded(name: string, tests: string[]) {
@@ -104,16 +110,36 @@ test('a video that cannot be copied stops neither the others nor the pruning', (
   expect(filesIn(join(keptIn, runs[runs.length - 1]))).toEqual(['video.webm']);
 });
 
+test('a .webm that cannot be removed stops neither the others nor the pruning', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('undeletable-webm', ['one', 'two']);
+  for (let day = 1; day <= 12; day += 1) {
+    mkdirSync(join(keptIn, `2020-01-${String(day).padStart(2, '0')}T00-00-00-000Z`), { recursive: true });
+  }
+  tidyUp(outputDir, LOCKS_THE_DIRECTORY);
+
+  const runs = runsKeptIn(keptIn);
+  const run = join(keptIn, runs[runs.length - 1]);
+  readdirSync(run).forEach((one) => chmodSync(join(run, one), 0o755));
+
+  expect(runs).toHaveLength(10);
+  // Both videos are kept, .webm and all, rather than the second being lost
+  // because the first could not be tidied up.
+  expect(filesIn(run)).toEqual(['video.mp4', 'video.mp4', 'video.webm', 'video.webm']);
+});
+
 test('a recording moved there by hand is left alone', () => {
   const { outputDir, keptIn } = aRunThatRecorded('kept-by-hand', ['one']);
-  mkdirSync(join(keptIn, 'issue-1982'), { recursive: true });
-  writeFileSync(join(keptIn, 'issue-1982', 'video.webm'), 'kept by hand');
+  // The second is named closely enough to a run to be worth pinning down.
+  ['issue-1982', '2020-01-01T---Z'].forEach((byHand) => {
+    mkdirSync(join(keptIn, byHand), { recursive: true });
+    writeFileSync(join(keptIn, byHand, 'video.webm'), 'kept by hand');
+  });
   for (let day = 1; day <= 12; day += 1) {
     mkdirSync(join(keptIn, `2020-01-${String(day).padStart(2, '0')}T00-00-00-000Z`), { recursive: true });
   }
   tidyUp(outputDir, IS_MISSING);
 
-  expect(runsKeptIn(keptIn)).toContain('issue-1982');
+  expect(runsKeptIn(keptIn)).toEqual(expect.arrayContaining(['issue-1982', '2020-01-01T---Z']));
 });
 
 test('when nothing can be kept no run is left behind', () => {

--- a/client/e2e/recordings-kept.spec.ts
+++ b/client/e2e/recordings-kept.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import globalTeardown from './global-teardown';
+
+/**
+ * What the teardown does with the videos of a recorded run.
+ *
+ * It is called here directly, against directories made for each case, rather
+ * than by recording a real test: the cases below are about a video that cannot
+ * be copied or an ffmpeg that gives up part way, which a passing run does not
+ * produce. No browser is started.
+ */
+
+const ROOT = mkdtempSync(join(tmpdir(), 'recordings-kept-'));
+const REAL_PATH = process.env.PATH || '';
+
+test.afterAll(() => rmSync(ROOT, { recursive: true, force: true }));
+
+/** An ffmpeg that behaves in the given way, on a PATH of its own. */
+function ffmpegThat(name: string, script: string) {
+  const dir = join(ROOT, 'ffmpeg', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'ffmpeg'), `#!/bin/bash\n${script}\n`, { mode: 0o755 });
+  return dir;
+}
+
+const NAME_OF_OUTPUT = 'out=""\nwhile [ $# -gt 0 ]; do [ "$1" = "-y" ] && out="$2"; shift; done';
+const CONVERTS = ffmpegThat('converts', `${NAME_OF_OUTPUT}\necho mp4 > "$out"`);
+// ffmpeg makes the file it is asked for before it reads anything.
+const GIVES_UP = ffmpegThat('gives-up', `${NAME_OF_OUTPUT}\necho half > "$out"\nexit 1`);
+const IS_MISSING = ffmpegThat('is-missing', 'exit 127');
+
+/** A run that recorded a video for each of the named tests. */
+function aRunThatRecorded(name: string, tests: string[]) {
+  const outputDir = join(ROOT, name, 'test-results');
+  tests.forEach((one) => {
+    mkdirSync(join(outputDir, one), { recursive: true });
+    writeFileSync(join(outputDir, one, 'video.webm'), 'pretend video');
+  });
+  mkdirSync(outputDir, { recursive: true });
+  return { outputDir, keptIn: join(ROOT, name, 'e2e-recordings') };
+}
+
+function tidyUp(outputDir: string, ffmpeg: string) {
+  process.env.RECORD = '1';
+  process.env.PATH = `${ffmpeg}:${REAL_PATH}`;
+  try {
+    globalTeardown({ projects: [{ outputDir }] } as never);
+  } finally {
+    process.env.PATH = REAL_PATH;
+    delete process.env.RECORD;
+  }
+}
+
+function runsKeptIn(keptIn: string) {
+  return existsSync(keptIn) ? readdirSync(keptIn).sort() : [];
+}
+
+function filesIn(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => (entry.isDirectory() ? filesIn(join(dir, entry.name)) : [entry.name]))
+    .sort();
+}
+
+test('without ffmpeg the videos are kept as they are', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('no-ffmpeg', ['one', 'two']);
+  tidyUp(outputDir, IS_MISSING);
+
+  const [run] = runsKeptIn(keptIn);
+  expect(filesIn(join(keptIn, run))).toEqual(['video.webm', 'video.webm']);
+  // Reporters run after the teardown and print where they left each video.
+  expect(existsSync(join(outputDir, 'one', 'video.webm'))).toBe(true);
+});
+
+test('with ffmpeg only the .mp4 is kept', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('with-ffmpeg', ['one']);
+  tidyUp(outputDir, CONVERTS);
+
+  const [run] = runsKeptIn(keptIn);
+  expect(filesIn(join(keptIn, run))).toEqual(['video.mp4']);
+});
+
+test('a conversion that stops part way leaves no .mp4 behind', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('ffmpeg-gives-up', ['one']);
+  tidyUp(outputDir, GIVES_UP);
+
+  const [run] = runsKeptIn(keptIn);
+  expect(filesIn(join(keptIn, run))).toEqual(['video.webm']);
+});
+
+test('a video that cannot be copied stops neither the others nor the pruning', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('one-unreadable', ['one', 'two']);
+  chmodSync(join(outputDir, 'one', 'video.webm'), 0o000);
+  for (let day = 1; day <= 12; day += 1) {
+    mkdirSync(join(keptIn, `2020-01-${String(day).padStart(2, '0')}T00-00-00-000Z`), { recursive: true });
+  }
+  tidyUp(outputDir, IS_MISSING);
+  chmodSync(join(outputDir, 'one', 'video.webm'), 0o644);
+
+  const runs = runsKeptIn(keptIn);
+  expect(runs).toHaveLength(10);
+  expect(filesIn(join(keptIn, runs[runs.length - 1]))).toEqual(['video.webm']);
+});
+
+test('a recording moved there by hand is left alone', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('kept-by-hand', ['one']);
+  mkdirSync(join(keptIn, 'issue-1982'), { recursive: true });
+  writeFileSync(join(keptIn, 'issue-1982', 'video.webm'), 'kept by hand');
+  for (let day = 1; day <= 12; day += 1) {
+    mkdirSync(join(keptIn, `2020-01-${String(day).padStart(2, '0')}T00-00-00-000Z`), { recursive: true });
+  }
+  tidyUp(outputDir, IS_MISSING);
+
+  expect(runsKeptIn(keptIn)).toContain('issue-1982');
+});
+
+test('when nothing can be kept no run is left behind', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('all-unreadable', ['one']);
+  chmodSync(join(outputDir, 'one', 'video.webm'), 0o000);
+  tidyUp(outputDir, IS_MISSING);
+  chmodSync(join(outputDir, 'one', 'video.webm'), 0o644);
+
+  expect(runsKeptIn(keptIn)).toEqual([]);
+});
+
+test('a run that recorded nothing keeps nothing', () => {
+  const { outputDir, keptIn } = aRunThatRecorded('no-videos', []);
+  tidyUp(outputDir, IS_MISSING);
+
+  expect(runsKeptIn(keptIn)).toEqual([]);
+});


### PR DESCRIPTION
Fixes #2010

`RECORD=1 ./node_modules/.bin/playwright test <spec>` wrote its video to
`client/test-results/`, which Playwright empties when a run starts — so the next run deleted it,
and nothing said so. Recording a test, changing something and recording it again to compare was
not possible.

## What changes

The teardown now **copies** the videos of a recorded run into `client/e2e-recordings/<time the
run ended>/`, which no run empties.

Copying rather than moving is the point that decides the design. `globalTeardown` runs *before*
`reporter.onEnd()` (`runner/tasks.js` — teardowns run inside `taskRunner.run()`, and
`finishTaskRun` calls `onEnd` after it returns). So anything the teardown moves is gone by the
time the list reporter prints `attachment #2: video … test-results/…/video.webm`, and by the
time `--reporter=html` copies the attachments out. Leaving the output directory exactly as
Playwright left it keeps both working.

`playwright.config.ts` is therefore untouched.

Also:

- Converted to `.mp4` where ffmpeg is installed, and the `.webm` dropped once it has. ffmpeg
  creates the file `-y` names before it reads anything, so a conversion that stops part way —
  a timeout, a corrupt source — leaves an `.mp4` that will not play; that file is removed and
  the video is kept as it is.
- The ten most recent runs are kept. Only directories named after a time are counted and
  dropped, so a recording moved in there by hand stays.
- A video that cannot be copied is reported and passed over, rather than taking the rest of the
  run's videos and the dropping of old runs with it.
- A run that recorded nothing, and an ffmpeg that is not installed, are now said out loud
  instead of passing silently.

## Tests

`client/e2e/recordings-kept.spec.ts` calls the teardown directly against directories made for
each case — a video that cannot be copied, an ffmpeg that gives up part way, and a hand-kept
recording among twelve old runs are not things a passing run produces. No browser is started,
so the seven cases take about two seconds. Each one was checked to fail when the behaviour it
covers is removed.

Verified by recording throwaway tests as well: every path the reporter printed still existed
afterwards, `--reporter=html` still held its videos, and a run without recording left the kept
recordings alone.

## CI

Untouched. No CI job sets `RECORD`, and without it the teardown is not even registered
(`globalTeardown: recording ? … : undefined`), so CI keeps writing to `client/test-results` and
collecting it as before. The new spec is picked up by the existing `e2e_playwright_1` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)