### PR TITLE
Child scoreboard: make sure a measurement marked as not taken is not kept

### DIFF
--- a/client/e2e/child-scoreboard-encounter-chw.spec.ts
+++ b/client/e2e/child-scoreboard-encounter-chw.spec.ts
@@ -6,6 +6,8 @@ import { syncAndWait } from './helpers/common';
 import {
   createChildAndStartEncounter,
   completeNCDA,
+  queryNCDAWeight,
+  reopenNCDAAndSayWeightNotTaken,
   completeVaccinationHistory,
   endChildScoreboardEncounter,
   queryChildScoreboardNodes,
@@ -51,7 +53,12 @@ test.describe('CHW: Child Scoreboard Encounter — First NCDA + Vaccination Hist
     //    ChildBehindOnVaccination answered "No" to trigger VaccinationHistory.
     await completeNCDA(page);
 
-    // 3. Complete VaccinationHistory activity (answer "No" to prior doses for each vaccine).
+    // 3. Reopen the scorecard and say the weight could not be taken. The form
+    //    is saved only at the end of its steps, so this checks the weight saved
+    //    a moment ago does not come back and get written again (#2004).
+    await reopenNCDAAndSayWeightNotTaken(page);
+
+    // 4. Complete VaccinationHistory activity (answer "No" to prior doses for each vaccine).
     await completeVaccinationHistory(page);
 
     // 4. End encounter (no diarrhea popup since we answered No).
@@ -77,6 +84,10 @@ test.describe('CHW: Child Scoreboard Encounter — First NCDA + Vaccination Hist
     const nodes = queryChildScoreboardNodes(fullName, expectedTypes);
 
     expect(nodes['child_scoreboard_ncda'], 'child_scoreboard_ncda should exist').toBe(true);
+
+    // The weight was saved, then said not to have been taken: it should be gone
+    // rather than written again from what the form was holding.
+    expect(queryNCDAWeight(fullName), 'the weight should not be kept').toBeNull();
     expect(nodes['child_scoreboard_bcg_iz'], 'child_scoreboard_bcg_iz should exist').toBe(true);
     expect(nodes['child_scoreboard_opv_iz'], 'child_scoreboard_opv_iz should exist').toBe(true);
     expect(nodes['child_scoreboard_dtp_iz'], 'child_scoreboard_dtp_iz should exist').toBe(true);

--- a/client/e2e/child-scoreboard-encounter-chw.spec.ts
+++ b/client/e2e/child-scoreboard-encounter-chw.spec.ts
@@ -61,13 +61,13 @@ test.describe('CHW: Child Scoreboard Encounter — First NCDA + Vaccination Hist
     // 4. Complete VaccinationHistory activity (answer "No" to prior doses for each vaccine).
     await completeVaccinationHistory(page);
 
-    // 4. End encounter (no diarrhea popup since we answered No).
+    // 5. End encounter (no diarrhea popup since we answered No).
     await endChildScoreboardEncounter(page);
 
-    // 5. Sync to backend.
+    // 6. Sync to backend.
     await syncAndWait(page);
 
-    // 6. Verify backend nodes.
+    // 7. Verify backend nodes.
     // For a 10-month-old male on Rwanda site with no vaccination history,
     // all 7 common vaccines are overdue (BCG, OPV, DTP, PCV13, Rotarix, IPV, MR).
     // DTPStandalone is Burundi-only, so absent on Rwanda.

--- a/client/e2e/helpers/child-scoreboard.ts
+++ b/client/e2e/helpers/child-scoreboard.ts
@@ -1,5 +1,7 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
+import { execSync } from 'child_process';
 import { click } from './auth';
+import { drushEnv } from './device';
 import {
   WAIT,
   expectMeasurementsOutOfRangeRefused,
@@ -378,6 +380,54 @@ export async function completeNCDA(page: Page) {
  *
  * Creates: child_scoreboard_*_iz nodes for each vaccine tab completed.
  */
+/**
+ * Reopens the saved Child Scorecard, says the weight could not be taken, and
+ * saves again.
+ *
+ * The form is filled over several steps and saved only at the end, so what it
+ * holds between them is what gets saved. Ticking the box empties the input and
+ * hides it; this checks the weight saved a moment ago does not come back in its
+ * place and get written again.
+ */
+export async function reopenNCDAAndSayWeightNotTaken(page: Page) {
+  await page.locator('div.page-encounter.child-scoreboard').waitFor({ timeout: 10000 });
+  await page.waitForTimeout(WAIT.elmRerender);
+
+  await click(page.locator('#completed-tab'), page);
+  await page.waitForTimeout(WAIT.elmRerender);
+
+  // Child Scorecard and Birth History share an icon, so pick it by name.
+  await click(
+    page.locator('.card', { hasText: 'CHILD SCORECARD' }).locator('.icon-task-history'),
+    page,
+  );
+  await page.locator('div.page-activity.child-scoreboard').waitFor({ timeout: 10000 });
+  await page.waitForTimeout(WAIT.elmRerender);
+
+  await clickNCDAStepTab(page, 'nutrition-assessment');
+  await page.waitForTimeout(WAIT.elmRerender);
+
+  // The weight saved a moment ago is on the form.
+  const weightInput = page.locator('.form-input.measurement.weight input[type="number"]');
+  await expect(weightInput, 'the saved weight should be on the form').toHaveValue('8.5');
+
+  const notTaken = page.locator('div.ui.checkbox', { hasText: 'not taken' }).first();
+  await click(notTaken, page);
+  await page.waitForTimeout(WAIT.formInteraction);
+
+  // The input goes with it.
+  await expect(weightInput, 'the input should go when the box is ticked').toHaveCount(0);
+
+  // Save through the steps that follow, which is where the value is written.
+  await clickSave(page);
+  await page.waitForTimeout(WAIT.sectionTransition);
+  await clickSave(page);
+  await page.waitForTimeout(WAIT.sectionTransition);
+  await clickSave(page);
+  await page.locator('div.page-encounter.child-scoreboard').waitFor({ timeout: 15000 });
+  await page.waitForTimeout(WAIT.elmRerender);
+}
+
 export async function completeVaccinationHistory(page: Page) {
   await openActivity(page, 'child-scoreboard', 'immunisation');
 
@@ -453,6 +503,51 @@ export async function endChildScoreboardEncounter(page: Page) {
  * Query the backend for Child Scoreboard measurement nodes associated with a person.
  * Returns an object mapping node type → boolean (exists).
  */
+/**
+ * The weight held on the saved Child Scorecard, or null when it holds none.
+ *
+ * Read as a field rather than as "does the node exist", because the node is
+ * always there - the question is whether the measurement was written into it.
+ */
+export function queryNCDAWeight(personName: string): number | null {
+  const personNameB64 = Buffer.from(personName, 'utf8').toString('base64');
+  const php = `
+    \\$person_name = base64_decode('${personNameB64}');
+    \\$query = new EntityFieldQuery();
+    \\$result = \\$query->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'person')
+      ->propertyCondition('title', \\$person_name)
+      ->execute();
+    if (empty(\\$result['node'])) {
+      echo json_encode(['error' => 'Person not found']);
+      return;
+    }
+    \\$person_nid = key(\\$result['node']);
+
+    \\$q = new EntityFieldQuery();
+    \\$r = \\$q->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'child_scoreboard_ncda')
+      ->fieldCondition('field_person', 'target_id', \\$person_nid)
+      ->execute();
+    if (empty(\\$r['node'])) {
+      echo json_encode(['error' => 'NCDA not found']);
+      return;
+    }
+    \\$node = node_load(key(\\$r['node']));
+    \\$wrapper = entity_metadata_wrapper('node', \\$node);
+    \\$weight = \\$wrapper->field_weight->value();
+    echo json_encode(['weight' => \\$weight]);
+  `;
+
+  const { drushCmd, cwd } = drushEnv();
+  const output = execSync(`${drushCmd} eval "${php}"`, { cwd, timeout: 30000, encoding: 'utf-8' });
+  const parsed = JSON.parse(output.trim());
+  if (parsed.error) {
+    throw new Error(`queryNCDAWeight: ${parsed.error}`);
+  }
+  return parsed.weight === null || parsed.weight === undefined ? null : Number(parsed.weight);
+}
+
 export function queryChildScoreboardNodes(
   personName: string,
   expectedTypes?: string[],

--- a/client/e2e/helpers/child-scoreboard.ts
+++ b/client/e2e/helpers/child-scoreboard.ts
@@ -438,6 +438,11 @@ export async function reopenNCDAAndSayWeightNotTaken(page: Page) {
 
   await encounterPage.waitFor({ timeout: 15000 });
   await page.waitForTimeout(WAIT.elmRerender);
+
+  // Back to the things still to do, or the activity that follows cannot be
+  // reached: this left the page on the completed ones.
+  await click(page.locator('#pending-tab'), page);
+  await page.waitForTimeout(WAIT.elmRerender);
 }
 
 export async function completeVaccinationHistory(page: Page) {

--- a/client/e2e/helpers/child-scoreboard.ts
+++ b/client/e2e/helpers/child-scoreboard.ts
@@ -411,20 +411,32 @@ export async function reopenNCDAAndSayWeightNotTaken(page: Page) {
   const weightInput = page.locator('.form-input.measurement.weight input[type="number"]');
   await expect(weightInput, 'the saved weight should be on the form').toHaveValue('8.5');
 
-  const notTaken = page.locator('div.ui.checkbox', { hasText: 'not taken' }).first();
-  await click(notTaken, page);
+  // Three measurements on this step carry the same label, so the box is picked
+  // by the measurement it belongs to.
+  await click(page.locator('div.ui.checkbox.skip-step.weight'), page);
   await page.waitForTimeout(WAIT.formInteraction);
 
   // The input goes with it.
   await expect(weightInput, 'the input should go when the box is ticked').toHaveCount(0);
 
-  // Save through the steps that follow, which is where the value is written.
-  await clickSave(page);
-  await page.waitForTimeout(WAIT.sectionTransition);
-  await clickSave(page);
-  await page.waitForTimeout(WAIT.sectionTransition);
-  await clickSave(page);
-  await page.locator('div.page-encounter.child-scoreboard').waitFor({ timeout: 15000 });
+  // Save through whatever steps remain. A form that is already complete goes
+  // back to the encounter sooner than one being filled for the first time, so
+  // press Save until it does rather than a fixed number of times.
+  const encounterPage = page.locator('div.page-encounter.child-scoreboard');
+  const saveBtn = page.locator('button.ui.fluid.primary.button', { hasText: 'Save' });
+
+  for (let step = 0; step < 6; step += 1) {
+    if (await encounterPage.isVisible({ timeout: 1000 }).catch(() => false)) {
+      break;
+    }
+    if (!(await saveBtn.isVisible({ timeout: 2000 }).catch(() => false))) {
+      break;
+    }
+    await click(saveBtn, page);
+    await page.waitForTimeout(WAIT.sectionTransition);
+  }
+
+  await encounterPage.waitFor({ timeout: 15000 });
   await page.waitForTimeout(WAIT.elmRerender);
 }
 

--- a/client/e2e/helpers/child-scoreboard.ts
+++ b/client/e2e/helpers/child-scoreboard.ts
@@ -366,20 +366,6 @@ export async function completeNCDA(page: Page) {
   await page.waitForTimeout(WAIT.elmRerender);
 }
 
-// ---------------------------------------------------------------------------
-// Vaccination History activity
-// ---------------------------------------------------------------------------
-
-/**
- * Complete the Vaccination History activity by iterating all visible
- * vaccine tabs and answering "No" to "Did the child receive any [vaccine]
- * immunizations prior to today that are not recorded above".
- *
- * In Child Scoreboard, suggestDoseToday is false, so answering "No"
- * to the previous-doses question completes each vaccine tab.
- *
- * Creates: child_scoreboard_*_iz nodes for each vaccine tab completed.
- */
 /**
  * Reopens the saved Child Scorecard, says the weight could not be taken, and
  * saves again.
@@ -445,6 +431,20 @@ export async function reopenNCDAAndSayWeightNotTaken(page: Page) {
   await page.waitForTimeout(WAIT.elmRerender);
 }
 
+// ---------------------------------------------------------------------------
+// Vaccination History activity
+// ---------------------------------------------------------------------------
+
+/**
+ * Complete the Vaccination History activity by iterating all visible
+ * vaccine tabs and answering "No" to "Did the child receive any [vaccine]
+ * immunizations prior to today that are not recorded above".
+ *
+ * In Child Scoreboard, suggestDoseToday is false, so answering "No"
+ * to the previous-doses question completes each vaccine tab.
+ *
+ * Creates: child_scoreboard_*_iz nodes for each vaccine tab completed.
+ */
 export async function completeVaccinationHistory(page: Page) {
   await openActivity(page, 'child-scoreboard', 'immunisation');
 
@@ -520,6 +520,23 @@ export async function endChildScoreboardEncounter(page: Page) {
  * Query the backend for Child Scoreboard measurement nodes associated with a person.
  * Returns an object mapping node type → boolean (exists).
  */
+export function queryChildScoreboardNodes(
+  personName: string,
+  expectedTypes?: string[],
+): Record<string, boolean> {
+  return queryMeasurementNodes(personName, [
+    'child_scoreboard_ncda',
+    'child_scoreboard_bcg_iz',
+    'child_scoreboard_dtp_iz',
+    'child_scoreboard_dtp_sa_iz',
+    'child_scoreboard_ipv_iz',
+    'child_scoreboard_mr_iz',
+    'child_scoreboard_opv_iz',
+    'child_scoreboard_pcv13_iz',
+    'child_scoreboard_rotarix_iz',
+  ], expectedTypes);
+}
+
 /**
  * The weight held on the saved Child Scorecard, or null when it holds none.
  *
@@ -545,6 +562,8 @@ export function queryNCDAWeight(personName: string): number | null {
     \\$r = \\$q->entityCondition('entity_type', 'node')
       ->propertyCondition('type', 'child_scoreboard_ncda')
       ->fieldCondition('field_person', 'target_id', \\$person_nid)
+      ->propertyOrderBy('nid', 'DESC')
+      ->range(0, 1)
       ->execute();
     if (empty(\\$r['node'])) {
       echo json_encode(['error' => 'NCDA not found']);
@@ -563,21 +582,4 @@ export function queryNCDAWeight(personName: string): number | null {
     throw new Error(`queryNCDAWeight: ${parsed.error}`);
   }
   return parsed.weight === null || parsed.weight === undefined ? null : Number(parsed.weight);
-}
-
-export function queryChildScoreboardNodes(
-  personName: string,
-  expectedTypes?: string[],
-): Record<string, boolean> {
-  return queryMeasurementNodes(personName, [
-    'child_scoreboard_ncda',
-    'child_scoreboard_bcg_iz',
-    'child_scoreboard_dtp_iz',
-    'child_scoreboard_dtp_sa_iz',
-    'child_scoreboard_ipv_iz',
-    'child_scoreboard_mr_iz',
-    'child_scoreboard_opv_iz',
-    'child_scoreboard_pcv13_iz',
-    'child_scoreboard_rotarix_iz',
-  ], expectedTypes);
 }

--- a/client/src/elm/Measurement/Test.elm
+++ b/client/src/elm/Measurement/Test.elm
@@ -9,15 +9,17 @@ import Backend.Measurement.Model
         , LiverFunctionTestValue
         , MuacInCm(..)
         , SkippedForm(..)
+        , StuntingLevel(..)
         , TestExecutionNote(..)
         , VaccineDose(..)
         , WeightInGrm(..)
+        , WeightInKg(..)
         , WellChildVaccineType(..)
         )
 import Date exposing (Unit(..))
 import EverySet
 import Expect
-import Measurement.Model exposing (AnthropometricMeasurement(..), MsgChild(..), NCDAStep(..), emptyCreatinineResultForm, emptyHeightForm, emptyLiverFunctionResultForm, emptyModelChild)
+import Measurement.Model exposing (AnthropometricMeasurement(..), MsgChild(..), NCDAStep(..), emptyCreatinineResultForm, emptyHeightForm, emptyLiverFunctionResultForm, emptyModelChild, emptyNCDAData)
 import Measurement.Update exposing (updateChild)
 import Measurement.Utils
     exposing
@@ -32,6 +34,7 @@ import Measurement.Utils
         , heightFormWithDefault
         , initialVaccinationDateByBirthDate
         , liverFunctionResultFormWithDefault
+        , ncdaFormWithDefault
         , outOfRangeAsEntered
         )
 import Measurement.View exposing (viewColorAlertIndication)
@@ -459,6 +462,7 @@ all =
         , getAllDosesForVaccineTest
         , initialVaccinationDateByBirthDateTest
         , updateChildSetMuacTest
+        , ncdaFormWithDefaultNotTakenTest
         , outOfRangeAsEnteredTest
         , updateChildOutOfRangePopupTest
         , birthWeightBlocksNCDAFormTest
@@ -566,4 +570,69 @@ updateChildOutOfRangePopupTest =
                 in
                 ( model.measurementOutOfRangePopupState, outMsg )
                     |> Expect.equal ( [], Nothing )
+        ]
+
+
+{-| The Child Scorecard is filled over several steps and saved only at the end,
+so what the form holds between them is what gets saved. Ticking "measurement
+not taken" empties the input and hides it; the measurement saved at an earlier
+encounter must not come back in its place, or it is live behind a box saying it
+was not taken, and saved again at the end.
+-}
+ncdaFormWithDefaultNotTakenTest : Test
+ncdaFormWithDefaultNotTakenTest =
+    let
+        saved =
+            { signs = EverySet.empty
+            , birthWeight = Nothing
+            , ancVisitsDates = EverySet.empty
+            , receivesVitaminA = Nothing
+            , stuntingLevel = Just LevelYellow
+            , weight = Just (WeightInKg 12)
+            , muac = Just (MuacInCm 14)
+            }
+
+        emptyForm =
+            emptyNCDAData.form
+
+        hydrate form =
+            ncdaFormWithDefault form (Just saved)
+    in
+    describe "ncdaFormWithDefault, on a measurement said not to have been taken"
+        [ test "the weight saved earlier does not come back" <|
+            \_ ->
+                hydrate { emptyForm | weightNotTaken = Just True }
+                    |> .weight
+                    |> Expect.equal Nothing
+        , test "the MUAC saved earlier does not come back" <|
+            \_ ->
+                hydrate { emptyForm | muacNotTaken = Just True }
+                    |> .muac
+                    |> Expect.equal Nothing
+        , test "the stunting level saved earlier does not come back" <|
+            \_ ->
+                hydrate { emptyForm | stuntingLevelNotTaken = Just True }
+                    |> .stuntingLevel
+                    |> Expect.equal Nothing
+        , test "saying one was not taken leaves the others alone" <|
+            \_ ->
+                let
+                    form =
+                        hydrate { emptyForm | weightNotTaken = Just True }
+                in
+                ( form.weight, form.muac, form.stuntingLevel )
+                    |> Expect.equal ( Nothing, Just (MuacInCm 14), Just LevelYellow )
+        , test "a form nobody has touched still inherits what was saved" <|
+            \_ ->
+                let
+                    form =
+                        hydrate emptyForm
+                in
+                ( form.weight, form.muac, form.stuntingLevel )
+                    |> Expect.equal ( Just (WeightInKg 12), Just (MuacInCm 14), Just LevelYellow )
+        , test "what the nurse has typed is kept over what was saved" <|
+            \_ ->
+                hydrate { emptyForm | weight = Just (WeightInKg 13) }
+                    |> .weight
+                    |> Expect.equal (Just (WeightInKg 13))
         ]

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -8551,15 +8551,32 @@ ncdaFormWithDefault form saved =
                 , birthWeight = or form.birthWeight value.birthWeight
 
                 -- Nutrition measurements.
-                , stuntingLevel = or form.stuntingLevel value.stuntingLevel
+                , stuntingLevel = measurementUnlessNotTaken form.stuntingLevelNotTaken form.stuntingLevel value.stuntingLevel
                 , stuntingLevelNotTaken = or form.stuntingLevelNotTaken (isNothing value.stuntingLevel |> Just)
-                , weight = or form.weight value.weight
+                , weight = measurementUnlessNotTaken form.weightNotTaken form.weight value.weight
                 , weightNotTaken = or form.weightNotTaken (isNothing value.weight |> Just)
-                , muac = or form.muac value.muac
+                , muac = measurementUnlessNotTaken form.muacNotTaken form.muac value.muac
                 , muacNotTaken = or form.muacNotTaken (isNothing value.muac |> Just)
                 , showsEdemaSigns = or form.showsEdemaSigns (EverySet.member ShowsEdemaSigns value.signs |> Just)
                 }
             )
+
+
+{-| What the form holds for a measurement once the one saved earlier is merged
+into it, and nothing when the nurse has said it was not taken.
+
+Ticking that empties the input and hides it, so the measurement saved earlier
+must not come back in its place: it would be live behind a box saying it was not
+taken, and saved again at the end of the flow.
+
+-}
+measurementUnlessNotTaken : Maybe Bool -> Maybe a -> Maybe a -> Maybe a
+measurementUnlessNotTaken notTaken onForm saved =
+    if notTaken == Just True then
+        Nothing
+
+    else
+        or onForm saved
 
 
 toNCDAValueWithDefault : Maybe NCDAValue -> NCDAForm -> Maybe NCDAValue

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -3274,7 +3274,7 @@ ncdaFormInputsAndTasks language currentDate site personId person config form cur
 
                         notTakenCheckbox =
                             [ div
-                                [ class "ui checkbox activity skip-step"
+                                [ class "ui checkbox activity skip-step stunting-level"
                                 , onClick <| config.setBoolInputMsg measurementNotTakenUpdateFunc measurementNotTakenValueWhenChecked
                                 ]
                                 [ input
@@ -3328,7 +3328,7 @@ ncdaFormInputsAndTasks language currentDate site personId person config form cur
 
                         notTakenCheckbox =
                             [ div
-                                [ class "ui checkbox activity skip-step"
+                                [ class "ui checkbox activity skip-step weight"
                                 , onClick <| config.setBoolInputMsg measurementNotTakenUpdateFunc measurementNotTakenValueWhenChecked
                                 ]
                                 [ input
@@ -3399,7 +3399,7 @@ ncdaFormInputsAndTasks language currentDate site personId person config form cur
 
                                         notTakenCheckbox =
                                             [ div
-                                                [ class "ui checkbox activity skip-step"
+                                                [ class "ui checkbox activity skip-step muac"
                                                 , onClick <| config.setBoolInputMsg measurementNotTakenUpdateFunc measurementNotTakenValueWhenChecked
                                                 ]
                                                 [ input


### PR DESCRIPTION
Fixes #2004

Based on `i1998-birth-length-range`, which now carries the whole range series (#2007 and the five
merged into it). Part of #2006. #2005 follows this one, and needs it: a stale hidden value would
otherwise block that form with nothing on screen to correct.

## The bug

Ticking "measurement not taken" sets `{ weightNotTaken = Just True, weight = Nothing }`, but
hydration ignored it:

```elm
weight = or form.weight value.weight
```

so the measurement saved at an earlier encounter came straight back. It was then **live behind a
box saying it had not been taken** — and because the Child Scorecard is filled over several steps
and saved only at the end, it was written again.

This is the one issue in the series that fixes a **data** bug rather than feedback, and four pages
share this hydration: Nutrition, Well Child, Child Scorecard and the group sessions.

## The fix

One named question, asked by each of the measurements:

```elm
measurementUnlessNotTaken : Maybe Bool -> Maybe a -> Maybe a -> Maybe a
```

No dirty flags, as #2004 asks: `weightNotTaken` and `muacNotTaken` already record the intent, they
persist on the same form across every step, and they are present at save time. Because
`toNCDAValueWithDefault = ncdaFormWithDefault >> toNCDAValue`, the one change fixes both what is
rendered on any step and what is saved at the end.

## Beyond what the issue asks

The issue names weight and MUAC. **Stunting level has the identical bug** — same checkbox clearing
the value (`stuntingLevel = Nothing`), same `or form.stuntingLevel value.stuntingLevel` merge. It
is fixed with them; leaving one of three identical cases would have been arbitrary.

## Tests

Six on hydration directly: each of the three does not come back, saying one was not taken leaves
the others alone, an untouched form still inherits what was saved, and what the nurse typed still
wins over what was saved.

**e2e** in `child-scoreboard-encounter-chw.spec.ts`: complete the scorecard with a weight, reopen
it from the Completed tab, check the saved weight is on the form, tick "not taken", check the input
goes, save through the remaining steps, and read the field back from the backend — it must be
**null**. That needed a new query: the existing one only reports whether a node exists, and here
the node always exists; the question is whether the measurement was written into it.

**Discrimination, both directions:**

- putting the old merge back fails four tests
- fixing **only** weight and MUAC, exactly as the issue names, fails the stunting-level test — which
  is what makes the third case evidence rather than my speculation

548 modules compile, `elm-format --validate` clean, **2935 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)