### PR TITLE
Measurements: make sure Prenatal encounter height, weight, MUAC and fundal height are entered in the right units

### DIFF
--- a/client/e2e/helpers/prenatal.ts
+++ b/client/e2e/helpers/prenatal.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 import { click } from './auth';
 import {
   WAIT,
@@ -428,7 +428,12 @@ export async function completeHistory(
  */
 export async function completeExamination(
   page: Page,
-  options?: { isPostpartum?: boolean; vitals?: { sys?: string; dia?: string } },
+  options?: {
+    isPostpartum?: boolean;
+    vitals?: { sys?: string; dia?: string };
+    // Type a MUAC in the wrong unit first, and check the nurse is told.
+    checkRanges?: boolean;
+  },
 ) {
   await openActivity(page, 'prenatal', 'examination');
 
@@ -454,6 +459,31 @@ export async function completeExamination(
     await heightInput.fill('160');
   }
   await fillMeasurement(page, 'weight', '60');
+
+  if (options?.checkRanges) {
+    // Millimetres typed where centimetres are asked for. The button answers,
+    // the warning names the MUAC, and closing it saves nothing - unlike this
+    // page's other warnings, which save on the way out.
+    await fillMeasurement(page, 'muac', '125');
+    await page.waitForTimeout(WAIT.formInteraction);
+
+    const saveBtn = page.locator('button.ui.fluid.primary.button', { hasText: 'Save' });
+    await expect(saveBtn, 'save should answer for a MUAC of 125').not.toHaveClass(/disabled/);
+    await click(saveBtn, page);
+
+    const popup = page.locator('div.ui.active.modal.measurement-out-of-range');
+    await popup.waitFor({ timeout: 10000 });
+    await expect(popup, 'the warning should name the MUAC').toHaveClass(
+      /(^| )muac-out-of-range( |$)/,
+    );
+    await click(popup.locator('button.ui.primary.fluid.button'), page);
+    await popup.waitFor({ state: 'hidden', timeout: 10000 });
+
+    // Still on the form, so nothing out of range was saved.
+    await expect(page.locator('.form-input.measurement.muac').first()).toBeVisible();
+    await page.waitForTimeout(WAIT.formInteraction);
+  }
+
   await fillMeasurement(page, 'muac', '25');
 
   await saveSubTask(page);

--- a/client/e2e/helpers/prenatal.ts
+++ b/client/e2e/helpers/prenatal.ts
@@ -426,6 +426,35 @@ export async function completeHistory(
  *          obstetrical_exam (not postpartum), breast_exam,
  *          prenatal_gu_exam (postpartum only)
  */
+/**
+ * Enters a value outside the range the measurement can take, and checks the
+ * nurse is told which one is wrong rather than left with a button that will not
+ * answer. Closing the warning saves nothing: this page's other warnings save on
+ * the way out, and this one must not.
+ */
+async function refusesOutOfRange(page: Page, id: string, value: string, named: string) {
+  await fillMeasurement(page, id, value);
+  await page.waitForTimeout(WAIT.formInteraction);
+
+  // This page marks refusal by adding `disabled`, not by removing `active`.
+  const saveBtn = page.locator('button.ui.fluid.primary.button', { hasText: 'Save' });
+  await expect(saveBtn, `save should answer for ${id} ${value}`).not.toHaveClass(/disabled/);
+  await click(saveBtn, page);
+
+  const popup = page.locator('div.ui.active.modal.measurement-out-of-range');
+  await popup.waitFor({ timeout: 10000 });
+  await expect(popup, `the warning should name the ${id}`).toHaveClass(
+    new RegExp(`(^| )${named}( |$)`),
+  );
+
+  // Still on the form, so nothing out of range was saved.
+  await expect(page.locator(`.form-input.measurement.${id}`).first()).toBeVisible();
+
+  await click(popup.locator('button.ui.primary.fluid.button'), page);
+  await popup.waitFor({ state: 'hidden', timeout: 10000 });
+  await page.waitForTimeout(WAIT.formInteraction);
+}
+
 export async function completeExamination(
   page: Page,
   options?: {
@@ -461,27 +490,22 @@ export async function completeExamination(
   await fillMeasurement(page, 'weight', '60');
 
   if (options?.checkRanges) {
-    // Millimetres typed where centimetres are asked for. The button answers,
-    // the warning names the MUAC, and closing it saves nothing - unlike this
-    // page's other warnings, which save on the way out.
-    await fillMeasurement(page, 'muac', '125');
-    await page.waitForTimeout(WAIT.formInteraction);
+    // All three are asked for behind one button, so the others have to hold a
+    // value for it to answer at all. Each is then made wrong in turn: a height
+    // in millimetres, a weight with the decimal in the wrong place, and a MUAC
+    // in millimetres where centimetres are asked for.
+    await fillMeasurement(page, 'muac', '25');
 
-    const saveBtn = page.locator('button.ui.fluid.primary.button', { hasText: 'Save' });
-    await expect(saveBtn, 'save should answer for a MUAC of 125').not.toHaveClass(/disabled/);
-    await click(saveBtn, page);
+    if (await heightInput.isVisible()) {
+      await refusesOutOfRange(page, 'height', '1600', 'height-out-of-range');
+      await heightInput.fill('160');
+      await page.waitForTimeout(WAIT.formInteraction);
+    }
 
-    const popup = page.locator('div.ui.active.modal.measurement-out-of-range');
-    await popup.waitFor({ timeout: 10000 });
-    await expect(popup, 'the warning should name the MUAC').toHaveClass(
-      /(^| )muac-out-of-range( |$)/,
-    );
-    await click(popup.locator('button.ui.primary.fluid.button'), page);
-    await popup.waitFor({ state: 'hidden', timeout: 10000 });
+    await refusesOutOfRange(page, 'weight', '850', 'weight-out-of-range');
+    await fillMeasurement(page, 'weight', '60');
 
-    // Still on the form, so nothing out of range was saved.
-    await expect(page.locator('.form-input.measurement.muac').first()).toBeVisible();
-    await page.waitForTimeout(WAIT.formInteraction);
+    await refusesOutOfRange(page, 'muac', '125', 'muac-out-of-range');
   }
 
   await fillMeasurement(page, 'muac', '25');
@@ -548,6 +572,15 @@ export async function completeExamination(
 
     // Previous c-section scar → None
     await selectCheckbox(page, 'None');
+
+    if (options?.checkRanges && (await fundalInput.isVisible().catch(() => false))) {
+      // The range this work gives fundal height, which had none before. Asked
+      // last, because the rest of this form has to hold values for the button
+      // to answer at all.
+      await refusesOutOfRange(page, 'fundal-height', '120', 'fundal-height-out-of-range');
+      await fundalInput.fill('30');
+      await page.waitForTimeout(WAIT.formInteraction);
+    }
 
     await saveSubTask(page);
   }

--- a/client/e2e/prenatal-encounter-nurse.spec.ts
+++ b/client/e2e/prenatal-encounter-nurse.spec.ts
@@ -201,7 +201,7 @@ test.describe('Nurse: Prenatal Initial → Subsequent → Postpartum', () => {
 
     await completePregnancyDating(page, lmpDate);
     await completeHistory(page);
-    await completeExamination(page);
+    await completeExamination(page, { checkRanges: true });
     await completeFamilyPlanning(page);
     await completeDangerSigns(page);
     await completeSymptomReview(page);

--- a/client/src/elm/Measurement/Model.elm
+++ b/client/src/elm/Measurement/Model.elm
@@ -246,6 +246,7 @@ defined in.
 type AnthropometricMeasurement
     = MeasurementBirthLength
     | MeasurementBirthWeight
+    | MeasurementFundalHeight
     | MeasurementHeight
     | MeasurementMuac
     | MeasurementWeight

--- a/client/src/elm/Measurement/Test.elm
+++ b/client/src/elm/Measurement/Test.elm
@@ -32,9 +32,7 @@ import Measurement.Utils
         , heightFormWithDefault
         , initialVaccinationDateByBirthDate
         , liverFunctionResultFormWithDefault
-        , muacOutsideConstraints
         , outOfRangeAsEntered
-        , outsideConstraints
         )
 import Measurement.View exposing (viewColorAlertIndication)
 import SyncManager.Model exposing (Site(..))
@@ -372,78 +370,6 @@ birthWeightOutsideConstraintsTest =
         ]
 
 
-outsideConstraintsTest : Test
-outsideConstraintsTest =
-    -- Guards the Save actions of every measurement form: a value that is absent,
-    -- or outside the range printed above the input, must keep Save disabled.
-    describe "outsideConstraints"
-        [ test "a plausible height is inside the constraints" <|
-            \_ ->
-                outsideConstraints getInputConstraintsHeight (Just 105)
-                    |> Expect.equal False
-        , test "a mistyped height (1050 cm) is outside the constraints" <|
-            \_ ->
-                outsideConstraints getInputConstraintsHeight (Just 1050)
-                    |> Expect.equal True
-        , test "a grossly mistyped weight (850 kg) is outside the constraints" <|
-            \_ ->
-                outsideConstraints getInputConstraintsWeight (Just 850)
-                    |> Expect.equal True
-        , test "the weight range is wide (0.5-200 kg), so an implausible 85 kg for a child still passes" <|
-            -- The constraints are a typo guard, not a plausibility check: the
-            -- weight form is shared with adult encounters. A dropped decimal
-            -- (8.5 -> 85) is therefore NOT caught here.
-            \_ ->
-                outsideConstraints getInputConstraintsWeight (Just 85)
-                    |> Expect.equal False
-        , test "the range bounds themselves are inside the constraints" <|
-            \_ ->
-                ( outsideConstraints getInputConstraintsHeight (Just 25)
-                , outsideConstraints getInputConstraintsHeight (Just 250)
-                )
-                    |> Expect.equal ( False, False )
-        , test "a value just below the minimum is outside the constraints" <|
-            \_ ->
-                outsideConstraints getInputConstraintsHeight (Just 24.9)
-                    |> Expect.equal True
-        , test "an unset value is outside the constraints, so Save stays disabled" <|
-            \_ ->
-                outsideConstraints getInputConstraintsHeight Nothing
-                    |> Expect.equal True
-        ]
-
-
-muacOutsideConstraintsTest : Test
-muacOutsideConstraintsTest =
-    -- MUAC is stored in cm, but its constraints are expressed in the unit shown
-    -- to the nurse - mm at Burundi. Comparing the stored value directly would
-    -- reject every legitimate Burundi measurement.
-    describe "muacOutsideConstraints (site-aware)"
-        [ test "Burundi: a stored 12.5 cm (125 mm) is inside the 50-999 mm range" <|
-            \_ ->
-                muacOutsideConstraints SiteBurundi (Just 12.5)
-                    |> Expect.equal False
-        , test "Burundi: a stored 0.4 cm (4 mm) is below the 50 mm minimum" <|
-            \_ ->
-                muacOutsideConstraints SiteBurundi (Just 0.4)
-                    |> Expect.equal True
-        , test "Rwanda: a stored 12.5 cm is inside the 5-99 cm range" <|
-            \_ ->
-                muacOutsideConstraints SiteRwanda (Just 12.5)
-                    |> Expect.equal False
-        , test "Rwanda: a stored 125 cm (mm typed into a cm field) is above the 99 cm maximum" <|
-            \_ ->
-                muacOutsideConstraints SiteRwanda (Just 125)
-                    |> Expect.equal True
-        , test "an unset MUAC is outside the constraints at either site" <|
-            \_ ->
-                ( muacOutsideConstraints SiteBurundi Nothing
-                , muacOutsideConstraints SiteRwanda Nothing
-                )
-                    |> Expect.equal ( True, True )
-        ]
-
-
 {-| A saved creatinine test with both results filled in, so the tests can check
 what happens when the nurse clears one and re-opens the recurrent encounter.
 -}
@@ -537,8 +463,6 @@ all =
         , updateChildOutOfRangePopupTest
         , birthWeightBlocksNCDAFormTest
         , birthWeightOutsideConstraintsTest
-        , outsideConstraintsTest
-        , muacOutsideConstraintsTest
         , heightFormWithDefaultSkippedTest
         , creatinineResultFormWithDefaultTest
         , liverFunctionResultFormWithDefaultTest

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -1,4 +1,4 @@
-module Measurement.Utils exposing (OutsideCareConfig, ahezaFormWithDefault, ahezaMotherFormWithDefault, allNextStepsTasks, allVaccineTypes, anthropometricConstraints, anthropometricOutOfRange, behindOnVaccinationsByHistory, birthWeightBlocksNCDAForm, birthWeightOutsideConstraints, bloodGpRsResultFormAndTasks, bloodGpRsResultFormWithDefault, bloodGpRsTestFormWithDefault, bloodSmearResultNotSet, bloodSmearResultSet, contributingFactorsFormWithDefault, corePhysicalExamFormWithDefault, creatinineResultFormAndTasks, creatinineResultFormWithDefault, emptyContentAndTasksForPerformedLaboratoryTestConfig, emptyContentAndTasksForPerformedLaboratoryUniversalTestConfig, emptyContentAndTasksLaboratoryResultConfig, emptyContentAndTasksLaboratoryTestInitialConfig, emptyContentAndTasksLaboratoryUniversalTestInitialConfig, expectParticipantConsent, expectUniversalTestResultTask, expectVaccineDoseForPerson, familyPlanningFormWithDefault, fbfFormToValue, followUpFormWithDefault, generateAssembledDataForChildScoreboard, generateAssembledDataForWellChild, generateFutureVaccinationsData, generateGroupNutritionAssessmentEntries, generateIndividualNutritionAssessmentEntries, generateVaccinationProgressDictByChildScoreboard, generateVaccinationProgressForVaccine, getAllDosesForVaccine, getChildForm, getInputConstraintsHeight, getInputConstraintsMuac, getInputConstraintsWeight, getIntervalForVaccine, getMotherForm, getNextVaccineDose, getPreviousMeasurements, hba1cTestFormWithDefault, healthEducationFormWithDefault, heightFormWithDefault, heightOutOfRange, hemoglobinResultFormAndTasks, hemoglobinResultFormWithDefault, hemoglobinTestFormWithDefault, hepatitisBResultFormAndTasks, hepatitisBResultFormWithDefault, hepatitisBTestFormWithDefault, hivPCRResultFormAndTasks, hivPCRResultFormWithDefault, hivPCRTestFormWithDefault, hivResultFollowUpsFormAndTasks, hivResultFormAndTasks, hivResultFormWithDefault, hivTestFormWithDefault, hivTestUniversalFormWithDefault, immunisationTaskToVaccineType, initialVaccinationDateByBirthDate, isBehindOnVaccinationsByProgress, isTestResultValid, laboratoryTaskIconClass, lactationFormToSigns, lipidPanelResultFormAndTasks, lipidPanelResultFormWithDefault, liverFunctionResultFormAndTasks, liverFunctionResultFormWithDefault, malariaResultFormAndTasks, malariaResultFormWithDefault, malariaTestFormWithDefault, medicationAdministrationFormInputsAndTasks, medicationAdministrationFormWithDefault, muacFormWithDefault, muacMeasurementIsOff, muacOutOfRange, muacOutsideConstraints, ncdaFormWithDefault, nextVaccinationDataForVaccine, nonRDTFormWithDefault, nutritionCaringFormWithDefault, nutritionFeedingFormWithDefault, nutritionFollowUpFormWithDefault, nutritionFoodSecurityFormWithDefault, nutritionFormWithDefault, nutritionHygieneFormWithDefault, ongoingTreatmentReviewFormWithDefault, outOfRangeAsEntered, outsideCareFormInputsAndTasks, outsideCareFormWithDefault, outsideCareMedicationOptionsAnemia, outsideCareMedicationOptionsHIV, outsideCareMedicationOptionsHypertension, outsideCareMedicationOptionsMalaria, outsideCareMedicationOptionsSyphilis, outsideConstraints, partnerHIVResultFollowUpsFormAndTasks, partnerHIVResultFormAndTasks, partnerHIVResultFormWithDefault, partnerHIVTestFormWithDefault, pregnancyTestFormWithDefault, randomBloodSugarFormWithDefault, randomBloodSugarResultFormAndTasks, randomBloodSugarResultFormWithDefault, randomBloodSugarUniversalFormWithDefault, renderDatePart, resoloveLastScheduledImmunizationVisitDate, resolveChildANCPregnancyData, resolveLabTestDate, resolveMedicationsNonAdministrationReasons, resolveNCDASteps, sendToHCFormWithDefault, showNCDAQuestionsByNewbornExam, syphilisResultFollowUpsFormAndTasks, syphilisResultFormAndTasks, syphilisResultFormWithDefault, syphilisTestFormWithDefault, testNotPerformedByWhyNotAtExecutionNote, testPerformedByExecutionNote, testPerformedByValue, toAdministrationNoteWithDefault, toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toBloodGpRsResultValueWithDefault, toBloodGpRsTestValueWithDefault, toContributingFactorsValueWithDefault, toCorePhysicalExamValueWithDefault, toCreatinineResultValueWithDefault, toCreatinineTestValueWithEmptyResults, toEverySet, toFamilyPlanningValueWithDefault, toFollowUpValueWithDefault, toHIVPCRResultValueWithDefault, toHIVPCRTestValueWithDefault, toHIVResultValueWithDefault, toHIVTestValueUniversalWithDefault, toHIVTestValueWithDefault, toHbA1cTestValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toHemoglobinResultValueWithDefault, toHemoglobinTestValueWithDefault, toHepatitisBResultValueWithDefault, toHepatitisBTestValueWithDefault, toLipidPanelResultValueWithDefault, toLipidPanelTestValueWithEmptyResults, toLiverFunctionResultValueWithDefault, toLiverFunctionTestValueWithEmptyResults, toMalariaResultValueWithDefault, toMalariaTestValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNonRDTValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toOngoingTreatmentReviewValueWithDefault, toOutsideCareValueWithDefault, toPartnerHIVResultValueWithDefault, toPartnerHIVTestValueWithDefault, toPregnancyTestValueWithDefault, toRandomBloodSugarResultValueWithDefault, toRandomBloodSugarTestValueUniversalWithDefault, toRandomBloodSugarTestValueWithDefault, toSendToHCValueWithDefault, toSyphilisResultValueWithDefault, toSyphilisTestValueWithDefault, toUrineDipstickResultValueWithDefault, toUrineDipstickTestValueUniversalWithDefault, toUrineDipstickTestValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, treatmentReviewCustomReasonsForNotTakingInputsAndTasks, treatmentReviewInputsAndTasks, urineDipstickFormWithDefault, urineDipstickResultFormAndTasks, urineDipstickResultFormWithDefault, urineDipstickUniversalFormWithDefault, vaccinationFormDynamicContentAndTasks, vaccinationFormWithDefault, vaccineDoseToComparable, viewAdministeredMedicationCustomLabel, viewAdministeredMedicationQuestion, viewBloodGpRsTestForm, viewHIVPCRTestForm, viewHIVTestForm, viewHIVTestUniversalForm, viewHbA1cTestForm, viewHemoglobinTestForm, viewHepatitisBTestForm, viewMalariaTestForm, viewNonRDTForm, viewPartnerHIVTestForm, viewPregnancyTestForm, viewRandomBloodSugarTestForm, viewRandomBloodSugarTestUniversalForm, viewReinforceAdherenceQuestion, viewSelectInput, viewSyphilisTestForm, viewUrineDipstickTestForm, viewUrineDipstickTestUniversalForm, vitalsFormWithDefault, wasFirstDoseAdministeredWithin14DaysFromBirthByVaccinationForm, wasInitialOpvAdministeredByVaccinationProgress, weightFormWithDefault, weightOutOfRange)
+module Measurement.Utils exposing (OutsideCareConfig, ahezaFormWithDefault, ahezaMotherFormWithDefault, allNextStepsTasks, allVaccineTypes, anthropometricConstraints, anthropometricOutOfRange, behindOnVaccinationsByHistory, birthWeightBlocksNCDAForm, birthWeightOutsideConstraints, bloodGpRsResultFormAndTasks, bloodGpRsResultFormWithDefault, bloodGpRsTestFormWithDefault, bloodSmearResultNotSet, bloodSmearResultSet, contributingFactorsFormWithDefault, corePhysicalExamFormWithDefault, creatinineResultFormAndTasks, creatinineResultFormWithDefault, emptyContentAndTasksForPerformedLaboratoryTestConfig, emptyContentAndTasksForPerformedLaboratoryUniversalTestConfig, emptyContentAndTasksLaboratoryResultConfig, emptyContentAndTasksLaboratoryTestInitialConfig, emptyContentAndTasksLaboratoryUniversalTestInitialConfig, expectParticipantConsent, expectUniversalTestResultTask, expectVaccineDoseForPerson, familyPlanningFormWithDefault, fbfFormToValue, followUpFormWithDefault, generateAssembledDataForChildScoreboard, generateAssembledDataForWellChild, generateFutureVaccinationsData, generateGroupNutritionAssessmentEntries, generateIndividualNutritionAssessmentEntries, generateVaccinationProgressDictByChildScoreboard, generateVaccinationProgressForVaccine, getAllDosesForVaccine, getChildForm, getInputConstraintsHeight, getInputConstraintsMuac, getInputConstraintsWeight, getIntervalForVaccine, getMotherForm, getNextVaccineDose, getPreviousMeasurements, hba1cTestFormWithDefault, healthEducationFormWithDefault, heightFormWithDefault, heightOutOfRange, hemoglobinResultFormAndTasks, hemoglobinResultFormWithDefault, hemoglobinTestFormWithDefault, hepatitisBResultFormAndTasks, hepatitisBResultFormWithDefault, hepatitisBTestFormWithDefault, hivPCRResultFormAndTasks, hivPCRResultFormWithDefault, hivPCRTestFormWithDefault, hivResultFollowUpsFormAndTasks, hivResultFormAndTasks, hivResultFormWithDefault, hivTestFormWithDefault, hivTestUniversalFormWithDefault, immunisationTaskToVaccineType, initialVaccinationDateByBirthDate, isBehindOnVaccinationsByProgress, isTestResultValid, laboratoryTaskIconClass, lactationFormToSigns, lipidPanelResultFormAndTasks, lipidPanelResultFormWithDefault, liverFunctionResultFormAndTasks, liverFunctionResultFormWithDefault, malariaResultFormAndTasks, malariaResultFormWithDefault, malariaTestFormWithDefault, medicationAdministrationFormInputsAndTasks, medicationAdministrationFormWithDefault, muacFormWithDefault, muacMeasurementIsOff, muacOutOfRange, ncdaFormWithDefault, nextVaccinationDataForVaccine, nonRDTFormWithDefault, nutritionCaringFormWithDefault, nutritionFeedingFormWithDefault, nutritionFollowUpFormWithDefault, nutritionFoodSecurityFormWithDefault, nutritionFormWithDefault, nutritionHygieneFormWithDefault, ongoingTreatmentReviewFormWithDefault, outOfRange, outOfRangeAsEntered, outsideCareFormInputsAndTasks, outsideCareFormWithDefault, outsideCareMedicationOptionsAnemia, outsideCareMedicationOptionsHIV, outsideCareMedicationOptionsHypertension, outsideCareMedicationOptionsMalaria, outsideCareMedicationOptionsSyphilis, partnerHIVResultFollowUpsFormAndTasks, partnerHIVResultFormAndTasks, partnerHIVResultFormWithDefault, partnerHIVTestFormWithDefault, pregnancyTestFormWithDefault, randomBloodSugarFormWithDefault, randomBloodSugarResultFormAndTasks, randomBloodSugarResultFormWithDefault, randomBloodSugarUniversalFormWithDefault, renderDatePart, resoloveLastScheduledImmunizationVisitDate, resolveChildANCPregnancyData, resolveLabTestDate, resolveMedicationsNonAdministrationReasons, resolveNCDASteps, sendToHCFormWithDefault, showNCDAQuestionsByNewbornExam, syphilisResultFollowUpsFormAndTasks, syphilisResultFormAndTasks, syphilisResultFormWithDefault, syphilisTestFormWithDefault, testNotPerformedByWhyNotAtExecutionNote, testPerformedByExecutionNote, testPerformedByValue, toAdministrationNoteWithDefault, toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toBloodGpRsResultValueWithDefault, toBloodGpRsTestValueWithDefault, toContributingFactorsValueWithDefault, toCorePhysicalExamValueWithDefault, toCreatinineResultValueWithDefault, toCreatinineTestValueWithEmptyResults, toEverySet, toFamilyPlanningValueWithDefault, toFollowUpValueWithDefault, toHIVPCRResultValueWithDefault, toHIVPCRTestValueWithDefault, toHIVResultValueWithDefault, toHIVTestValueUniversalWithDefault, toHIVTestValueWithDefault, toHbA1cTestValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toHemoglobinResultValueWithDefault, toHemoglobinTestValueWithDefault, toHepatitisBResultValueWithDefault, toHepatitisBTestValueWithDefault, toLipidPanelResultValueWithDefault, toLipidPanelTestValueWithEmptyResults, toLiverFunctionResultValueWithDefault, toLiverFunctionTestValueWithEmptyResults, toMalariaResultValueWithDefault, toMalariaTestValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNonRDTValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toOngoingTreatmentReviewValueWithDefault, toOutsideCareValueWithDefault, toPartnerHIVResultValueWithDefault, toPartnerHIVTestValueWithDefault, toPregnancyTestValueWithDefault, toRandomBloodSugarResultValueWithDefault, toRandomBloodSugarTestValueUniversalWithDefault, toRandomBloodSugarTestValueWithDefault, toSendToHCValueWithDefault, toSyphilisResultValueWithDefault, toSyphilisTestValueWithDefault, toUrineDipstickResultValueWithDefault, toUrineDipstickTestValueUniversalWithDefault, toUrineDipstickTestValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, treatmentReviewCustomReasonsForNotTakingInputsAndTasks, treatmentReviewInputsAndTasks, urineDipstickFormWithDefault, urineDipstickResultFormAndTasks, urineDipstickResultFormWithDefault, urineDipstickUniversalFormWithDefault, vaccinationFormDynamicContentAndTasks, vaccinationFormWithDefault, vaccineDoseToComparable, viewAdministeredMedicationCustomLabel, viewAdministeredMedicationQuestion, viewBloodGpRsTestForm, viewHIVPCRTestForm, viewHIVTestForm, viewHIVTestUniversalForm, viewHbA1cTestForm, viewHemoglobinTestForm, viewHepatitisBTestForm, viewMalariaTestForm, viewNonRDTForm, viewPartnerHIVTestForm, viewPregnancyTestForm, viewRandomBloodSugarTestForm, viewRandomBloodSugarTestUniversalForm, viewReinforceAdherenceQuestion, viewSelectInput, viewSyphilisTestForm, viewUrineDipstickTestForm, viewUrineDipstickTestUniversalForm, vitalsFormWithDefault, wasFirstDoseAdministeredWithin14DaysFromBirthByVaccinationForm, wasInitialOpvAdministeredByVaccinationProgress, weightFormWithDefault, weightOutOfRange)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Counseling.Model exposing (CounselingTiming(..))
@@ -108,6 +108,18 @@ entered in metres, or a weight entered by mistake.
 getInputConstraintsBirthLength : FloatInputConstraints
 getInputConstraintsBirthLength =
     { minVal = 15
+    , maxVal = 60
+    }
+
+
+{-| The height of the uterus above the pubic bone, in centimetres. Wide enough
+for every week a pregnancy is measured at, and for the sites that record it from
+the first weeks; it refuses a value in millimetres, or a weight entered by
+mistake.
+-}
+getInputConstraintsFundalHeight : FloatInputConstraints
+getInputConstraintsFundalHeight =
+    { minVal = 1
     , maxVal = 60
     }
 
@@ -303,28 +315,9 @@ withinConstraints constraints value =
     value >= constraints.minVal && value <= constraints.maxVal
 
 
-{-| The complement of `withinConstraints` for an optional measurement value:
-`True` when the value is not set yet, or is set but falls outside its allowed
-range.
-
-Save actions are kept disabled while this holds, so that a mistyped measurement
-(a height of 1050 cm, say) can never reach the z-score calculations.
-
--}
-outsideConstraints : FloatInputConstraints -> Maybe Float -> Bool
-outsideConstraints constraints value =
-    Maybe.map (withinConstraints constraints >> not) value
-        |> Maybe.withDefault True
-
-
-{-| True when a birth weight has been entered and is outside the range a birth
-weight in grams can take.
-
-Unlike `outsideConstraints`, a birth weight that has not been entered is not
-reported here. This answers "is what was entered wrong", which is what the
-warning shown on save is about; whether the measurement still has to be taken is
-already answered by the task count.
-
+{-| True when a birth weight has been entered and is outside the range it can
+take. An unset weight is not reported: whether it still has to be taken is
+answered by the task count.
 -}
 birthWeightOutsideConstraints : Site -> Maybe WeightInGrm -> Bool
 birthWeightOutsideConstraints site birthWeight =
@@ -358,6 +351,10 @@ weightOutOfRange site form =
     outOfRange site MeasurementWeight form.weight
 
 
+{-| The measurement, when what a form holds for it is outside the range it can
+take. For forms holding the value the way the measurements are stored, which is
+centimetres for MUAC; it is put into the unit it is shown in before comparing.
+-}
 outOfRange : Site -> AnthropometricMeasurement -> Maybe Float -> List AnthropometricMeasurement
 outOfRange site measurement value =
     if anthropometricOutOfRange site measurement value then
@@ -396,6 +393,9 @@ anthropometricConstraints site measurement =
 
         MeasurementBirthWeight ->
             getInputConstraintsBirthWeight
+
+        MeasurementFundalHeight ->
+            getInputConstraintsFundalHeight
 
         MeasurementHeight ->
             getInputConstraintsHeight
@@ -468,20 +468,6 @@ birthWeightBlocksNCDAForm site steps newbornExamPregnancySummary birthWeight =
     List.member NCDAStepAntenatalCare steps
         && showNCDAQuestionsByNewbornExam newbornExamPregnancySummary
         && birthWeightOutsideConstraints site birthWeight
-
-
-{-| `outsideConstraints` for a MUAC value as stored on the form (in cm).
-
-MUAC constraints are expressed in the unit shown to the user, which is mm at the
-Burundi site, so the stored value must be converted with `muacValueForSite`
-before it's compared. Use this rather than `outsideConstraints` directly, so the
-conversion can't be forgotten.
-
--}
-muacOutsideConstraints : Site -> Maybe Float -> Bool
-muacOutsideConstraints site muac =
-    Maybe.map (muacValueForSite site) muac
-        |> outsideConstraints (getInputConstraintsMuac site)
 
 
 lactationSignsToForm : EverySet LactationSign -> LactationForm

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -2614,6 +2614,20 @@ viewNCDAContent language currentDate site personId person config helperState sho
                 )
                 currentStep
                 |> Maybe.withDefault ( emptyNode, emptyNode )
+
+        outOfRangeWarning =
+            if showBirthWeightOutOfRangePopup then
+                Just <|
+                    measurementOutOfRangePopup language
+                        site
+                        [ MeasurementBirthWeight ]
+                        (config.setBirthWeightOutOfRangePopupMsg False)
+
+            else
+                Nothing
+
+        helperDialog =
+            viewNCDAHelperDialog language (config.setHelperStateMsg Nothing) helperState
     in
     [ header
     , viewTasksCount language tasksCompleted totalTasks
@@ -2622,12 +2636,10 @@ viewNCDAContent language currentDate site personId person config helperState sho
             [ div [ class "ui form ncda" ] viewForm ]
         , actions
         ]
-    , viewModal <|
-        if showBirthWeightOutOfRangePopup then
-            Just <| measurementOutOfRangePopup language site [ MeasurementBirthWeight ] (config.setBirthWeightOutOfRangePopupMsg False)
 
-        else
-            viewNCDAHelperDialog language (config.setHelperStateMsg Nothing) helperState
+    -- One at a time, and the warning wins: it answers what the nurse just
+    -- pressed, while the dialog only explains a question.
+    , viewModal <| Maybe.Extra.or outOfRangeWarning helperDialog
     ]
 
 

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -3708,6 +3708,9 @@ measurementOutOfRangeClass measurement =
         MeasurementBirthWeight ->
             "birth-weight-out-of-range"
 
+        MeasurementFundalHeight ->
+            "fundal-height-out-of-range"
+
         MeasurementHeight ->
             "height-out-of-range"
 

--- a/client/src/elm/Pages/Prenatal/Activity/Model.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Model.elm
@@ -113,6 +113,7 @@ type Msg
       -- ExaminationMsgs, Nutrition Assessment
     | SetNutritionAssessmentMeasurement (Maybe Float -> NutritionAssessmentForm -> NutritionAssessmentForm) String
     | SetNutritionAssessmentMuac String
+    | PreSaveNutritionAssessment PersonId (Maybe ( PrenatalNutritionId, PrenatalNutrition )) (Maybe Float) (Maybe Bool) (Maybe ExaminationTask)
     | SaveNutritionAssessment PersonId (Maybe ( PrenatalNutritionId, PrenatalNutrition )) (Maybe Float) (Maybe Bool) (Maybe ExaminationTask)
       -- ExaminationMsgs, Core Physical Exam
     | SetCorePhysicalExamBoolInput (Bool -> CorePhysicalExamForm -> CorePhysicalExamForm) Bool
@@ -131,6 +132,7 @@ type Msg
     | SetObstetricalExamCSectionScar CSectionScar
     | HideFundalPalpablePopup
     | ToggleFetalHeartRateNotAudible
+    | PreSaveObstetricalExam PersonId (Maybe ( ObstetricalExamId, ObstetricalExam )) (Maybe ExaminationTask)
     | SaveObstetricalExam PersonId (Maybe ( ObstetricalExamId, ObstetricalExam )) (Maybe ExaminationTask)
       -- ExaminationMsgs, Breast Exam
     | SetBreastExamBoolInput (Bool -> BreastExamForm -> BreastExamForm) Bool

--- a/client/src/elm/Pages/Prenatal/Activity/Test.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Test.elm
@@ -34,6 +34,7 @@ import Backend.Measurement.Model
         , VitalsValue
         , emptyPrenatalMeasurements
         )
+import Backend.Model exposing (emptyModelIndexedDb)
 import Backend.Person.Model exposing (Person)
 import Backend.PrenatalEncounter.Model exposing (PrenatalEncounter, PrenatalEncounterType(..))
 import Backend.PrenatalEncounter.Types exposing (PrenatalDiagnosis(..))
@@ -41,10 +42,14 @@ import Date
 import EverySet exposing (EverySet)
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
-import Pages.Prenatal.Activity.Types exposing (PrePregnancyClassification(..))
+import Measurement.Model exposing (AnthropometricMeasurement(..))
+import Pages.Prenatal.Activity.Model exposing (Msg(..), emptyModel)
+import Pages.Prenatal.Activity.Types exposing (PrePregnancyClassification(..), WarningPopupType(..))
+import Pages.Prenatal.Activity.Update exposing (update)
 import Pages.Prenatal.Activity.Utils exposing (bmiToPrePregnancyClassification, generatePrenatalAssesmentForChw, generatePrenatalDiagnosesForNurse, suicideRiskDiagnosedBySigns, zscoreToPrePregnancyClassification)
 import Pages.Prenatal.Model exposing (AssembledData)
 import Restful.Endpoint exposing (EntityUuid, toEntityUuid)
+import SyncManager.Model exposing (Site(..))
 import Test exposing (Test, describe, test)
 import Time
 
@@ -1317,7 +1322,8 @@ suicideRiskDiagnosedBySignsTest =
 all : Test
 all =
     describe "Prenatal Activity tests"
-        [ bmiToPrePregnancyClassificationTest
+        [ measurementOutOfRangeTest
+        , bmiToPrePregnancyClassificationTest
         , zscoreToPrePregnancyClassificationTest
         , generatePrenatalDiagnosesForNurseLabsTest
         , generatePrenatalDiagnosesForNurseRecurrentLabsTest
@@ -1333,4 +1339,121 @@ all =
         , generatePrenatalDiagnosesForNurseHIVViralLoadRecurrentTest
         , generatePrenatalDiagnosesForNurseEGA37PlusPreeclampsiaRecurrentTest
         , suicideRiskDiagnosedBySignsTest
+        ]
+
+
+{-| Nothing was checked on this encounter, so a mistyped height, weight, MUAC or
+fundal height saved without a word. Each is named on a warning now, and nothing
+is saved until it is entered again.
+
+A height measured at an earlier encounter is carried over and its input is not
+drawn, so it is not asked about: there would be nothing on screen to correct.
+
+-}
+measurementOutOfRangeTest : Test
+measurementOutOfRangeTest =
+    let
+        person =
+            toEntityUuid "person"
+
+        preSaveNutrition site carriedOverHeight height weight muac =
+            let
+                data =
+                    emptyModel.examinationData
+
+                form =
+                    data.nutritionAssessmentForm
+
+                model =
+                    { emptyModel
+                        | examinationData =
+                            { data
+                                | nutritionAssessmentForm =
+                                    { form | height = height, weight = weight, muac = muac }
+                            }
+                    }
+
+                ( updatedModel, _, appMsgs ) =
+                    update (Date.fromCalendarDate 2026 Time.Jul 28)
+                        site
+                        (toEntityUuid "encounter")
+                        emptyModelIndexedDb
+                        (PreSaveNutritionAssessment person Nothing carriedOverHeight Nothing Nothing)
+                        model
+            in
+            -- What the warning names, and whether anything was saved.
+            ( updatedModel.warningPopupState, not <| List.isEmpty appMsgs )
+
+        preSaveObstetrical palpable fundalHeight =
+            let
+                data =
+                    emptyModel.examinationData
+
+                form =
+                    data.obstetricalExamForm
+
+                model =
+                    { emptyModel
+                        | examinationData =
+                            { data
+                                | obstetricalExamForm =
+                                    { form | fundalPalpable = palpable, fundalHeight = fundalHeight }
+                            }
+                    }
+
+                ( updatedModel, _, appMsgs ) =
+                    update (Date.fromCalendarDate 2026 Time.Jul 28)
+                        SiteRwanda
+                        (toEntityUuid "encounter")
+                        emptyModelIndexedDb
+                        (PreSaveObstetricalExam person Nothing Nothing)
+                        model
+            in
+            ( updatedModel.warningPopupState, not <| List.isEmpty appMsgs )
+
+        named measurements =
+            Just (WarningPopupMeasurementOutOfRange measurements)
+    in
+    describe "the ANC save gate"
+        [ test "a height of 1050 cm is named and saves nothing" <|
+            \_ ->
+                preSaveNutrition SiteRwanda Nothing (Just 1050) Nothing Nothing
+                    |> Expect.equal ( named [ MeasurementHeight ], False )
+        , test "a weight of 850 kg is named and saves nothing" <|
+            \_ ->
+                preSaveNutrition SiteRwanda Nothing Nothing (Just 850) Nothing
+                    |> Expect.equal ( named [ MeasurementWeight ], False )
+        , test "a MUAC of 125, being millimetres, is named and saves nothing" <|
+            \_ ->
+                preSaveNutrition SiteRwanda Nothing Nothing Nothing (Just 125)
+                    |> Expect.equal ( named [ MeasurementMuac ], False )
+        , test "Burundi holds MUAC in centimetres too, so 12.5 is within range there" <|
+            \_ ->
+                preSaveNutrition SiteBurundi Nothing Nothing Nothing (Just 12.5)
+                    |> Expect.equal ( Nothing, True )
+        , test "every one that is wrong is named, not just the first" <|
+            \_ ->
+                preSaveNutrition SiteRwanda Nothing (Just 1050) (Just 850) (Just 125)
+                    |> Expect.equal
+                        ( named [ MeasurementHeight, MeasurementWeight, MeasurementMuac ], False )
+        , test "a height carried over from an earlier encounter is not asked about" <|
+            \_ ->
+                preSaveNutrition SiteRwanda (Just 165) (Just 1050) Nothing Nothing
+                    |> Expect.equal ( Nothing, True )
+        , test "measurements within range save with no warning" <|
+            \_ ->
+                preSaveNutrition SiteRwanda Nothing (Just 165) (Just 65) (Just 25)
+                    |> Expect.equal ( Nothing, True )
+        , test "a fundal height of 120 cm is named and saves nothing" <|
+            \_ ->
+                preSaveObstetrical (Just True) (Just 120)
+                    |> Expect.equal ( named [ MeasurementFundalHeight ], False )
+        , test "a fundal height within range saves with no warning" <|
+            \_ ->
+                preSaveObstetrical (Just True) (Just 30)
+                    |> Expect.equal ( Nothing, True )
+        , test "nothing is asked when the uterus cannot be felt" <|
+            \_ ->
+                preSaveObstetrical (Just False) (Just 120)
+                    |> Expect.equal ( Nothing, True )
         ]

--- a/client/src/elm/Pages/Prenatal/Activity/Types.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Types.elm
@@ -1,5 +1,7 @@
 module Pages.Prenatal.Activity.Types exposing (ExaminationTask(..), GWGClassification(..), HistoryTask(..), ImmunisationTask(..), MedicationTask(..), NextStepsTask(..), ObstetricHistoryStep(..), PrePregnancyClassification(..), SymptomReviewStep(..), TreatmentReviewTask(..), WarningPopupType(..))
 
+import Measurement.Model exposing (AnthropometricMeasurement)
+
 
 type ExaminationTask
     = BreastExam
@@ -54,6 +56,7 @@ type WarningPopupType msg
     | WarningPopupMentalHealth msg
     | WarningPopupTreatmentReview msg
     | WarningPopupVitaminA msg
+    | WarningPopupMeasurementOutOfRange (List AnthropometricMeasurement)
 
 
 type ObstetricHistoryStep

--- a/client/src/elm/Pages/Prenatal/Activity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Update.elm
@@ -41,7 +41,7 @@ import EverySet
 import Gizra.NominalDate exposing (NominalDate)
 import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (unwrap)
-import Measurement.Model exposing (VaccinationFormViewMode(..))
+import Measurement.Model exposing (AnthropometricMeasurement(..), VaccinationFormViewMode(..))
 import Measurement.Utils
     exposing
         ( corePhysicalExamFormWithDefault
@@ -70,7 +70,7 @@ import Measurement.Utils
 import Pages.Page exposing (Page(..), UserPage(..))
 import Pages.Prenatal.Activity.Model exposing (Model, Msg(..), emptyPregnancyDatingForm)
 import Pages.Prenatal.Activity.Types exposing (ImmunisationTask(..), ObstetricHistoryStep(..), SymptomReviewStep(..), WarningPopupType(..))
-import Pages.Prenatal.Activity.Utils exposing (birthPlanFormWithDefault, breastExamFormWithDefault, dangerSignsFormWithDefault, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, guExamFormWithDefault, medicalHistoryFormWithDefault, mentalHealthFormWithDefault, obstetricHistoryStep2FormWithDefault, obstetricalExamFormWithDefault, symptomReviewFormWithDefault, toAppointmentConfirmationValueWithDefault, toBirthPlanValueWithDefault, toBreastExamValueWithDefault, toBreastfeedingValueWithDefault, toDangerSignsValueWithDefault, toFollowUpValueWithDefault, toGUExamValueWithDefault, toHealthEducationValueWithDefault, toLastMenstrualPeriodValueWithDefault, toMedicalHistoryValueWithDefault, toMedicationValueWithDefault, toObstetricHistoryStep2ValueWithDefault, toObstetricHistoryValueWithDefault, toObstetricalExamValueWithDefault, toPregnancyTestValueWithDefault, toPrenatalMentalHealthValueWithDefault, toPrenatalNutritionValueWithDefault, toSocialHistoryValueWithDefault, toSpecialityCareValueWithDefault, toSymptomReviewValueWithDefault, toUltrasoundValueWithDefault, updateSymptomReviewFormWithSymptoms, updateVaccinationFormByVaccineType)
+import Pages.Prenatal.Activity.Utils exposing (birthPlanFormWithDefault, breastExamFormWithDefault, dangerSignsFormWithDefault, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, guExamFormWithDefault, medicalHistoryFormWithDefault, mentalHealthFormWithDefault, obstetricHistoryStep2FormWithDefault, obstetricalExamFormWithDefault, prenatalNutritionFormWithDefault, symptomReviewFormWithDefault, toAppointmentConfirmationValueWithDefault, toBirthPlanValueWithDefault, toBreastExamValueWithDefault, toBreastfeedingValueWithDefault, toDangerSignsValueWithDefault, toFollowUpValueWithDefault, toGUExamValueWithDefault, toHealthEducationValueWithDefault, toLastMenstrualPeriodValueWithDefault, toMedicalHistoryValueWithDefault, toMedicationValueWithDefault, toObstetricHistoryStep2ValueWithDefault, toObstetricHistoryValueWithDefault, toObstetricalExamValueWithDefault, toPregnancyTestValueWithDefault, toPrenatalMentalHealthValueWithDefault, toPrenatalNutritionValueWithDefault, toSocialHistoryValueWithDefault, toSpecialityCareValueWithDefault, toSymptomReviewValueWithDefault, toUltrasoundValueWithDefault, updateSymptomReviewFormWithSymptoms, updateVaccinationFormByVaccineType)
 import Pages.Prenatal.Utils exposing (medicationDistributionFormWithDefaultInitialPhase, referralFormWithDefault, toMalariaPreventionValueWithDefault, toMedicationDistributionValueWithDefaultInitialPhase, toPrenatalReferralValueWithDefault)
 import Pages.Utils exposing (insertIntoSet, nonAdministrationReasonToSign, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue, tasksBarId)
 import RemoteData exposing (RemoteData(..))
@@ -1087,6 +1087,67 @@ update currentDate site id db msg model =
             , Cmd.none
             , []
             )
+
+        PreSaveNutritionAssessment personId saved maybeHeight isAdequateGWG nextTask ->
+            let
+                form =
+                    getMeasurementValueFunc saved
+                        |> prenatalNutritionFormWithDefault model.examinationData.nutritionAssessmentForm
+
+                outOfRange =
+                    List.concat
+                        [ -- A height measured at an earlier encounter is carried
+                          -- over and its input is not drawn, so there would be
+                          -- nothing on screen to enter again.
+                          if maybeHeight /= Nothing then
+                            []
+
+                          else
+                            Measurement.Utils.outOfRange site MeasurementHeight form.height
+                        , Measurement.Utils.outOfRange site MeasurementWeight form.weight
+                        , Measurement.Utils.outOfRange site MeasurementMuac form.muac
+                        ]
+
+                extraMsgs =
+                    if List.isEmpty outOfRange then
+                        [ SaveNutritionAssessment personId saved maybeHeight isAdequateGWG nextTask ]
+
+                    else
+                        [ SetWarningPopupState <| Just <| WarningPopupMeasurementOutOfRange outOfRange ]
+            in
+            ( model
+            , Cmd.none
+            , []
+            )
+                |> sequenceExtra (update currentDate site id db) extraMsgs
+
+        PreSaveObstetricalExam personId saved nextTask ->
+            let
+                form =
+                    getMeasurementValueFunc saved
+                        |> obstetricalExamFormWithDefault model.examinationData.obstetricalExamForm
+
+                outOfRange =
+                    -- Asked for only when the uterus can be felt; the input is
+                    -- not drawn otherwise.
+                    if form.fundalPalpable == Just True then
+                        Measurement.Utils.outOfRange site MeasurementFundalHeight form.fundalHeight
+
+                    else
+                        []
+
+                extraMsgs =
+                    if List.isEmpty outOfRange then
+                        [ SaveObstetricalExam personId saved nextTask ]
+
+                    else
+                        [ SetWarningPopupState <| Just <| WarningPopupMeasurementOutOfRange outOfRange ]
+            in
+            ( model
+            , Cmd.none
+            , []
+            )
+                |> sequenceExtra (update currentDate site id db) extraMsgs
 
         SaveNutritionAssessment personId saved maybeHeight isAdequateGWG nextTask ->
             let

--- a/client/src/elm/Pages/Prenatal/Activity/View.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/View.elm
@@ -162,7 +162,18 @@ viewHeaderAndContent language currentDate zscores site features id isChw activit
         [ viewHeader language id activity assembled
         , viewContent language currentDate zscores site features isChw activity model assembled
         , viewModal <|
-            warningPopup language assembled.encounter.diagnoses SetWarningPopupState model.warningPopupState
+            case model.warningPopupState of
+                -- Answered here, where the site is known: the warning names the
+                -- unit a measurement is recorded in, and that differs by site.
+                Just (WarningPopupMeasurementOutOfRange measurements) ->
+                    Just <|
+                        Measurement.View.measurementOutOfRangePopup language
+                            site
+                            measurements
+                            (SetWarningPopupState Nothing)
+
+                _ ->
+                    warningPopup language assembled.encounter.diagnoses SetWarningPopupState model.warningPopupState
         ]
 
 
@@ -308,6 +319,10 @@ warningPopup language encounterDiagnoses setStateMsg state =
                                 , emptyNode
                                 , treatmentReviewAtion
                                 )
+
+                        -- Answered by the page, which knows the site.
+                        WarningPopupMeasurementOutOfRange _ ->
+                            Nothing
             in
             Maybe.map (customWarningPopup language) data
         )
@@ -1046,13 +1061,13 @@ viewExaminationContent language currentDate zscores site features assembled data
                                     SaveVitals personId measurements.vitals nextTask
 
                                 NutritionAssessment ->
-                                    SaveNutritionAssessment personId measurements.nutrition previouslyMeasuredHeight isAdequateGWG nextTask
+                                    PreSaveNutritionAssessment personId measurements.nutrition previouslyMeasuredHeight isAdequateGWG nextTask
 
                                 CorePhysicalExam ->
                                     SaveCorePhysicalExam personId measurements.corePhysicalExam nextTask
 
                                 ObstetricalExam ->
-                                    SaveObstetricalExam personId measurements.obstetricalExam nextTask
+                                    PreSaveObstetricalExam personId measurements.obstetricalExam nextTask
 
                                 BreastExam ->
                                     SaveBreastExam personId measurements.breastExam nextTask

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -12074,6 +12074,13 @@ translationSet trans =
                     , somali = Nothing
                     }
 
+                Measurement.Model.MeasurementFundalHeight ->
+                    { english = "Fundal height is recorded in centimetres."
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
                 Measurement.Model.MeasurementHeight ->
                     { english = "Height is recorded in centimetres."
                     , kinyarwanda = Nothing


### PR DESCRIPTION
Fixes #2003

Based on #2015 — **merge that first**; the base moves down the stack as each one lands.

Part of #2006. This is the last of the encounter pages; #2004 and #2005 (the Child Scorecard) remain.

## What a nurse gets

**Nothing was checked here at all.** A height in millimetres, a weight with the decimal in the
wrong place, a MUAC in the unit the site does not ask for, a fundal height that could not be one —
each saved without a word, and went on into the assessment. Each is named on a warning now, and
nothing is saved until it is entered again.

Fundal height gets a range of its own, **1 to 60 cm**.

## The three traps, and how each is held down

**1. Closing the warning must not save.** This page's three existing warnings are
acknowledge-and-save; this one is the opposite — the measurement is still there to be corrected.
The popup's action is `SetWarningPopupState Nothing`.

**2. A carried-over height cannot be gated.** When a height was measured at an earlier encounter
the input is not drawn and `SaveNutritionAssessment` overwrites the form with it, so refusing it
would be an inescapable dead end. Excluded, and *pinned*: forcing that branch on fails the test
that covers it.

**3. MUAC is stored in centimetres here** — the opposite of the group session forms in #2014 — so
it uses the converting question. A Burundi case pins that direction.

Fundal height is asked about only when the uterus can be felt, for the same reason as the height:
otherwise there is nothing on screen to correct. Also pinned.

## The cleanup this issue exists to make possible

`outsideConstraints` and `muacOutsideConstraints` — the pair that answered "outside the range, or
not entered at all" — have no callers left once this lands, so they are **deleted**. That is what
stops the next form refusing a measurement with a button that will not answer and says nothing.

## Tests

Ten new on `update`: each of the four measurements, all three named together, both exclusions, the
Burundi MUAC direction, and the within-range paths. Twelve go with the deleted predicates.

**e2e** in `prenatal-encounter-nurse.spec.ts`: a MUAC of `125` refused with the warning naming it,
the form still up, then `25` recorded.

548 modules compile, `elm-format --validate` clean, **2929 tests pass**, elm-review clean in a
fresh clone under CI's checkout, prenatal e2e passes (3 tests, 5.6m).

**Discrimination:** removing either exclusion fails exactly the test that covers it.

One note on the e2e, since it failed first time and the failure was mine: this page renders its
Save inline with `classList [ ( "ui fluid primary button", True ), ( "disabled", … ) ]`, so an
enabled button carries no `active` class at all. The assertion now checks for the absence of
`disabled`, as the Acute Illness and group session checks already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)