### PR TITLE
Measurements: make sure Acute Illness and Family Nutrition MUAC is entered in the right unit

### DIFF
--- a/client/e2e/acute-illness-encounter-nurse.spec.ts
+++ b/client/e2e/acute-illness-encounter-nurse.spec.ts
@@ -224,6 +224,7 @@ test.describe('Nurse: Acute Illness Initial Encounter — GI Infection', () => {
     //    MUAC + Nutrition tabs appear for child.
     //    Acute Findings: Sunken Eyes + Poor Skin Turgor (dehydration).
     await completePhysicalExam(page, {
+      checkMuacRange: true,
       respiratoryRate: '30',
       bodyTemp: '39.0',
       muac: '14',

--- a/client/e2e/family-nutrition-encounter-chw.spec.ts
+++ b/client/e2e/family-nutrition-encounter-chw.spec.ts
@@ -52,7 +52,7 @@ test.describe('CHW: Family Nutrition Encounter', () => {
     await completeAhezaMother(page, { amount: '3', reasonIndex: 1 });
 
     // 4. Complete MUAC for mother.
-    await completeMuac(page, { value: '25.0' });
+    await completeMuac(page, { value: '25.0', checkRange: true });
 
     // 5. All mother activities done → End Encounter should be enabled.
     await endFamilyNutritionEncounter(page);

--- a/client/e2e/helpers/acute-illness.ts
+++ b/client/e2e/helpers/acute-illness.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { click } from './auth';
 import {
   WAIT,
@@ -457,6 +457,8 @@ export async function completePhysicalExam(
     respiratoryRate?: string;
     bodyTemp?: string;
     muac?: string;
+    // Type a MUAC in the wrong unit first, and check the nurse is told.
+    checkMuacRange?: boolean;
     /** General acute findings to select (e.g. ['Sunken Eyes', 'Poor Skin Turgor']). Empty = "None of the above". */
     acuteFindingsGeneral?: string[];
     /** Respiratory acute findings to select. Empty = "None of the above". */
@@ -523,12 +525,30 @@ export async function completePhysicalExam(
   const muacTab = page.locator('.link-section:has(.icon-activity-task.icon-physical-exam-muac)');
   if (await muacTab.isVisible({ timeout: 2000 }).catch(() => false)) {
     await clickSubTaskTab(page, 'physical-exam-muac');
+
+    const saveMuac = page.locator('.actions.symptoms button.ui.fluid.primary.button');
+
+    if (options?.checkMuacRange) {
+      // Millimetres typed where centimetres are asked for. The button answers
+      // and the warning names the measurement; nothing is saved.
+      await fillMeasurement(page, 'muac', '125');
+      await page.waitForTimeout(WAIT.formInteraction);
+      await expect(saveMuac, 'save should answer for a MUAC of 125').not.toHaveClass(/disabled/);
+      await click(saveMuac, page);
+
+      const popup = page.locator('div.ui.active.modal.measurement-out-of-range');
+      await popup.waitFor({ timeout: 10000 });
+      await expect(popup, 'the warning should name the MUAC').toHaveClass(
+        /(^| )muac-out-of-range( |$)/,
+      );
+      await click(popup.locator('button.ui.primary.fluid.button'), page);
+      await popup.waitFor({ state: 'hidden', timeout: 10000 });
+      await page.waitForTimeout(WAIT.formInteraction);
+    }
+
     await fillMeasurement(page, 'muac', muac);
     // Save MUAC.
-    await click(
-      page.locator('.actions.symptoms button.ui.fluid.primary.button'),
-      page,
-    );
+    await click(saveMuac, page);
     await page.waitForTimeout(WAIT.elmRerender);
   }
 

--- a/client/e2e/helpers/family-nutrition.ts
+++ b/client/e2e/helpers/family-nutrition.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import { click } from './auth';
 import { drushEnv } from './device';
@@ -483,16 +483,35 @@ export async function completeAhezaChild(
  */
 export async function completeMuac(
   page: Page,
-  options?: { value?: string },
+  options?: { value?: string; checkRange?: boolean },
 ) {
   const value = options?.value ?? '25.0';
+  const input = page.locator('div.ui.full.segment.muac input[type="number"]');
 
   await openActivity(page, 'muac', 'div.ui.full.segment.muac');
 
+  if (options?.checkRange) {
+    // This encounter shows no range above the input, so the warning is the
+    // only place a nurse is ever told what the range is.
+    await input.fill('125');
+    await page.waitForTimeout(WAIT.elmRerender);
+
+    const saveBtn = page.locator('button.ui.fluid.primary.button', { hasText: 'Save' });
+    await expect(saveBtn, 'save should answer for a MUAC of 125').not.toHaveClass(/disabled/);
+    await click(saveBtn, page);
+
+    const popup = page.locator('div.ui.active.modal.measurement-out-of-range');
+    await popup.waitFor({ timeout: 10000 });
+    await expect(popup, 'the warning should name the MUAC').toHaveClass(
+      /(^| )muac-out-of-range( |$)/,
+    );
+    await click(popup.locator('button.ui.primary.fluid.button'), page);
+    await popup.waitFor({ state: 'hidden', timeout: 10000 });
+    await page.waitForTimeout(WAIT.elmRerender);
+  }
+
   // Fill MUAC value (accepts Float via String.toFloat).
-  await page
-    .locator('div.ui.full.segment.muac input[type="number"]')
-    .fill(value);
+  await input.fill(value);
   await page.waitForTimeout(WAIT.elmRerender);
 
   await saveActivity(page);

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -2623,13 +2623,11 @@ viewNCDAContent language currentDate site personId person config helperState sho
         , actions
         ]
     , viewModal <|
-        viewNCDAHelperDialog language (config.setHelperStateMsg Nothing) helperState
-    , viewModal <|
         if showBirthWeightOutOfRangePopup then
             Just <| measurementOutOfRangePopup language site [ MeasurementBirthWeight ] (config.setBirthWeightOutOfRangePopupMsg False)
 
         else
-            Nothing
+            viewNCDAHelperDialog language (config.setHelperStateMsg Nothing) helperState
     ]
 
 

--- a/client/src/elm/Pages/AcuteIllness/Activity/Model.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Model.elm
@@ -11,7 +11,7 @@ import DateSelector.Model exposing (DateSelectorConfig)
 import EverySet exposing (EverySet)
 import Form
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (HealthEducationForm, MuacForm, OngoingTreatmentReviewForm, SendToHCForm, VitalsForm, emptyHealthEducationForm, emptyMuacForm, emptyOngoingTreatmentReviewForm, emptySendToHCForm, emptyVitalsForm)
+import Measurement.Model exposing (AnthropometricMeasurement, HealthEducationForm, MuacForm, OngoingTreatmentReviewForm, SendToHCForm, VitalsForm, emptyHealthEducationForm, emptyMuacForm, emptyOngoingTreatmentReviewForm, emptySendToHCForm, emptyVitalsForm)
 import Pages.AcuteIllness.Activity.Types exposing (AILaboratoryTask, DangerSignsTask, ExposureTask, OngoingTreatmentTask, PhysicalExamTask, PriorTreatmentTask, SymptomsTask)
 import Pages.Page exposing (Page)
 import SyncManager.Model exposing (Site)
@@ -22,6 +22,7 @@ type Msg
     | SetActivePage Page
     | SetAlertsDialogState Bool
     | SetWarningPopupState (Maybe AcuteIllnessDiagnosis)
+    | SetMeasurementOutOfRangePopupState (List AnthropometricMeasurement)
     | SetPertinentSymptomsPopupState Bool
       -- SYMPTOMS Msgs
     | SetActiveSymptomsTask SymptomsTask
@@ -45,6 +46,7 @@ type Msg
     | SaveVitals PersonId (Maybe ( AcuteIllnessVitalsId, AcuteIllnessVitals )) (Maybe PhysicalExamTask)
     | SaveAcuteFindings PersonId (Maybe ( AcuteFindingsId, AcuteFindings )) (Maybe PhysicalExamTask)
     | SetMuac String
+    | PreSaveMuac PersonId (Maybe ( AcuteIllnessMuacId, AcuteIllnessMuac )) (Maybe PhysicalExamTask)
     | SaveMuac PersonId (Maybe ( AcuteIllnessMuacId, AcuteIllnessMuac )) (Maybe PhysicalExamTask)
     | SetNutritionSign ChildNutritionSign
     | SaveNutrition PersonId (Maybe ( AcuteIllnessNutritionId, AcuteIllnessNutrition )) (Maybe PhysicalExamTask)
@@ -114,6 +116,9 @@ type alias Model =
     , showAlertsDialog : Bool
     , showPertinentSymptomsPopup : Bool
     , warningPopupState : Maybe AcuteIllnessDiagnosis
+
+    -- Kept apart from warningPopupState, which carries a diagnosis.
+    , measurementOutOfRangePopupState : List AnthropometricMeasurement
     }
 
 
@@ -130,6 +135,7 @@ emptyModel =
     , showAlertsDialog = False
     , showPertinentSymptomsPopup = False
     , warningPopupState = Nothing
+    , measurementOutOfRangePopupState = []
     }
 
 

--- a/client/src/elm/Pages/AcuteIllness/Activity/Test.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Test.elm
@@ -23,20 +23,20 @@ import Backend.Measurement.Model
         , SymptomsRespiratorySign(..)
         , VitalsValue
         )
+import Backend.Model exposing (emptyModelIndexedDb)
 import Backend.Person.Model exposing (Person)
 import Date
 import EverySet exposing (EverySet)
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (emptyMuacForm)
-import Pages.AcuteIllness.Activity.Model exposing (emptyCovidTestingForm)
-import Pages.AcuteIllness.Activity.Types exposing (PhysicalExamTask(..))
+import Measurement.Model exposing (AnthropometricMeasurement(..), emptyMuacForm)
+import Pages.AcuteIllness.Activity.Model exposing (Msg(..), emptyCovidTestingForm, emptyModel)
+import Pages.AcuteIllness.Activity.Update exposing (update)
 import Pages.AcuteIllness.Activity.Utils
     exposing
         ( malariaDangerSignsPresent
         , mildGastrointestinalInfectionSymptomsPresent
         , nonBloodyDiarrheaAtSymptoms
-        , physicalExamSaveDisabled
         , resolveAcuteIllnessDiagnosis
         , resolveAcuteIllnessDiagnosisByMalariaRDT
         , resolveAmoxicillinDosage
@@ -875,7 +875,7 @@ all =
         , orsDosageTest
         , zincDosageTest
         , amoxicillinDosageTest
-        , physicalExamSaveDisabledTest
+        , preSaveMuacTest
         , covidTestingRoundTripTest
         ]
 
@@ -909,44 +909,49 @@ covidTestingRoundTripTest =
         ]
 
 
-{-| The Physical Exam save action used to be gated on task completeness alone,
-so a mistyped MUAC saved silently and fed the nutrition assessment - while the
-same shared MUAC form is range-gated in the Nutrition encounter, the group
-sessions and Family Nutrition.
+{-| A mistyped MUAC used to deaden the Save button with nothing on screen to
+say why. The measurement is named on a warning instead, and nothing is saved
+until it is entered again.
 -}
-physicalExamSaveDisabledTest : Test
-physicalExamSaveDisabledTest =
+preSaveMuacTest : Test
+preSaveMuacTest =
     let
-        saveDisabled site tasksIncomplete muac task =
-            physicalExamSaveDisabled site tasksIncomplete { emptyMuacForm | muac = muac } task
+        preSave site muac =
+            let
+                data =
+                    emptyModel.physicalExamData
+
+                model =
+                    { emptyModel
+                        | physicalExamData = { data | muacForm = { emptyMuacForm | muac = muac } }
+                    }
+
+                ( updatedModel, _, appMsgs ) =
+                    update site
+                        Nothing
+                        (toEntityUuid "encounter")
+                        emptyModelIndexedDb
+                        (PreSaveMuac (toEntityUuid "person") Nothing Nothing)
+                        model
+            in
+            -- What the warning names, and whether anything was saved.
+            ( updatedModel.measurementOutOfRangePopupState, not <| List.isEmpty appMsgs )
     in
-    describe "physicalExamSaveDisabled"
-        [ test "Muac: Rwanda accepts a plausible 12.5 cm" <|
+    describe "the MUAC save gate"
+        [ test "Rwanda: a plausible 12.5 cm names nothing and saves" <|
             \_ ->
-                saveDisabled SiteRwanda False (Just 12.5) PhysicalExamMuac
-                    |> Expect.equal False
-        , test "Muac: Rwanda rejects 125, a mm value typed into a cm field" <|
+                preSave SiteRwanda (Just 12.5)
+                    |> Expect.equal ( [], True )
+        , test "Rwanda: 125, a mm value typed into a cm field, is named and saves nothing" <|
             \_ ->
-                saveDisabled SiteRwanda False (Just 125) PhysicalExamMuac
-                    |> Expect.equal True
-        , test "Muac: Burundi stores cm, so 12.5 cm (125 mm) enables Save" <|
+                preSave SiteRwanda (Just 125)
+                    |> Expect.equal ( [ MeasurementMuac ], False )
+        , test "Burundi: a form holding 12.5 cm is 125 mm there, so it names nothing and saves" <|
             \_ ->
-                saveDisabled SiteBurundi False (Just 12.5) PhysicalExamMuac
-                    |> Expect.equal False
-        , test "Muac: an unset value keeps Save disabled" <|
+                preSave SiteBurundi (Just 12.5)
+                    |> Expect.equal ( [], True )
+        , test "Burundi: a form holding 1.25 cm is 12.5 mm there, below the range" <|
             \_ ->
-                saveDisabled SiteRwanda False Nothing PhysicalExamMuac
-                    |> Expect.equal True
-        , test "Muac: an unanswered task keeps Save disabled even with a valid value" <|
-            \_ ->
-                saveDisabled SiteRwanda True (Just 12.5) PhysicalExamMuac
-                    |> Expect.equal True
-        , test "the other physical exam tasks remain gated on task completeness only" <|
-            \_ ->
-                [ saveDisabled SiteRwanda False Nothing PhysicalExamVitals
-                , saveDisabled SiteRwanda True Nothing PhysicalExamVitals
-                , saveDisabled SiteRwanda False Nothing PhysicalExamNutrition
-                , saveDisabled SiteRwanda False Nothing PhysicalExamAcuteFindings
-                ]
-                    |> Expect.equal [ False, True, False, False ]
+                preSave SiteBurundi (Just 1.25)
+                    |> Expect.equal ( [ MeasurementMuac ], False )
         ]

--- a/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
@@ -388,7 +388,10 @@ update site selectedHealthCenter id db msg model =
                     model.physicalExamData
                         |> (\data -> { data | activeTask = Just task })
             in
-            ( { model | physicalExamData = updatedData }
+            -- Moving to another task forgets what the one before it was
+            -- complaining about: the warning names a measurement, and the
+            -- tasks of this activity share one place to put it.
+            ( { model | physicalExamData = updatedData, measurementOutOfRangePopupState = [] }
             , Cmd.none
             , []
             )

--- a/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Update.elm
@@ -30,7 +30,9 @@ import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (isJust, isNothing, unwrap)
 import Measurement.Utils
     exposing
-        ( ongoingTreatmentReviewFormWithDefault
+        ( muacFormWithDefault
+        , muacOutOfRange
+        , ongoingTreatmentReviewFormWithDefault
         , toHealthEducationValueWithDefault
         , toMuacValueWithDefault
         , toOngoingTreatmentReviewValueWithDefault
@@ -117,6 +119,31 @@ update site selectedHealthCenter id db msg model =
 
         SetWarningPopupState diagnosis ->
             ( { model | warningPopupState = diagnosis }, Cmd.none, [] )
+
+        SetMeasurementOutOfRangePopupState state ->
+            ( { model | measurementOutOfRangePopupState = state }, Cmd.none, [] )
+
+        PreSaveMuac personId saved nextTask ->
+            let
+                outOfRange =
+                    getMeasurementValueFunc saved
+                        |> muacFormWithDefault model.physicalExamData.muacForm
+                        |> muacOutOfRange site
+
+                extraMsgs =
+                    if List.isEmpty outOfRange then
+                        [ SaveMuac personId saved nextTask ]
+
+                    else
+                        -- Tell the nurse what is wrong and leave the form as it
+                        -- is, so the measurement can be entered again.
+                        [ SetMeasurementOutOfRangePopupState outOfRange ]
+            in
+            ( model
+            , Cmd.none
+            , []
+            )
+                |> sequenceExtra (update site selectedHealthCenter id db) extraMsgs
 
         SetPertinentSymptomsPopupState isOpen ->
             ( { model | showPertinentSymptomsPopup = isOpen }, Cmd.none, [] )

--- a/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.AcuteIllness.Activity.Utils exposing (activityCompleted, acuteFindingsFormInutsAndTasks, acuteFindingsFormWithDefault, allSymptomsGISigns, allSymptomsGeneralSigns, allSymptomsRespiratorySigns, contactsTracingFormWithDefault, coreExamFormInutsAndTasks, coreExamFormWithDefault, coughLessThan2WeeksConstant, covidTestingFormInputsAndTasks, covidTestingFormWithDefault, dangerSignsTasksCompletedFromTotal, expectActivity, expectLaboratoryTask, expectPhysicalExamTask, feverRecorded, followUpFormInutsAndTasks, followUpFormWithDefault, gastrointestinalInfectionDangerSignsPresent, generateVitalsFormConfig, healthEducationFormInutsAndTasks, laboratoryTasks, laboratoryTasksCompletedFromTotal, malariaDangerSignsPresent, malariaTestingFormInputsAndTasks, malariaTestingFormWithDefault, mandatoryActivitiesCompletedSubsequentVisit, medicationDistributionFormInutsAndTasks, medicationDistributionFormWithDefault, mildGastrointestinalInfectionSymptomsPresent, muacRedOnSubsequentVisit, nextStepsTasksCompletedFromTotal, noImprovementOnSubsequentVisit, nonBloodyDiarrheaAtSymptoms, nutritionFormInutsAndTasks, nutritionFormWithDefault, ongoingTreatmentTasksCompletedFromTotal, physicalExamSaveDisabled, physicalExamTasks, physicalExamTasksCompletedFromTotal, resolveAcuteIllnessDiagnosis, resolveAcuteIllnessDiagnosisByMalariaRDT, resolveAmoxicillinDosage, resolveCoartemDosage, resolveMedicationsNonAdministrationReasons, resolveNextStepFirstEncounter, resolveNextStepSubsequentEncounter, resolveNextStepsTasks, resolveORSDosage, resolvePreviousValue, resolveZincDosage, respiratoryInfectionDangerSignsPresent, respiratoryRateAbnormalForAge, respiratoryRateElevated, respiratoryRateElevatedByAge, respiratoryRateElevatedByAgeForCovid19, reviewDangerSignsFormInutsAndTasks, reviewDangerSignsFormWithDefault, sendToHCOnSubsequentVisitByNutrition, symptomMaxDuration, symptomsGIFormWithDefault, symptomsGeneralFormWithDefault, symptomsReliefFormInutsAndTasks, symptomsRespiratoryFormWithDefault, symptomsTasksCompletedFromTotal, toAcuteFindingsValueWithDefault, toContactsTracingValueWithDefault, toCoreExamValueWithDefault, toCovidTestingValueWithDefault, toFollowUpValueWithDefault, toMalariaTestingValueWithDefault, toMedicationDistributionValueWithDefault, toNutritionValueWithDefault, toReviewDangerSignsValueWithDefault, toSymptomsGIValueWithDefault, toSymptomsGeneralValueWithDefault, toSymptomsRespiratoryValueWithDefault, toTreatmentReviewValueWithDefault, toggleSymptomsSign, treatmentReviewFormInutsAndTasks, treatmentReviewFormWithDefault, treatmentTasksCompletedFromTotal, viewAdministeredMedicationLabel, viewAmoxicillinAdministrationInstructions, viewHCRecommendation, viewOralSolutionPrescription, viewParacetamolAdministrationInstructions, viewTabletsPrescription, vomitingAtSymptoms)
+module Pages.AcuteIllness.Activity.Utils exposing (activityCompleted, acuteFindingsFormInutsAndTasks, acuteFindingsFormWithDefault, allSymptomsGISigns, allSymptomsGeneralSigns, allSymptomsRespiratorySigns, contactsTracingFormWithDefault, coreExamFormInutsAndTasks, coreExamFormWithDefault, coughLessThan2WeeksConstant, covidTestingFormInputsAndTasks, covidTestingFormWithDefault, dangerSignsTasksCompletedFromTotal, expectActivity, expectLaboratoryTask, expectPhysicalExamTask, feverRecorded, followUpFormInutsAndTasks, followUpFormWithDefault, gastrointestinalInfectionDangerSignsPresent, generateVitalsFormConfig, healthEducationFormInutsAndTasks, laboratoryTasks, laboratoryTasksCompletedFromTotal, malariaDangerSignsPresent, malariaTestingFormInputsAndTasks, malariaTestingFormWithDefault, mandatoryActivitiesCompletedSubsequentVisit, medicationDistributionFormInutsAndTasks, medicationDistributionFormWithDefault, mildGastrointestinalInfectionSymptomsPresent, muacRedOnSubsequentVisit, nextStepsTasksCompletedFromTotal, noImprovementOnSubsequentVisit, nonBloodyDiarrheaAtSymptoms, nutritionFormInutsAndTasks, nutritionFormWithDefault, ongoingTreatmentTasksCompletedFromTotal, physicalExamTasks, physicalExamTasksCompletedFromTotal, resolveAcuteIllnessDiagnosis, resolveAcuteIllnessDiagnosisByMalariaRDT, resolveAmoxicillinDosage, resolveCoartemDosage, resolveMedicationsNonAdministrationReasons, resolveNextStepFirstEncounter, resolveNextStepSubsequentEncounter, resolveNextStepsTasks, resolveORSDosage, resolvePreviousValue, resolveZincDosage, respiratoryInfectionDangerSignsPresent, respiratoryRateAbnormalForAge, respiratoryRateElevated, respiratoryRateElevatedByAge, respiratoryRateElevatedByAgeForCovid19, reviewDangerSignsFormInutsAndTasks, reviewDangerSignsFormWithDefault, sendToHCOnSubsequentVisitByNutrition, symptomMaxDuration, symptomsGIFormWithDefault, symptomsGeneralFormWithDefault, symptomsReliefFormInutsAndTasks, symptomsRespiratoryFormWithDefault, symptomsTasksCompletedFromTotal, toAcuteFindingsValueWithDefault, toContactsTracingValueWithDefault, toCoreExamValueWithDefault, toCovidTestingValueWithDefault, toFollowUpValueWithDefault, toMalariaTestingValueWithDefault, toMedicationDistributionValueWithDefault, toNutritionValueWithDefault, toReviewDangerSignsValueWithDefault, toSymptomsGIValueWithDefault, toSymptomsGeneralValueWithDefault, toSymptomsRespiratoryValueWithDefault, toTreatmentReviewValueWithDefault, toggleSymptomsSign, treatmentReviewFormInutsAndTasks, treatmentReviewFormWithDefault, treatmentTasksCompletedFromTotal, viewAdministeredMedicationLabel, viewAmoxicillinAdministrationInstructions, viewHCRecommendation, viewOralSolutionPrescription, viewParacetamolAdministrationInstructions, viewTabletsPrescription, vomitingAtSymptoms)
 
 import AssocList as Dict exposing (Dict)
 import Backend.AcuteIllnessActivity.Model exposing (AcuteIllnessActivity(..))
@@ -360,34 +360,6 @@ physicalExamTasksCompletedFromTotal currentDate isChw assembled data task =
                         |> nutritionFormInutsAndTasks English
     in
     resolveTasksCompletedFromTotal tasks
-
-
-{-| Whether the Save action of a Physical Exam task must stay disabled.
-
-Beyond all the task's questions being answered, MUAC requires a value within the
-allowed range that is shown to the nurse above the input - the same gate the
-Nutrition encounter and the group sessions apply. Otherwise a mistyped value
-would be persisted and fed to the nutrition assessment.
-
--}
-physicalExamSaveDisabled : Site -> Bool -> MuacForm -> PhysicalExamTask -> Bool
-physicalExamSaveDisabled site tasksIncomplete muacForm task =
-    case task of
-        PhysicalExamVitals ->
-            tasksIncomplete
-
-        PhysicalExamCoreExam ->
-            tasksIncomplete
-
-        PhysicalExamMuac ->
-            tasksIncomplete
-                || muacOutsideConstraints site muacForm.muac
-
-        PhysicalExamAcuteFindings ->
-            tasksIncomplete
-
-        PhysicalExamNutrition ->
-            tasksIncomplete
 
 
 generateVitalsFormConfig : Bool -> AssembledData -> VitalsFormConfig Msg

--- a/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Utils.elm
@@ -16,12 +16,11 @@ import Gizra.NominalDate exposing (NominalDate)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Maybe.Extra exposing (andMap, isJust, isNothing, or, unwrap)
-import Measurement.Model exposing (HealthEducationForm, InvokationModule(..), MuacForm, VitalsFormConfig, VitalsFormMode(..))
+import Measurement.Model exposing (HealthEducationForm, InvokationModule(..), VitalsFormConfig, VitalsFormMode(..))
 import Measurement.Utils
     exposing
         ( healthEducationFormWithDefault
         , muacFormWithDefault
-        , muacOutsideConstraints
         , ongoingTreatmentReviewFormWithDefault
         , renderDatePart
         , sendToHCFormWithDefault

--- a/client/src/elm/Pages/AcuteIllness/Activity/View.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/View.elm
@@ -105,13 +105,11 @@ viewHeaderAndContent language currentDate site geoInfo id isChw activity db mode
                 SetWarningPopupState
                 assembled
         , viewModal <|
-            pertinentSymptomsPopup language
-                model.showPertinentSymptomsPopup
-                (SetPertinentSymptomsPopupState False)
-                assembled.measurements
-        , viewModal <|
             if List.isEmpty model.measurementOutOfRangePopupState then
-                Nothing
+                pertinentSymptomsPopup language
+                    model.showPertinentSymptomsPopup
+                    (SetPertinentSymptomsPopupState False)
+                    assembled.measurements
 
             else
                 Just <|

--- a/client/src/elm/Pages/AcuteIllness/Activity/View.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/View.elm
@@ -41,10 +41,10 @@ import Measurement.Utils
         , treatmentReviewInputsAndTasks
         , vitalsFormWithDefault
         )
-import Measurement.View exposing (viewSendToHealthCenterForm, viewSendToHospitalForm)
+import Measurement.View exposing (measurementOutOfRangePopup, viewSendToHealthCenterForm, viewSendToHospitalForm)
 import Pages.AcuteIllness.Activity.Model exposing (AcuteFindingsForm, AcuteIllnessCoreExamForm, AcuteIllnessNutritionForm, ContactsTracingForm, ContactsTracingFormState(..), CovidTestingForm, DangerSignsData, FollowUpForm, LaboratoryData, MalariaTestingForm, MedicationDistributionForm, Model, Msg(..), NextStepsData, OngoingTreatmentData, PhysicalExamData, PriorTreatmentData, RecordContactDetailsData, RegisterContactData, ReviewDangerSignsForm, SymptomsData, SymptomsGIForm, SymptomsGeneralForm, SymptomsRespiratoryForm, TreatmentReviewForm, emptyRecordContactDetailsData, emptyRegisterContactData)
 import Pages.AcuteIllness.Activity.Types exposing (AILaboratoryTask(..), DangerSignsTask(..), NextStepsTask(..), OngoingTreatmentTask(..), PhysicalExamTask(..), PriorTreatmentTask(..), SymptomsTask(..))
-import Pages.AcuteIllness.Activity.Utils exposing (acuteFindingsFormInutsAndTasks, acuteFindingsFormWithDefault, allSymptomsGISigns, allSymptomsGeneralSigns, allSymptomsRespiratorySigns, contactsTracingFormWithDefault, coreExamFormInutsAndTasks, coreExamFormWithDefault, coughLessThan2WeeksConstant, covidTestingFormInputsAndTasks, covidTestingFormWithDefault, dangerSignsTasksCompletedFromTotal, expectLaboratoryTask, expectPhysicalExamTask, feverRecorded, followUpFormInutsAndTasks, followUpFormWithDefault, generateVitalsFormConfig, healthEducationFormInutsAndTasks, laboratoryTasks, laboratoryTasksCompletedFromTotal, malariaTestingFormInputsAndTasks, malariaTestingFormWithDefault, medicationDistributionFormInutsAndTasks, medicationDistributionFormWithDefault, nextStepsTasksCompletedFromTotal, noImprovementOnSubsequentVisit, nutritionFormInutsAndTasks, ongoingTreatmentTasksCompletedFromTotal, physicalExamSaveDisabled, physicalExamTasks, physicalExamTasksCompletedFromTotal, resolveNextStepsTasks, resolvePreviousValue, reviewDangerSignsFormInutsAndTasks, reviewDangerSignsFormWithDefault, symptomMaxDuration, symptomsGIFormWithDefault, symptomsGeneralFormWithDefault, symptomsReliefFormInutsAndTasks, symptomsRespiratoryFormWithDefault, symptomsTasksCompletedFromTotal, treatmentReviewFormInutsAndTasks, treatmentReviewFormWithDefault, treatmentTasksCompletedFromTotal, vomitingAtSymptoms)
+import Pages.AcuteIllness.Activity.Utils exposing (acuteFindingsFormInutsAndTasks, acuteFindingsFormWithDefault, allSymptomsGISigns, allSymptomsGeneralSigns, allSymptomsRespiratorySigns, contactsTracingFormWithDefault, coreExamFormInutsAndTasks, coreExamFormWithDefault, coughLessThan2WeeksConstant, covidTestingFormInputsAndTasks, covidTestingFormWithDefault, dangerSignsTasksCompletedFromTotal, expectLaboratoryTask, expectPhysicalExamTask, feverRecorded, followUpFormInutsAndTasks, followUpFormWithDefault, generateVitalsFormConfig, healthEducationFormInutsAndTasks, laboratoryTasks, laboratoryTasksCompletedFromTotal, malariaTestingFormInputsAndTasks, malariaTestingFormWithDefault, medicationDistributionFormInutsAndTasks, medicationDistributionFormWithDefault, nextStepsTasksCompletedFromTotal, noImprovementOnSubsequentVisit, nutritionFormInutsAndTasks, ongoingTreatmentTasksCompletedFromTotal, physicalExamTasks, physicalExamTasksCompletedFromTotal, resolveNextStepsTasks, resolvePreviousValue, reviewDangerSignsFormInutsAndTasks, reviewDangerSignsFormWithDefault, symptomMaxDuration, symptomsGIFormWithDefault, symptomsGeneralFormWithDefault, symptomsReliefFormInutsAndTasks, symptomsRespiratoryFormWithDefault, symptomsTasksCompletedFromTotal, treatmentReviewFormInutsAndTasks, treatmentReviewFormWithDefault, treatmentTasksCompletedFromTotal, vomitingAtSymptoms)
 import Pages.AcuteIllness.Encounter.Model exposing (AssembledData)
 import Pages.AcuteIllness.Encounter.Utils exposing (generateAssembledData)
 import Pages.AcuteIllness.Encounter.View exposing (viewPersonDetailsWithAlert, warningPopup)
@@ -109,6 +109,16 @@ viewHeaderAndContent language currentDate site geoInfo id isChw activity db mode
                 model.showPertinentSymptomsPopup
                 (SetPertinentSymptomsPopupState False)
                 assembled.measurements
+        , viewModal <|
+            if List.isEmpty model.measurementOutOfRangePopupState then
+                Nothing
+
+            else
+                Just <|
+                    measurementOutOfRangePopup language
+                        site
+                        model.measurementOutOfRangePopupState
+                        (SetMeasurementOutOfRangePopupState [])
         ]
 
 
@@ -746,10 +756,6 @@ viewAcuteIllnessPhysicalExam language currentDate site isChw assembled data =
             Maybe.andThen (\task -> Dict.get task tasksCompletedFromTotalDict) activeTask
                 |> Maybe.withDefault ( 0, 0 )
 
-        muacForm =
-            getMeasurementValueFunc measurements.muac
-                |> muacFormWithDefault data.muacForm
-
         viewForm =
             case activeTask of
                 Just PhysicalExamVitals ->
@@ -772,7 +778,8 @@ viewAcuteIllnessPhysicalExam language currentDate site isChw assembled data =
                         previousValue =
                             resolvePreviousValue assembled .muac (muacValueFuncForSite site)
                     in
-                    muacForm
+                    getMeasurementValueFunc measurements.muac
+                        |> muacFormWithDefault data.muacForm
                         |> Measurement.View.viewMuacForm language currentDate site assembled.person previousValue SetMuac
 
                 Just PhysicalExamAcuteFindings ->
@@ -810,7 +817,7 @@ viewAcuteIllnessPhysicalExam language currentDate site isChw assembled data =
                                         SaveCoreExam personId measurements.coreExam nextTask
 
                                     PhysicalExamMuac ->
-                                        SaveMuac personId measurements.muac nextTask
+                                        PreSaveMuac personId measurements.muac nextTask
 
                                     PhysicalExamAcuteFindings ->
                                         SaveAcuteFindings personId measurements.acuteFindings nextTask
@@ -819,7 +826,7 @@ viewAcuteIllnessPhysicalExam language currentDate site isChw assembled data =
                                         SaveNutrition personId measurements.nutrition nextTask
 
                             disabled =
-                                physicalExamSaveDisabled site (tasksCompleted /= totalTasks) muacForm task
+                                tasksCompleted /= totalTasks
                         in
                         div [ class "actions symptoms" ]
                             [ button

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Model.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Model.elm
@@ -7,7 +7,7 @@ import Backend.FamilyNutritionEncounter.Model exposing (FamilyNutritionEncounter
 import Backend.Measurement.Model exposing (..)
 import Backend.Person.Model exposing (Person)
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AhezaForm, DropZoneFile, MuacForm, PhotoForm, emptyAhezaForm, emptyMuacForm, emptyPhotoForm)
+import Measurement.Model exposing (AhezaForm, AnthropometricMeasurement, DropZoneFile, MuacForm, PhotoForm, emptyAhezaForm, emptyMuacForm, emptyPhotoForm)
 import Pages.Page exposing (Page)
 
 
@@ -19,6 +19,11 @@ type alias Model =
     , selectedTab : Tab
     , dialogState : Maybe DialogType
     , selectedFamilyMember : Maybe FamilyMember
+
+    -- The measurement that was entered outside the range it can take, named on
+    -- a warning until the nurse closes it. This encounter shows no range above
+    -- the input, so the warning is the only place it is said.
+    , measurementOutOfRangePopupState : List AnthropometricMeasurement
     }
 
 
@@ -31,6 +36,7 @@ emptyModel =
     , selectedTab = Pending
     , dialogState = Nothing
     , selectedFamilyMember = Just FamilyMemberMother
+    , measurementOutOfRangePopupState = []
     }
 
 
@@ -39,6 +45,8 @@ type Msg
     | DropZoneComplete DropZoneFile
     | SaveAhezaChild PersonId (Maybe ( AhezaChildId, AhezaChild ))
     | SaveAhezaMother PersonId (Maybe ( AhezaMotherId, AhezaMother ))
+    | PreSaveMuacChild PersonId (Maybe ( FamilyNutritionMuacChildId, FamilyNutritionMuacChild ))
+    | PreSaveMuacMother PersonId (Maybe ( FamilyNutritionMuacMotherId, FamilyNutritionMuacMother ))
     | SaveMuacChild PersonId (Maybe ( FamilyNutritionMuacChildId, FamilyNutritionMuacChild ))
     | SaveMuacMother PersonId (Maybe ( FamilyNutritionMuacMotherId, FamilyNutritionMuacMother ))
     | SavePhoto PersonId (Maybe ( FamilyNutritionPhotoId, FamilyNutritionPhoto ))
@@ -46,6 +54,7 @@ type Msg
     | SetAheza String
     | SetAhezaDistributionReason String
     | SetDialogState (Maybe DialogType)
+    | SetMeasurementOutOfRangePopupState (List AnthropometricMeasurement)
     | SetMuac String
     | SetSelectedActivity (Maybe FamilyNutritionActivity)
     | SetSelectedFamilyMember (Maybe FamilyMember)

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Test.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Test.elm
@@ -1,0 +1,73 @@
+module Pages.FamilyNutrition.Encounter.Test exposing (all)
+
+import Backend.Model exposing (emptyModelIndexedDb)
+import Expect
+import Measurement.Model exposing (AnthropometricMeasurement(..), emptyMuacForm)
+import Pages.FamilyNutrition.Encounter.Model exposing (Msg(..), emptyModel)
+import Pages.FamilyNutrition.Encounter.Update exposing (update)
+import Restful.Endpoint exposing (toEntityUuid)
+import SyncManager.Model exposing (Site(..))
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "Pages.FamilyNutrition.Encounter"
+        [ preSaveMuacTest
+        ]
+
+
+{-| This encounter shows no range above the input, so a MUAC outside it was
+refused by a Save button that would not answer and said nothing at all. The
+measurement is named on a warning instead, which is the only place the range is
+said here.
+
+The same warning is asked for whether the MUAC is the mother's or a child's.
+
+-}
+preSaveMuacTest : Test
+preSaveMuacTest =
+    let
+        person =
+            toEntityUuid "person"
+
+        preSave site muac msg =
+            let
+                data =
+                    emptyModel.muacData
+
+                model =
+                    { emptyModel | muacData = { data | form = { emptyMuacForm | muac = muac } } }
+
+                ( updatedModel, _, appMsgs ) =
+                    update site (toEntityUuid "encounter") emptyModelIndexedDb msg model
+            in
+            -- What the warning names, and whether anything was saved.
+            ( updatedModel.measurementOutOfRangePopupState, not <| List.isEmpty appMsgs )
+    in
+    describe "the MUAC save gate"
+        [ test "the mother's: a plausible 12.5 cm names nothing and saves" <|
+            \_ ->
+                preSave SiteRwanda (Just 12.5) (PreSaveMuacMother person Nothing)
+                    |> Expect.equal ( [], True )
+        , test "the mother's: 125, a mm value typed into a cm field, is named and saves nothing" <|
+            \_ ->
+                preSave SiteRwanda (Just 125) (PreSaveMuacMother person Nothing)
+                    |> Expect.equal ( [ MeasurementMuac ], False )
+        , test "a child's is asked the same way" <|
+            \_ ->
+                preSave SiteRwanda (Just 125) (PreSaveMuacChild person Nothing)
+                    |> Expect.equal ( [ MeasurementMuac ], False )
+        , test "Burundi: a form holding 12.5 cm is 125 mm there, so it names nothing and saves" <|
+            \_ ->
+                preSave SiteBurundi (Just 12.5) (PreSaveMuacMother person Nothing)
+                    |> Expect.equal ( [], True )
+        , test "Burundi: a form holding 1.25 cm is 12.5 mm there, below the range" <|
+            \_ ->
+                preSave SiteBurundi (Just 1.25) (PreSaveMuacMother person Nothing)
+                    |> Expect.equal ( [ MeasurementMuac ], False )
+        , test "closing the warning names nothing, and saves nothing on the way" <|
+            \_ ->
+                preSave SiteRwanda (Just 125) (SetMeasurementOutOfRangePopupState [])
+                    |> Expect.equal ( [], False )
+        ]

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Update.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Update.elm
@@ -320,7 +320,8 @@ update site id db msg model =
                         _ ->
                             Cmd.none
             in
-            ( { model | selectedActivity = activity }, cmd, [] )
+            -- Leaving the activity forgets what it was complaining about.
+            ( { model | selectedActivity = activity, measurementOutOfRangePopupState = [] }, cmd, [] )
 
         SetSelectedFamilyMember member ->
             let
@@ -339,6 +340,7 @@ update site id db msg model =
                 , ahezaData = emptyAhezaData
                 , muacData = emptyMuacData
                 , photoData = emptyPhotoData
+                , measurementOutOfRangePopupState = []
               }
             , cmd
             , []

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Update.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Update.elm
@@ -10,7 +10,8 @@ import Backend.Measurement.Utils exposing (ahezaDistributionReasonFromString, ge
 import Backend.Model exposing (ModelIndexedDb)
 import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (unwrap)
-import Measurement.Utils exposing (toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toMuacValueWithDefault)
+import Measurement.Model exposing (AnthropometricMeasurement)
+import Measurement.Utils exposing (muacFormWithDefault, muacOutOfRange, toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toMuacValueWithDefault)
 import Pages.FamilyNutrition.Encounter.Model exposing (FamilyMember(..), Model, Msg(..), Tab(..), emptyAhezaData, emptyMuacData, emptyPhotoData)
 import Pages.FamilyNutrition.Encounter.Utils exposing (activitiesForFamilyMember, activityCompleted, generateAssembledData, nextFamilyMemberWithPendingActivities)
 import Pages.Page exposing (Page(..))
@@ -113,6 +114,23 @@ update site id db msg model =
             , appMsgs
             )
                 |> sequenceExtra (update site id db) extraMsgs
+
+        SetMeasurementOutOfRangePopupState state ->
+            ( { model | measurementOutOfRangePopupState = state }, Cmd.none, [] )
+
+        PreSaveMuacChild personId saved ->
+            (getMeasurementValueFunc saved
+                |> muacFormWithDefault model.muacData.form
+                |> muacOutOfRange site
+            )
+                |> preSaveMuac site id db model (SaveMuacChild personId saved)
+
+        PreSaveMuacMother personId saved ->
+            (getMeasurementValueFunc saved
+                |> muacFormWithDefault model.muacData.form
+                |> muacOutOfRange site
+            )
+                |> preSaveMuac site id db model (SaveMuacMother personId saved)
 
         SaveMuacChild personId saved ->
             let
@@ -376,3 +394,34 @@ generateAutoAdvanceMsgs encounterId triggeringCompletedActivity db maybeMember =
                                     [ SetSelectedFamilyMember Nothing ]
                     )
                 |> Maybe.withDefault []
+
+
+{-| Saves a MUAC, unless it was entered outside the range it can take.
+
+The nurse is told and the form is left as it is, so it can be entered again.
+Nothing is saved until it is within range. This encounter shows no range above
+the input, so the warning is the only place the range is said.
+
+-}
+preSaveMuac :
+    Site
+    -> FamilyNutritionEncounterId
+    -> ModelIndexedDb
+    -> Model
+    -> Msg
+    -> List AnthropometricMeasurement
+    -> ( Model, Cmd Msg, List App.Model.Msg )
+preSaveMuac site id db model saveMsg outOfRange =
+    let
+        extraMsgs =
+            if List.isEmpty outOfRange then
+                [ saveMsg ]
+
+            else
+                [ SetMeasurementOutOfRangePopupState outOfRange ]
+    in
+    ( model
+    , Cmd.none
+    , []
+    )
+        |> sequenceExtra (update site id db) extraMsgs

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/View.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/View.elm
@@ -14,7 +14,7 @@ import Gizra.NominalDate exposing (NominalDate)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Measurement.Utils exposing (ahezaFormWithDefault, ahezaMotherFormWithDefault, muacFormWithDefault, muacOutsideConstraints)
+import Measurement.Utils exposing (ahezaFormWithDefault, ahezaMotherFormWithDefault, muacFormWithDefault)
 import Measurement.View
 import Pages.FamilyNutrition.Encounter.Model exposing (AssembledData, DialogType(..), FamilyMember(..), Model, Msg(..), Tab(..))
 import Pages.FamilyNutrition.Encounter.Utils exposing (activitiesForFamilyMember, activityCompleted, generateAssembledData)
@@ -77,6 +77,16 @@ viewHeaderAndContent language currentDate site id model data =
         [ header
         , content
         , viewModal dialog
+        , viewModal <|
+            if List.isEmpty model.measurementOutOfRangePopupState then
+                Nothing
+
+            else
+                Just <|
+                    Measurement.View.measurementOutOfRangePopup language
+                        site
+                        model.measurementOutOfRangePopupState
+                        (SetMeasurementOutOfRangePopupState [])
         ]
 
 
@@ -552,16 +562,15 @@ viewMuacForm language currentDate site data model familyMember =
             resolveTasksCompletedFromTotal tasks
 
         disabled =
-            (tasksCompleted /= tasksTotal)
-                || muacOutsideConstraints site form.muac
+            tasksCompleted /= tasksTotal
 
         saveMsg =
             case familyMember of
                 FamilyMemberMother ->
-                    SaveMuacMother data.participant.person data.measurements.muacMother
+                    PreSaveMuacMother data.participant.person data.measurements.muacMother
 
                 FamilyMemberChild childId ->
-                    SaveMuacChild childId (Dict.get childId data.measurements.muacChild)
+                    PreSaveMuacChild childId (Dict.get childId data.measurements.muacChild)
     in
     div [ class "ui full segment muac" ]
         [ div [ class "content" ]

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/View.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/View.elm
@@ -59,26 +59,23 @@ viewHeaderAndContent language currentDate site id model data =
 
         content =
             viewContent language currentDate site model data
-
-        dialog =
-            Maybe.map
-                (\state ->
-                    case state of
-                        DialogEndEncounter ->
-                            viewConfirmationDialog language
-                                Translate.EndEncounterQuestion
-                                Translate.OnceYouEndTheEncounter
-                                (CloseEncounter id)
-                                (SetDialogState Nothing)
-                )
-                model.dialogState
     in
     div [ class "page-encounter family-nutrition" ]
         [ header
         , content
         , viewModal <|
             if List.isEmpty model.measurementOutOfRangePopupState then
-                dialog
+                Maybe.map
+                    (\state ->
+                        case state of
+                            DialogEndEncounter ->
+                                viewConfirmationDialog language
+                                    Translate.EndEncounterQuestion
+                                    Translate.OnceYouEndTheEncounter
+                                    (CloseEncounter id)
+                                    (SetDialogState Nothing)
+                    )
+                    model.dialogState
 
             else
                 Just <|

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/View.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/View.elm
@@ -76,10 +76,9 @@ viewHeaderAndContent language currentDate site id model data =
     div [ class "page-encounter family-nutrition" ]
         [ header
         , content
-        , viewModal dialog
         , viewModal <|
             if List.isEmpty model.measurementOutOfRangePopupState then
-                Nothing
+                dialog
 
             else
                 Just <|

--- a/client/src/elm/Pages/Nutrition/Activity/Update.elm
+++ b/client/src/elm/Pages/Nutrition/Activity/Update.elm
@@ -47,7 +47,8 @@ update site id db msg model =
             )
 
         SetActivePage page ->
-            ( model
+            -- Leaving the activity forgets what it was complaining about.
+            ( { model | measurementOutOfRangePopupState = [] }
             , Cmd.none
             , [ App.Model.SetActivePage page ]
             )

--- a/client/src/elm/Pages/WellChild/Activity/Update.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Update.elm
@@ -401,8 +401,20 @@ update currentDate site id db msg model =
                 updatedData =
                     model.nutritionAssessmentData
                         |> (\data -> { data | activeTask = Just task })
+
+                -- Moving to another task forgets what the one before it was
+                -- complaining about: the warning names a measurement, and the
+                -- tasks of this activity share one place to put it. Only that
+                -- warning is dropped, so a head circumference one still stands.
+                warningPopupState =
+                    case model.warningPopupState of
+                        Just (PopupMeasurementOutOfRange _) ->
+                            Nothing
+
+                        other ->
+                            other
             in
-            ( { model | nutritionAssessmentData = updatedData }
+            ( { model | nutritionAssessmentData = updatedData, warningPopupState = warningPopupState }
             , Cmd.none
             , []
             )


### PR DESCRIPTION
Fixes #2001

Based on #2014 — **merge that first**; the base moves down the stack as each one lands. The diff
here is only this issue's work.

Part of #2006.

## What a nurse gets

Both encounters refused a MUAC outside the range it can take by deadening the Save button, saying
nothing. The measurement is named on a warning instead, and the button goes back to answering the
task count alone. **What can be saved does not change.**

**Family Nutrition is the worse of the two, and the reason this issue is worth doing.** It draws
its MUAC input with `showRangeHelper = False`, so the range was enforced and *never stated
anywhere* — the button simply did not respond. The warning is now the only place a nurse is ever
told what the range is, which is noted at the model field and in the update's docblock so the next
person does not remove it as duplication.

Acute Illness follows the shape of the rest of the series: `physicalExamSaveDisabled` deleted,
`disabled` back to `tasksCompleted /= totalTasks`, and `PreSaveMuac` reading the merged form.

## Tests

`Pages/FamilyNutrition/Encounter/Test.elm` is new — that page had no test module at all. Six
cases: the mother's MUAC and a child's are asked the same way, both sites, and closing the warning
saves nothing on the way out.

The six `physicalExamSaveDisabled` tests are rewritten against `update`, keeping both sites: what
the form holds is centimetres either way, and only the unit it is shown in differs.

**e2e** in `acute-illness-encounter-nurse.spec.ts` and `family-nutrition-encounter-chw.spec.ts`:
each types `125` — millimetres where centimetres are asked for — and goes on only if the warning
names the MUAC.

One trap worth recording: the Acute Illness check is on the test with a **child**. I first put it
on the one with an adult, where the MUAC task is not drawn at all — the check would have passed by
doing nothing, and the test would still have been green.

548 modules compile, `elm-format --validate` clean, **2931 tests pass**, elm-review clean in a
fresh clone under CI's checkout, both e2e specs pass (4 tests, 2.5m).

**Discrimination:** forcing either gate to save fails exactly its own out-of-range cases — two on
Acute Illness, three on Family Nutrition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)