### PR TITLE
Measurements: make sure the Apgar scores are entered as scores out of ten

### DIFF
--- a/client/e2e/helpers/common.ts
+++ b/client/e2e/helpers/common.ts
@@ -400,7 +400,15 @@ export function queryPrenatalLmp(personName: string): string | null {
 export async function expectMeasurementsOutOfRangeRefused(
   page: Page,
   stillOnFormSelector: string,
-  measurements: Array<{ inputId: string; popupClass: string; bad: string; good: string }>,
+  measurements: Array<{
+    inputId: string;
+    popupClass: string;
+    bad: string;
+    good: string;
+    /** Words from the warning's line for this one. Give it for every
+     *  measurement to also check the order they are named in. */
+    saysInWarning?: string;
+  }>,
   notNamed: string[] = [],
 ): Promise<void> {
   for (const m of measurements) {
@@ -430,6 +438,17 @@ export async function expectMeasurementsOutOfRangeRefused(
   // And nothing that is in range is named.
   for (const cls of notNamed) {
     await expect(popup).not.toHaveClass(named(cls));
+  }
+
+  // They are named in the order the form asks for them. Otherwise the nurse
+  // reads them in a different order to the fields in front of her.
+  if (measurements.length > 1 && measurements.every(m => m.saysInWarning)) {
+    const said = await popup.locator('.popup-action p').allTextContents();
+    expect(said.length, 'the warning says one line per measurement named').toBe(measurements.length);
+    measurements.forEach((m, i) => {
+      expect(said[i], `line ${i + 1} of the warning is about ${m.inputId}`)
+        .toContain(m.saysInWarning as string);
+    });
   }
 
   // The form is still up, so nothing out of range was saved.

--- a/client/e2e/helpers/well-child.ts
+++ b/client/e2e/helpers/well-child.ts
@@ -598,12 +598,42 @@ export async function completePregnancySummary(page: Page) {
   await click(boolInputs.nth(1).locator('label', { hasText: 'Yes' }), page);
   await page.waitForTimeout(WAIT.formInteraction);
 
-  // Both measurements are entered in the wrong unit at once -- a weight in
-  // kilograms and a length in metres -- so the warning has to name both before
-  // either is entered as it should be.
+  // Everything the form asks for as a number is wrong at once -- Apgar scores
+  // that cannot be scores out of ten, a weight in kilograms and a length in
+  // metres -- so the warning has to name all four, in the order the form asks
+  // for them, before any of them is entered as it should be.
+  //
+  // 36 is the value recorded most often that cannot be an Apgar score, and
+  // 30000 the largest.
   await expectMeasurementsOutOfRangeRefused(page, '.ui.form.pregnancy-summary', [
-    { inputId: 'birth-weight', popupClass: 'birth-weight-out-of-range', bad: '3', good: '3000' },
-    { inputId: 'birth-length', popupClass: 'birth-length-out-of-range', bad: '0.5', good: '50' },
+    {
+      inputId: 'apgar.one-min',
+      popupClass: 'apgar-one-minute-out-of-range',
+      bad: '36',
+      good: '8',
+      saysInWarning: 'Apgar score at one minute',
+    },
+    {
+      inputId: 'apgar.five-min',
+      popupClass: 'apgar-five-minutes-out-of-range',
+      bad: '30000',
+      good: '9',
+      saysInWarning: 'Apgar score at five minutes',
+    },
+    {
+      inputId: 'birth-weight',
+      popupClass: 'birth-weight-out-of-range',
+      bad: '3',
+      good: '3000',
+      saysInWarning: 'Birth weight is recorded in grams',
+    },
+    {
+      inputId: 'birth-length',
+      popupClass: 'birth-length-out-of-range',
+      bad: '0.5',
+      good: '50',
+      saysInWarning: 'Birth length is recorded in centimetres',
+    },
   ]);
 
   await saveActivity(page, 'well-child');

--- a/client/src/elm/Measurement/Model.elm
+++ b/client/src/elm/Measurement/Model.elm
@@ -1,4 +1,4 @@
-module Measurement.Model exposing (AhezaForm, AnthropometricMeasurement(..), BloodGpRsResultForm, BloodGpRsTestForm, ContentAndTasksForPerformedLaboratoryTestConfig, ContentAndTasksForPerformedLaboratoryUniversalTestConfig, ContentAndTasksLaboratoryResultConfig, ContentAndTasksLaboratoryTestInitialConfig, ContentAndTasksLaboratoryUniversalTestInitialConfig, ContributingFactorsForm, CorePhysicalExamForm, CorePhysicalExamFormConfig, CreatinineResultForm, DropZoneFile, FamilyPlanningForm, FbfForm, FloatInputConstraints, FollowUpForm, GroupOfFoods(..), HIVPCRResultForm, HIVPCRTestForm, HIVResultForm, HIVTestForm, HIVTestUniversalForm, HbA1cTestForm, HealthEducationForm, HeightForm, HemoglobinResultForm, HemoglobinTestForm, HepatitisBResultForm, HepatitisBTestForm, ImmunisationTask(..), InvokationModule(..), LaboratoryTask(..), LipidPanelResultForm, LiverFunctionResultForm, MalariaResultForm, MalariaTestForm, MedicationAdministrationForm, MedicationAdministrationFormConfig, ModelChild, ModelMother, MsgChild(..), MsgMother(..), MuacForm, NCDAContentConfig, NCDAData, NCDAForm, NCDAStep(..), NextStepsTask(..), NonRDTForm, NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, OngoingTreatmentReviewForm, OutMsgChild(..), OutMsgMother(..), OutsideCareForm, OutsideCareStep(..), ParticipantFormProgress, ParticipantFormUI, PartnerHIVResultForm, PartnerHIVTestForm, PhotoForm, PregnancyTestForm, RandomBloodSugarResultForm, RandomBloodSugarTestForm, RandomBloodSugarTestUniversalForm, SendToHCForm, SyphilisResultForm, SyphilisTestForm, UrineDipstickResultForm, UrineDipstickTestForm, UrineDipstickTestUniversalForm, VaccinationForm, VaccinationFormDynamicContentAndTasksConfig, VaccinationFormViewMode(..), VaccinationProgressDict, VaccinationStatus(..), VitalsForm, VitalsFormConfig, VitalsFormMode(..), WeightForm, completedParticipantFormProgress, emptyAhezaForm, emptyBloodGpRsResultForm, emptyBloodGpRsTestForm, emptyContributingFactorsForm, emptyCorePhysicalExamForm, emptyCreatinineResultForm, emptyFamilyPlanningForm, emptyFbfForm, emptyFollowUpForm, emptyHIVPCRResultForm, emptyHIVPCRTestForm, emptyHIVResultForm, emptyHIVTestForm, emptyHIVTestUniversalForm, emptyHbA1cTestForm, emptyHealthEducationForm, emptyHeightForm, emptyHemoglobinResultForm, emptyHemoglobinTestForm, emptyHepatitisBResultForm, emptyHepatitisBTestForm, emptyLipidPanelResultForm, emptyLiverFunctionResultForm, emptyMalariaResultForm, emptyMalariaTestForm, emptyMedicationAdministrationForm, emptyModelChild, emptyModelMother, emptyMuacForm, emptyNCDAData, emptyNonRDTForm, emptyNutritionCaringForm, emptyNutritionFeedingForm, emptyNutritionFollowUpForm, emptyNutritionFoodSecurityForm, emptyNutritionForm, emptyNutritionHygieneForm, emptyOngoingTreatmentReviewForm, emptyOutsideCareForm, emptyParticipantFormProgress, emptyPartnerHIVResultForm, emptyPartnerHIVTestForm, emptyPhotoForm, emptyPregnancyTestForm, emptyRandomBloodSugarResultForm, emptyRandomBloodSugarTestForm, emptyRandomBloodSugarTestUniversalForm, emptySendToHCForm, emptySyphilisResultForm, emptySyphilisTestForm, emptyUrineDipstickResultForm, emptyUrineDipstickTestForm, emptyUrineDipstickTestUniversalForm, emptyVaccinationForm, emptyVitalsForm, emptyWeightForm)
+module Measurement.Model exposing (AhezaForm, BloodGpRsResultForm, BloodGpRsTestForm, ContentAndTasksForPerformedLaboratoryTestConfig, ContentAndTasksForPerformedLaboratoryUniversalTestConfig, ContentAndTasksLaboratoryResultConfig, ContentAndTasksLaboratoryTestInitialConfig, ContentAndTasksLaboratoryUniversalTestInitialConfig, ContributingFactorsForm, CorePhysicalExamForm, CorePhysicalExamFormConfig, CreatinineResultForm, DropZoneFile, FamilyPlanningForm, FbfForm, FloatInputConstraints, FollowUpForm, GroupOfFoods(..), HIVPCRResultForm, HIVPCRTestForm, HIVResultForm, HIVTestForm, HIVTestUniversalForm, HbA1cTestForm, HealthEducationForm, HeightForm, HemoglobinResultForm, HemoglobinTestForm, HepatitisBResultForm, HepatitisBTestForm, ImmunisationTask(..), InvokationModule(..), LaboratoryTask(..), LipidPanelResultForm, LiverFunctionResultForm, MalariaResultForm, MalariaTestForm, MedicationAdministrationForm, MedicationAdministrationFormConfig, ModelChild, ModelMother, MsgChild(..), MsgMother(..), MuacForm, NCDAContentConfig, NCDAData, NCDAForm, NCDAStep(..), NextStepsTask(..), NonRDTForm, NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, OngoingTreatmentReviewForm, OutMsgChild(..), OutMsgMother(..), OutsideCareForm, OutsideCareStep(..), ParticipantFormProgress, ParticipantFormUI, PartnerHIVResultForm, PartnerHIVTestForm, PhotoForm, PregnancyTestForm, RandomBloodSugarResultForm, RandomBloodSugarTestForm, RandomBloodSugarTestUniversalForm, RangedMeasurement(..), SendToHCForm, SyphilisResultForm, SyphilisTestForm, UrineDipstickResultForm, UrineDipstickTestForm, UrineDipstickTestUniversalForm, VaccinationForm, VaccinationFormDynamicContentAndTasksConfig, VaccinationFormViewMode(..), VaccinationProgressDict, VaccinationStatus(..), VitalsForm, VitalsFormConfig, VitalsFormMode(..), WeightForm, completedParticipantFormProgress, emptyAhezaForm, emptyBloodGpRsResultForm, emptyBloodGpRsTestForm, emptyContributingFactorsForm, emptyCorePhysicalExamForm, emptyCreatinineResultForm, emptyFamilyPlanningForm, emptyFbfForm, emptyFollowUpForm, emptyHIVPCRResultForm, emptyHIVPCRTestForm, emptyHIVResultForm, emptyHIVTestForm, emptyHIVTestUniversalForm, emptyHbA1cTestForm, emptyHealthEducationForm, emptyHeightForm, emptyHemoglobinResultForm, emptyHemoglobinTestForm, emptyHepatitisBResultForm, emptyHepatitisBTestForm, emptyLipidPanelResultForm, emptyLiverFunctionResultForm, emptyMalariaResultForm, emptyMalariaTestForm, emptyMedicationAdministrationForm, emptyModelChild, emptyModelMother, emptyMuacForm, emptyNCDAData, emptyNonRDTForm, emptyNutritionCaringForm, emptyNutritionFeedingForm, emptyNutritionFollowUpForm, emptyNutritionFoodSecurityForm, emptyNutritionForm, emptyNutritionHygieneForm, emptyOngoingTreatmentReviewForm, emptyOutsideCareForm, emptyParticipantFormProgress, emptyPartnerHIVResultForm, emptyPartnerHIVTestForm, emptyPhotoForm, emptyPregnancyTestForm, emptyRandomBloodSugarResultForm, emptyRandomBloodSugarTestForm, emptyRandomBloodSugarTestUniversalForm, emptySendToHCForm, emptySyphilisResultForm, emptySyphilisTestForm, emptyUrineDipstickResultForm, emptyUrineDipstickTestForm, emptyUrineDipstickTestUniversalForm, emptyVaccinationForm, emptyVitalsForm, emptyWeightForm)
 
 {-| These modules manage the UI for the various measurements relating to a
 participant.
@@ -55,7 +55,7 @@ type alias ModelChild =
 
     -- The measurements this form asks for that were entered outside the range
     -- they can take, named on a warning until the nurse closes it.
-    , measurementOutOfRangePopupState : List AnthropometricMeasurement
+    , measurementOutOfRangePopupState : List RangedMeasurement
     }
 
 
@@ -231,11 +231,15 @@ type alias FloatInputConstraints =
     }
 
 
-{-| A measurement of the body that is entered as a number, and so has a range
-the number has to be within.
+{-| A measurement entered as a number, and so one with a range the number has to
+be within.
 
 Naming the measurement lets one warning say which of them is wrong, on the forms
 that ask for several behind a single button.
+
+Most are measurements of the body; the Apgar scores are not, but they are asked
+for as numbers with a range in the same way, and are refused by the same warning
+when what is entered cannot be one.
 
 The range is asked for along with the site, because MUAC is entered in
 millimetres at Burundi and in centimetres everywhere else. The site is passed
@@ -243,8 +247,10 @@ alongside rather than held here: this module is below the one the site is
 defined in.
 
 -}
-type AnthropometricMeasurement
-    = MeasurementBirthLength
+type RangedMeasurement
+    = MeasurementApgarFiveMinutes
+    | MeasurementApgarOneMinute
+    | MeasurementBirthLength
     | MeasurementBirthWeight
     | MeasurementFundalHeight
     | MeasurementHeight
@@ -267,7 +273,7 @@ type MsgChild
     | SendOutMsgChild OutMsgChild
     | SetDistributedAmountForChild String
     | SetDistributoinNoticeForChild DistributionNotice
-    | SetMeasurementOutOfRangePopupState (List AnthropometricMeasurement)
+    | SetMeasurementOutOfRangePopupState (List RangedMeasurement)
     | UpdateHeight String
     | UpdateMuac String
     | UpdateWeight String

--- a/client/src/elm/Measurement/Test.elm
+++ b/client/src/elm/Measurement/Test.elm
@@ -17,7 +17,7 @@ import Backend.Measurement.Model
 import Date exposing (Unit(..))
 import EverySet
 import Expect
-import Measurement.Model exposing (AnthropometricMeasurement(..), MsgChild(..), NCDAStep(..), emptyCreatinineResultForm, emptyHeightForm, emptyLiverFunctionResultForm, emptyModelChild)
+import Measurement.Model exposing (MsgChild(..), NCDAStep(..), RangedMeasurement(..), emptyCreatinineResultForm, emptyHeightForm, emptyLiverFunctionResultForm, emptyModelChild)
 import Measurement.Update exposing (updateChild)
 import Measurement.Utils
     exposing

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -393,8 +393,11 @@ outOfRangeAsEntered constraints measurement value =
         [ measurement ]
 
 
-{-| The range a measurement of the body has to be within, in the unit it is
-entered in.
+{-| The range a measurement has to be within, in the unit it is entered in.
+
+The Apgar scores have one too, though they are neither of the body nor carried
+in a unit: they are scores out of ten.
+
 -}
 measurementConstraints : Site -> RangedMeasurement -> FloatInputConstraints
 measurementConstraints site measurement =

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -1,4 +1,4 @@
-module Measurement.Utils exposing (OutsideCareConfig, ahezaFormWithDefault, ahezaMotherFormWithDefault, allNextStepsTasks, allVaccineTypes, anthropometricConstraints, anthropometricOutOfRange, behindOnVaccinationsByHistory, birthWeightBlocksNCDAForm, birthWeightOutsideConstraints, bloodGpRsResultFormAndTasks, bloodGpRsResultFormWithDefault, bloodGpRsTestFormWithDefault, bloodSmearResultNotSet, bloodSmearResultSet, contributingFactorsFormWithDefault, corePhysicalExamFormWithDefault, creatinineResultFormAndTasks, creatinineResultFormWithDefault, emptyContentAndTasksForPerformedLaboratoryTestConfig, emptyContentAndTasksForPerformedLaboratoryUniversalTestConfig, emptyContentAndTasksLaboratoryResultConfig, emptyContentAndTasksLaboratoryTestInitialConfig, emptyContentAndTasksLaboratoryUniversalTestInitialConfig, expectParticipantConsent, expectUniversalTestResultTask, expectVaccineDoseForPerson, familyPlanningFormWithDefault, fbfFormToValue, followUpFormWithDefault, generateAssembledDataForChildScoreboard, generateAssembledDataForWellChild, generateFutureVaccinationsData, generateGroupNutritionAssessmentEntries, generateIndividualNutritionAssessmentEntries, generateVaccinationProgressDictByChildScoreboard, generateVaccinationProgressForVaccine, getAllDosesForVaccine, getChildForm, getInputConstraintsHeight, getInputConstraintsMuac, getInputConstraintsWeight, getIntervalForVaccine, getMotherForm, getNextVaccineDose, getPreviousMeasurements, hba1cTestFormWithDefault, healthEducationFormWithDefault, heightFormWithDefault, heightOutOfRange, hemoglobinResultFormAndTasks, hemoglobinResultFormWithDefault, hemoglobinTestFormWithDefault, hepatitisBResultFormAndTasks, hepatitisBResultFormWithDefault, hepatitisBTestFormWithDefault, hivPCRResultFormAndTasks, hivPCRResultFormWithDefault, hivPCRTestFormWithDefault, hivResultFollowUpsFormAndTasks, hivResultFormAndTasks, hivResultFormWithDefault, hivTestFormWithDefault, hivTestUniversalFormWithDefault, immunisationTaskToVaccineType, initialVaccinationDateByBirthDate, isBehindOnVaccinationsByProgress, isTestResultValid, laboratoryTaskIconClass, lactationFormToSigns, lipidPanelResultFormAndTasks, lipidPanelResultFormWithDefault, liverFunctionResultFormAndTasks, liverFunctionResultFormWithDefault, malariaResultFormAndTasks, malariaResultFormWithDefault, malariaTestFormWithDefault, medicationAdministrationFormInputsAndTasks, medicationAdministrationFormWithDefault, muacFormWithDefault, muacMeasurementIsOff, muacOutOfRange, ncdaFormWithDefault, nextVaccinationDataForVaccine, nonRDTFormWithDefault, nutritionCaringFormWithDefault, nutritionFeedingFormWithDefault, nutritionFollowUpFormWithDefault, nutritionFoodSecurityFormWithDefault, nutritionFormWithDefault, nutritionHygieneFormWithDefault, ongoingTreatmentReviewFormWithDefault, outOfRange, outOfRangeAsEntered, outsideCareFormInputsAndTasks, outsideCareFormWithDefault, outsideCareMedicationOptionsAnemia, outsideCareMedicationOptionsHIV, outsideCareMedicationOptionsHypertension, outsideCareMedicationOptionsMalaria, outsideCareMedicationOptionsSyphilis, partnerHIVResultFollowUpsFormAndTasks, partnerHIVResultFormAndTasks, partnerHIVResultFormWithDefault, partnerHIVTestFormWithDefault, pregnancyTestFormWithDefault, randomBloodSugarFormWithDefault, randomBloodSugarResultFormAndTasks, randomBloodSugarResultFormWithDefault, randomBloodSugarUniversalFormWithDefault, renderDatePart, resoloveLastScheduledImmunizationVisitDate, resolveChildANCPregnancyData, resolveLabTestDate, resolveMedicationsNonAdministrationReasons, resolveNCDASteps, sendToHCFormWithDefault, showNCDAQuestionsByNewbornExam, syphilisResultFollowUpsFormAndTasks, syphilisResultFormAndTasks, syphilisResultFormWithDefault, syphilisTestFormWithDefault, testNotPerformedByWhyNotAtExecutionNote, testPerformedByExecutionNote, testPerformedByValue, toAdministrationNoteWithDefault, toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toBloodGpRsResultValueWithDefault, toBloodGpRsTestValueWithDefault, toContributingFactorsValueWithDefault, toCorePhysicalExamValueWithDefault, toCreatinineResultValueWithDefault, toCreatinineTestValueWithEmptyResults, toEverySet, toFamilyPlanningValueWithDefault, toFollowUpValueWithDefault, toHIVPCRResultValueWithDefault, toHIVPCRTestValueWithDefault, toHIVResultValueWithDefault, toHIVTestValueUniversalWithDefault, toHIVTestValueWithDefault, toHbA1cTestValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toHemoglobinResultValueWithDefault, toHemoglobinTestValueWithDefault, toHepatitisBResultValueWithDefault, toHepatitisBTestValueWithDefault, toLipidPanelResultValueWithDefault, toLipidPanelTestValueWithEmptyResults, toLiverFunctionResultValueWithDefault, toLiverFunctionTestValueWithEmptyResults, toMalariaResultValueWithDefault, toMalariaTestValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNonRDTValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toOngoingTreatmentReviewValueWithDefault, toOutsideCareValueWithDefault, toPartnerHIVResultValueWithDefault, toPartnerHIVTestValueWithDefault, toPregnancyTestValueWithDefault, toRandomBloodSugarResultValueWithDefault, toRandomBloodSugarTestValueUniversalWithDefault, toRandomBloodSugarTestValueWithDefault, toSendToHCValueWithDefault, toSyphilisResultValueWithDefault, toSyphilisTestValueWithDefault, toUrineDipstickResultValueWithDefault, toUrineDipstickTestValueUniversalWithDefault, toUrineDipstickTestValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, treatmentReviewCustomReasonsForNotTakingInputsAndTasks, treatmentReviewInputsAndTasks, urineDipstickFormWithDefault, urineDipstickResultFormAndTasks, urineDipstickResultFormWithDefault, urineDipstickUniversalFormWithDefault, vaccinationFormDynamicContentAndTasks, vaccinationFormWithDefault, vaccineDoseToComparable, viewAdministeredMedicationCustomLabel, viewAdministeredMedicationQuestion, viewBloodGpRsTestForm, viewHIVPCRTestForm, viewHIVTestForm, viewHIVTestUniversalForm, viewHbA1cTestForm, viewHemoglobinTestForm, viewHepatitisBTestForm, viewMalariaTestForm, viewNonRDTForm, viewPartnerHIVTestForm, viewPregnancyTestForm, viewRandomBloodSugarTestForm, viewRandomBloodSugarTestUniversalForm, viewReinforceAdherenceQuestion, viewSelectInput, viewSyphilisTestForm, viewUrineDipstickTestForm, viewUrineDipstickTestUniversalForm, vitalsFormWithDefault, wasFirstDoseAdministeredWithin14DaysFromBirthByVaccinationForm, wasInitialOpvAdministeredByVaccinationProgress, weightFormWithDefault, weightOutOfRange)
+module Measurement.Utils exposing (OutsideCareConfig, ahezaFormWithDefault, ahezaMotherFormWithDefault, allNextStepsTasks, allVaccineTypes, behindOnVaccinationsByHistory, birthWeightBlocksNCDAForm, birthWeightOutsideConstraints, bloodGpRsResultFormAndTasks, bloodGpRsResultFormWithDefault, bloodGpRsTestFormWithDefault, bloodSmearResultNotSet, bloodSmearResultSet, contributingFactorsFormWithDefault, corePhysicalExamFormWithDefault, creatinineResultFormAndTasks, creatinineResultFormWithDefault, emptyContentAndTasksForPerformedLaboratoryTestConfig, emptyContentAndTasksForPerformedLaboratoryUniversalTestConfig, emptyContentAndTasksLaboratoryResultConfig, emptyContentAndTasksLaboratoryTestInitialConfig, emptyContentAndTasksLaboratoryUniversalTestInitialConfig, expectParticipantConsent, expectUniversalTestResultTask, expectVaccineDoseForPerson, familyPlanningFormWithDefault, fbfFormToValue, followUpFormWithDefault, generateAssembledDataForChildScoreboard, generateAssembledDataForWellChild, generateFutureVaccinationsData, generateGroupNutritionAssessmentEntries, generateIndividualNutritionAssessmentEntries, generateVaccinationProgressDictByChildScoreboard, generateVaccinationProgressForVaccine, getAllDosesForVaccine, getChildForm, getInputConstraintsHeight, getInputConstraintsMuac, getInputConstraintsWeight, getIntervalForVaccine, getMotherForm, getNextVaccineDose, getPreviousMeasurements, hba1cTestFormWithDefault, healthEducationFormWithDefault, heightFormWithDefault, heightOutOfRange, hemoglobinResultFormAndTasks, hemoglobinResultFormWithDefault, hemoglobinTestFormWithDefault, hepatitisBResultFormAndTasks, hepatitisBResultFormWithDefault, hepatitisBTestFormWithDefault, hivPCRResultFormAndTasks, hivPCRResultFormWithDefault, hivPCRTestFormWithDefault, hivResultFollowUpsFormAndTasks, hivResultFormAndTasks, hivResultFormWithDefault, hivTestFormWithDefault, hivTestUniversalFormWithDefault, immunisationTaskToVaccineType, initialVaccinationDateByBirthDate, isBehindOnVaccinationsByProgress, isTestResultValid, laboratoryTaskIconClass, lactationFormToSigns, lipidPanelResultFormAndTasks, lipidPanelResultFormWithDefault, liverFunctionResultFormAndTasks, liverFunctionResultFormWithDefault, malariaResultFormAndTasks, malariaResultFormWithDefault, malariaTestFormWithDefault, measurementConstraints, measurementOutOfRange, medicationAdministrationFormInputsAndTasks, medicationAdministrationFormWithDefault, muacFormWithDefault, muacMeasurementIsOff, muacOutOfRange, ncdaFormWithDefault, nextVaccinationDataForVaccine, nonRDTFormWithDefault, nutritionCaringFormWithDefault, nutritionFeedingFormWithDefault, nutritionFollowUpFormWithDefault, nutritionFoodSecurityFormWithDefault, nutritionFormWithDefault, nutritionHygieneFormWithDefault, ongoingTreatmentReviewFormWithDefault, outOfRange, outOfRangeAsEntered, outsideCareFormInputsAndTasks, outsideCareFormWithDefault, outsideCareMedicationOptionsAnemia, outsideCareMedicationOptionsHIV, outsideCareMedicationOptionsHypertension, outsideCareMedicationOptionsMalaria, outsideCareMedicationOptionsSyphilis, partnerHIVResultFollowUpsFormAndTasks, partnerHIVResultFormAndTasks, partnerHIVResultFormWithDefault, partnerHIVTestFormWithDefault, pregnancyTestFormWithDefault, randomBloodSugarFormWithDefault, randomBloodSugarResultFormAndTasks, randomBloodSugarResultFormWithDefault, randomBloodSugarUniversalFormWithDefault, renderDatePart, resoloveLastScheduledImmunizationVisitDate, resolveChildANCPregnancyData, resolveLabTestDate, resolveMedicationsNonAdministrationReasons, resolveNCDASteps, sendToHCFormWithDefault, showNCDAQuestionsByNewbornExam, syphilisResultFollowUpsFormAndTasks, syphilisResultFormAndTasks, syphilisResultFormWithDefault, syphilisTestFormWithDefault, testNotPerformedByWhyNotAtExecutionNote, testPerformedByExecutionNote, testPerformedByValue, toAdministrationNoteWithDefault, toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toBloodGpRsResultValueWithDefault, toBloodGpRsTestValueWithDefault, toContributingFactorsValueWithDefault, toCorePhysicalExamValueWithDefault, toCreatinineResultValueWithDefault, toCreatinineTestValueWithEmptyResults, toEverySet, toFamilyPlanningValueWithDefault, toFollowUpValueWithDefault, toHIVPCRResultValueWithDefault, toHIVPCRTestValueWithDefault, toHIVResultValueWithDefault, toHIVTestValueUniversalWithDefault, toHIVTestValueWithDefault, toHbA1cTestValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toHemoglobinResultValueWithDefault, toHemoglobinTestValueWithDefault, toHepatitisBResultValueWithDefault, toHepatitisBTestValueWithDefault, toLipidPanelResultValueWithDefault, toLipidPanelTestValueWithEmptyResults, toLiverFunctionResultValueWithDefault, toLiverFunctionTestValueWithEmptyResults, toMalariaResultValueWithDefault, toMalariaTestValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNonRDTValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toOngoingTreatmentReviewValueWithDefault, toOutsideCareValueWithDefault, toPartnerHIVResultValueWithDefault, toPartnerHIVTestValueWithDefault, toPregnancyTestValueWithDefault, toRandomBloodSugarResultValueWithDefault, toRandomBloodSugarTestValueUniversalWithDefault, toRandomBloodSugarTestValueWithDefault, toSendToHCValueWithDefault, toSyphilisResultValueWithDefault, toSyphilisTestValueWithDefault, toUrineDipstickResultValueWithDefault, toUrineDipstickTestValueUniversalWithDefault, toUrineDipstickTestValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, treatmentReviewCustomReasonsForNotTakingInputsAndTasks, treatmentReviewInputsAndTasks, urineDipstickFormWithDefault, urineDipstickResultFormAndTasks, urineDipstickResultFormWithDefault, urineDipstickUniversalFormWithDefault, vaccinationFormDynamicContentAndTasks, vaccinationFormWithDefault, vaccineDoseToComparable, viewAdministeredMedicationCustomLabel, viewAdministeredMedicationQuestion, viewBloodGpRsTestForm, viewHIVPCRTestForm, viewHIVTestForm, viewHIVTestUniversalForm, viewHbA1cTestForm, viewHemoglobinTestForm, viewHepatitisBTestForm, viewMalariaTestForm, viewNonRDTForm, viewPartnerHIVTestForm, viewPregnancyTestForm, viewRandomBloodSugarTestForm, viewRandomBloodSugarTestUniversalForm, viewReinforceAdherenceQuestion, viewSelectInput, viewSyphilisTestForm, viewUrineDipstickTestForm, viewUrineDipstickTestUniversalForm, vitalsFormWithDefault, wasFirstDoseAdministeredWithin14DaysFromBirthByVaccinationForm, wasInitialOpvAdministeredByVaccinationProgress, weightFormWithDefault, weightOutOfRange)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Counseling.Model exposing (CounselingTiming(..))
@@ -30,7 +30,7 @@ import Html.Events exposing (..)
 import List.Extra
 import LocalData
 import Maybe.Extra exposing (andMap, isJust, isNothing, or, unwrap)
-import Measurement.Model exposing (AhezaForm, AnthropometricMeasurement(..), BloodGpRsResultForm, BloodGpRsTestForm, ContentAndTasksForPerformedLaboratoryTestConfig, ContentAndTasksForPerformedLaboratoryUniversalTestConfig, ContentAndTasksLaboratoryResultConfig, ContentAndTasksLaboratoryTestInitialConfig, ContentAndTasksLaboratoryUniversalTestInitialConfig, ContributingFactorsForm, CorePhysicalExamForm, CreatinineResultForm, FamilyPlanningForm, FbfForm, FloatInputConstraints, FollowUpForm, HIVPCRResultForm, HIVPCRTestForm, HIVResultForm, HIVTestForm, HIVTestUniversalForm, HbA1cTestForm, HealthEducationForm, HeightForm, HemoglobinResultForm, HemoglobinTestForm, HepatitisBResultForm, HepatitisBTestForm, ImmunisationTask(..), LaboratoryTask(..), LipidPanelResultForm, LiverFunctionResultForm, MalariaResultForm, MalariaTestForm, MedicationAdministrationForm, MedicationAdministrationFormConfig, ModelChild, ModelMother, MuacForm, NCDAData, NCDAForm, NCDAStep(..), NextStepsTask(..), NonRDTForm, NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, OngoingTreatmentReviewForm, OutsideCareForm, OutsideCareStep(..), PartnerHIVResultForm, PartnerHIVTestForm, PregnancyTestForm, RandomBloodSugarResultForm, RandomBloodSugarTestForm, RandomBloodSugarTestUniversalForm, SendToHCForm, SyphilisResultForm, SyphilisTestForm, UrineDipstickResultForm, UrineDipstickTestForm, UrineDipstickTestUniversalForm, VaccinationForm, VaccinationFormDynamicContentAndTasksConfig, VaccinationFormViewMode(..), VaccinationProgressDict, VitalsForm, WeightForm, completedParticipantFormProgress, emptyContributingFactorsForm, emptyFbfForm, emptyHealthEducationForm, emptyMedicationAdministrationForm, emptyModelChild, emptyModelMother, emptyNCDAData, emptyNutritionFollowUpForm, emptySendToHCForm)
+import Measurement.Model exposing (AhezaForm, BloodGpRsResultForm, BloodGpRsTestForm, ContentAndTasksForPerformedLaboratoryTestConfig, ContentAndTasksForPerformedLaboratoryUniversalTestConfig, ContentAndTasksLaboratoryResultConfig, ContentAndTasksLaboratoryTestInitialConfig, ContentAndTasksLaboratoryUniversalTestInitialConfig, ContributingFactorsForm, CorePhysicalExamForm, CreatinineResultForm, FamilyPlanningForm, FbfForm, FloatInputConstraints, FollowUpForm, HIVPCRResultForm, HIVPCRTestForm, HIVResultForm, HIVTestForm, HIVTestUniversalForm, HbA1cTestForm, HealthEducationForm, HeightForm, HemoglobinResultForm, HemoglobinTestForm, HepatitisBResultForm, HepatitisBTestForm, ImmunisationTask(..), LaboratoryTask(..), LipidPanelResultForm, LiverFunctionResultForm, MalariaResultForm, MalariaTestForm, MedicationAdministrationForm, MedicationAdministrationFormConfig, ModelChild, ModelMother, MuacForm, NCDAData, NCDAForm, NCDAStep(..), NextStepsTask(..), NonRDTForm, NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, OngoingTreatmentReviewForm, OutsideCareForm, OutsideCareStep(..), PartnerHIVResultForm, PartnerHIVTestForm, PregnancyTestForm, RandomBloodSugarResultForm, RandomBloodSugarTestForm, RandomBloodSugarTestUniversalForm, RangedMeasurement(..), SendToHCForm, SyphilisResultForm, SyphilisTestForm, UrineDipstickResultForm, UrineDipstickTestForm, UrineDipstickTestUniversalForm, VaccinationForm, VaccinationFormDynamicContentAndTasksConfig, VaccinationFormViewMode(..), VaccinationProgressDict, VitalsForm, WeightForm, completedParticipantFormProgress, emptyContributingFactorsForm, emptyFbfForm, emptyHealthEducationForm, emptyMedicationAdministrationForm, emptyModelChild, emptyModelMother, emptyNCDAData, emptyNutritionFollowUpForm, emptySendToHCForm)
 import Pages.ChildScoreboard.Encounter.Model
 import Pages.Session.Model
 import Pages.Utils
@@ -94,6 +94,17 @@ getInputConstraintsBirthWeight =
     -- kilograms is still far below all of them.
     { minVal = 300
     , maxVal = 7000
+    }
+
+
+{-| The Apgar score is a score out of 10, given twice: once a minute after
+birth and once five minutes after. It is not a measurement of anything, so
+there is nothing else it could plausibly be.
+-}
+getInputConstraintsApgar : FloatInputConstraints
+getInputConstraintsApgar =
+    { minVal = 0
+    , maxVal = 10
     }
 
 
@@ -322,7 +333,7 @@ answered by the task count.
 birthWeightOutsideConstraints : Site -> Maybe WeightInGrm -> Bool
 birthWeightOutsideConstraints site birthWeight =
     Maybe.map (\(WeightInGrm weight) -> weight) birthWeight
-        |> anthropometricOutOfRange site MeasurementBirthWeight
+        |> measurementOutOfRange site MeasurementBirthWeight
 
 
 {-| The measurement a form asks for, when it was entered outside the range it
@@ -336,17 +347,17 @@ the form it is asked of holds no value in that case, and a measurement that was
 not entered is not out of range.
 
 -}
-heightOutOfRange : Site -> HeightForm -> List AnthropometricMeasurement
+heightOutOfRange : Site -> HeightForm -> List RangedMeasurement
 heightOutOfRange site form =
     outOfRange site MeasurementHeight form.height
 
 
-muacOutOfRange : Site -> MuacForm -> List AnthropometricMeasurement
+muacOutOfRange : Site -> MuacForm -> List RangedMeasurement
 muacOutOfRange site form =
     outOfRange site MeasurementMuac form.muac
 
 
-weightOutOfRange : Site -> WeightForm -> List AnthropometricMeasurement
+weightOutOfRange : Site -> WeightForm -> List RangedMeasurement
 weightOutOfRange site form =
     outOfRange site MeasurementWeight form.weight
 
@@ -355,9 +366,9 @@ weightOutOfRange site form =
 take. For forms holding the value the way the measurements are stored, which is
 centimetres for MUAC; it is put into the unit it is shown in before comparing.
 -}
-outOfRange : Site -> AnthropometricMeasurement -> Maybe Float -> List AnthropometricMeasurement
+outOfRange : Site -> RangedMeasurement -> Maybe Float -> List RangedMeasurement
 outOfRange site measurement value =
-    if anthropometricOutOfRange site measurement value then
+    if measurementOutOfRange site measurement value then
         [ measurement ]
 
     else
@@ -373,7 +384,7 @@ before it is put into the unit it is stored in. Converting here as well would
 report every MUAC at the site that asks for millimetres.
 
 -}
-outOfRangeAsEntered : FloatInputConstraints -> AnthropometricMeasurement -> Float -> List AnthropometricMeasurement
+outOfRangeAsEntered : FloatInputConstraints -> RangedMeasurement -> Float -> List RangedMeasurement
 outOfRangeAsEntered constraints measurement value =
     if withinConstraints constraints value then
         []
@@ -385,9 +396,15 @@ outOfRangeAsEntered constraints measurement value =
 {-| The range a measurement of the body has to be within, in the unit it is
 entered in.
 -}
-anthropometricConstraints : Site -> AnthropometricMeasurement -> FloatInputConstraints
-anthropometricConstraints site measurement =
+measurementConstraints : Site -> RangedMeasurement -> FloatInputConstraints
+measurementConstraints site measurement =
     case measurement of
+        MeasurementApgarFiveMinutes ->
+            getInputConstraintsApgar
+
+        MeasurementApgarOneMinute ->
+            getInputConstraintsApgar
+
         MeasurementBirthLength ->
             getInputConstraintsBirthLength
 
@@ -419,12 +436,12 @@ it is put back into the unit it was entered in before it is compared. Ask here
 rather than comparing against the range directly, so that cannot be forgotten.
 
 -}
-anthropometricOutOfRange : Site -> AnthropometricMeasurement -> Maybe Float -> Bool
-anthropometricOutOfRange site measurement value =
+measurementOutOfRange : Site -> RangedMeasurement -> Maybe Float -> Bool
+measurementOutOfRange site measurement value =
     Maybe.map
         (\number ->
             not <|
-                withinConstraints (anthropometricConstraints site measurement)
+                withinConstraints (measurementConstraints site measurement)
                     (asEntered site measurement number)
         )
         value
@@ -433,7 +450,7 @@ anthropometricOutOfRange site measurement value =
 
 {-| A measurement as the nurse typed it, from the way the form holds it.
 -}
-asEntered : Site -> AnthropometricMeasurement -> Float -> Float
+asEntered : Site -> RangedMeasurement -> Float -> Float
 asEntered site measurement number =
     case measurement of
         MeasurementMuac ->

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -97,9 +97,9 @@ getInputConstraintsBirthWeight =
     }
 
 
-{-| The Apgar score is a score out of 10, given twice: once a minute after
-birth and once five minutes after. It is not a measurement of anything, so
-there is nothing else it could plausibly be.
+{-| The Apgar score is a score out of 10, given twice: one minute after birth
+and again five minutes after. It is not a measurement of anything, so there is
+nothing else it could plausibly be.
 -}
 getInputConstraintsApgar : FloatInputConstraints
 getInputConstraintsApgar =

--- a/client/src/elm/Measurement/View.elm
+++ b/client/src/elm/Measurement/View.elm
@@ -47,8 +47,8 @@ import Json.Decode
 import List.Extra exposing (greedyGroupsOf)
 import Maybe.Extra exposing (isJust)
 import Measurement.Decoder exposing (decodeDropZoneFile)
-import Measurement.Model exposing (AnthropometricMeasurement(..), ContributingFactorsForm, CorePhysicalExamForm, CorePhysicalExamFormConfig, FamilyPlanningForm, FbfForm, FloatInputConstraints, GroupOfFoods(..), HealthEducationForm, HeightForm, InvokationModule(..), MedicationAdministrationForm, MedicationAdministrationFormConfig, ModelChild, ModelMother, MsgChild(..), MsgMother(..), MuacForm, NCDAContentConfig, NCDAData, NCDAForm, NCDAStep(..), NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, OutMsgChild(..), OutMsgMother(..), ParticipantFormUI, SendToHCForm, VitalsForm, VitalsFormConfig, VitalsFormMode(..), WeightForm, emptyParticipantFormProgress)
-import Measurement.Utils exposing (anthropometricConstraints, birthWeightBlocksNCDAForm, contributingFactorsFormWithDefault, fbfFormToValue, getInputConstraintsHeight, getInputConstraintsMuac, getInputConstraintsWeight, healthEducationFormWithDefault, isBehindOnVaccinationsByProgress, lactationFormToSigns, medicationAdministrationFormInputsAndTasks, muacMeasurementIsOff, ncdaFormWithDefault, nutritionFollowUpFormWithDefault, outOfRangeAsEntered, renderDatePart, resoloveLastScheduledImmunizationVisitDate, resolveChildANCPregnancyData, resolveNCDASteps, sendToHCFormWithDefault, showNCDAQuestionsByNewbornExam, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toNCDAValueWithDefault, toNutritionFollowUpValueWithDefault, toSendToHCValueWithDefault)
+import Measurement.Model exposing (ContributingFactorsForm, CorePhysicalExamForm, CorePhysicalExamFormConfig, FamilyPlanningForm, FbfForm, FloatInputConstraints, GroupOfFoods(..), HealthEducationForm, HeightForm, InvokationModule(..), MedicationAdministrationForm, MedicationAdministrationFormConfig, ModelChild, ModelMother, MsgChild(..), MsgMother(..), MuacForm, NCDAContentConfig, NCDAData, NCDAForm, NCDAStep(..), NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, OutMsgChild(..), OutMsgMother(..), ParticipantFormUI, RangedMeasurement(..), SendToHCForm, VitalsForm, VitalsFormConfig, VitalsFormMode(..), WeightForm, emptyParticipantFormProgress)
+import Measurement.Utils exposing (birthWeightBlocksNCDAForm, contributingFactorsFormWithDefault, fbfFormToValue, getInputConstraintsHeight, getInputConstraintsMuac, getInputConstraintsWeight, healthEducationFormWithDefault, isBehindOnVaccinationsByProgress, lactationFormToSigns, measurementConstraints, medicationAdministrationFormInputsAndTasks, muacMeasurementIsOff, ncdaFormWithDefault, nutritionFollowUpFormWithDefault, outOfRangeAsEntered, renderDatePart, resoloveLastScheduledImmunizationVisitDate, resolveChildANCPregnancyData, resolveNCDASteps, sendToHCFormWithDefault, showNCDAQuestionsByNewbornExam, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toNCDAValueWithDefault, toNutritionFollowUpValueWithDefault, toSendToHCValueWithDefault)
 import Pages.Utils
     exposing
         ( concatInputsAndTasksSections
@@ -153,7 +153,7 @@ type alias FloatFormConfig id value =
 
     -- Names the measurement on the warning when what was typed is outside the
     -- range above.
-    , measurement : AnthropometricMeasurement
+    , measurement : RangedMeasurement
     , unit : TranslationId
     , inputValue : ModelChild -> String
     , toBackendValue : String -> Maybe Float
@@ -3680,7 +3680,7 @@ several behind one button, and being told about them one save at a time would be
 tiresome.
 
 -}
-measurementOutOfRangePopup : Language -> Site -> List AnthropometricMeasurement -> msg -> Html msg
+measurementOutOfRangePopup : Language -> Site -> List RangedMeasurement -> msg -> Html msg
 measurementOutOfRangePopup language site measurements closeMsg =
     Pages.Utils.customPopup language
         True
@@ -3699,7 +3699,7 @@ measurementOutOfRangePopup language site measurements closeMsg =
                         -- which is already translated.
                         , text <|
                             translate language <|
-                                Translate.AllowedValuesRangeHelper (anthropometricConstraints site measurement)
+                                Translate.AllowedValuesRangeHelper (measurementConstraints site measurement)
                         ]
                 )
                 measurements
@@ -3711,9 +3711,15 @@ measurementOutOfRangePopup language site measurements closeMsg =
 {-| Names the measurement on the popup, so that a test can tell which one it is
 about.
 -}
-measurementOutOfRangeClass : AnthropometricMeasurement -> String
+measurementOutOfRangeClass : RangedMeasurement -> String
 measurementOutOfRangeClass measurement =
     case measurement of
+        MeasurementApgarFiveMinutes ->
+            "apgar-five-minutes-out-of-range"
+
+        MeasurementApgarOneMinute ->
+            "apgar-one-minute-out-of-range"
+
         MeasurementBirthLength ->
             "birth-length-out-of-range"
 

--- a/client/src/elm/Pages/AcuteIllness/Activity/Model.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Model.elm
@@ -11,7 +11,7 @@ import DateSelector.Model exposing (DateSelectorConfig)
 import EverySet exposing (EverySet)
 import Form
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AnthropometricMeasurement, HealthEducationForm, MuacForm, OngoingTreatmentReviewForm, SendToHCForm, VitalsForm, emptyHealthEducationForm, emptyMuacForm, emptyOngoingTreatmentReviewForm, emptySendToHCForm, emptyVitalsForm)
+import Measurement.Model exposing (HealthEducationForm, MuacForm, OngoingTreatmentReviewForm, RangedMeasurement, SendToHCForm, VitalsForm, emptyHealthEducationForm, emptyMuacForm, emptyOngoingTreatmentReviewForm, emptySendToHCForm, emptyVitalsForm)
 import Pages.AcuteIllness.Activity.Types exposing (AILaboratoryTask, DangerSignsTask, ExposureTask, OngoingTreatmentTask, PhysicalExamTask, PriorTreatmentTask, SymptomsTask)
 import Pages.Page exposing (Page)
 import SyncManager.Model exposing (Site)
@@ -22,7 +22,7 @@ type Msg
     | SetActivePage Page
     | SetAlertsDialogState Bool
     | SetWarningPopupState (Maybe AcuteIllnessDiagnosis)
-    | SetMeasurementOutOfRangePopupState (List AnthropometricMeasurement)
+    | SetMeasurementOutOfRangePopupState (List RangedMeasurement)
     | SetPertinentSymptomsPopupState Bool
       -- SYMPTOMS Msgs
     | SetActiveSymptomsTask SymptomsTask
@@ -118,7 +118,7 @@ type alias Model =
     , warningPopupState : Maybe AcuteIllnessDiagnosis
 
     -- Kept apart from warningPopupState, which carries a diagnosis.
-    , measurementOutOfRangePopupState : List AnthropometricMeasurement
+    , measurementOutOfRangePopupState : List RangedMeasurement
     }
 
 

--- a/client/src/elm/Pages/AcuteIllness/Activity/Test.elm
+++ b/client/src/elm/Pages/AcuteIllness/Activity/Test.elm
@@ -29,7 +29,7 @@ import Date
 import EverySet exposing (EverySet)
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AnthropometricMeasurement(..), emptyMuacForm)
+import Measurement.Model exposing (RangedMeasurement(..), emptyMuacForm)
 import Pages.AcuteIllness.Activity.Model exposing (Msg(..), emptyCovidTestingForm, emptyModel)
 import Pages.AcuteIllness.Activity.Update exposing (update)
 import Pages.AcuteIllness.Activity.Utils

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Model.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Model.elm
@@ -7,7 +7,7 @@ import Backend.FamilyNutritionEncounter.Model exposing (FamilyNutritionEncounter
 import Backend.Measurement.Model exposing (..)
 import Backend.Person.Model exposing (Person)
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AhezaForm, AnthropometricMeasurement, DropZoneFile, MuacForm, PhotoForm, emptyAhezaForm, emptyMuacForm, emptyPhotoForm)
+import Measurement.Model exposing (AhezaForm, DropZoneFile, MuacForm, PhotoForm, RangedMeasurement, emptyAhezaForm, emptyMuacForm, emptyPhotoForm)
 import Pages.Page exposing (Page)
 
 
@@ -23,7 +23,7 @@ type alias Model =
     -- The measurement that was entered outside the range it can take, named on
     -- a warning until the nurse closes it. This encounter shows no range above
     -- the input, so the warning is the only place it is said.
-    , measurementOutOfRangePopupState : List AnthropometricMeasurement
+    , measurementOutOfRangePopupState : List RangedMeasurement
     }
 
 
@@ -54,7 +54,7 @@ type Msg
     | SetAheza String
     | SetAhezaDistributionReason String
     | SetDialogState (Maybe DialogType)
-    | SetMeasurementOutOfRangePopupState (List AnthropometricMeasurement)
+    | SetMeasurementOutOfRangePopupState (List RangedMeasurement)
     | SetMuac String
     | SetSelectedActivity (Maybe FamilyNutritionActivity)
     | SetSelectedFamilyMember (Maybe FamilyMember)

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Test.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Test.elm
@@ -2,7 +2,7 @@ module Pages.FamilyNutrition.Encounter.Test exposing (all)
 
 import Backend.Model exposing (emptyModelIndexedDb)
 import Expect
-import Measurement.Model exposing (AnthropometricMeasurement(..), emptyMuacForm)
+import Measurement.Model exposing (RangedMeasurement(..), emptyMuacForm)
 import Pages.FamilyNutrition.Encounter.Model exposing (Msg(..), emptyModel)
 import Pages.FamilyNutrition.Encounter.Update exposing (update)
 import Restful.Endpoint exposing (toEntityUuid)

--- a/client/src/elm/Pages/FamilyNutrition/Encounter/Update.elm
+++ b/client/src/elm/Pages/FamilyNutrition/Encounter/Update.elm
@@ -10,7 +10,7 @@ import Backend.Measurement.Utils exposing (ahezaDistributionReasonFromString, ge
 import Backend.Model exposing (ModelIndexedDb)
 import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (unwrap)
-import Measurement.Model exposing (AnthropometricMeasurement)
+import Measurement.Model exposing (RangedMeasurement)
 import Measurement.Utils exposing (muacFormWithDefault, muacOutOfRange, toAhezaMotherValueWithDefault, toAhezaValueWithDefault, toMuacValueWithDefault)
 import Pages.FamilyNutrition.Encounter.Model exposing (FamilyMember(..), Model, Msg(..), Tab(..), emptyAhezaData, emptyMuacData, emptyPhotoData)
 import Pages.FamilyNutrition.Encounter.Utils exposing (activitiesForFamilyMember, activityCompleted, generateAssembledData, nextFamilyMemberWithPendingActivities)
@@ -411,7 +411,7 @@ preSaveMuac :
     -> ModelIndexedDb
     -> Model
     -> Msg
-    -> List AnthropometricMeasurement
+    -> List RangedMeasurement
     -> ( Model, Cmd Msg, List App.Model.Msg )
 preSaveMuac site id db model saveMsg outOfRange =
     let

--- a/client/src/elm/Pages/Nutrition/Activity/Model.elm
+++ b/client/src/elm/Pages/Nutrition/Activity/Model.elm
@@ -4,7 +4,7 @@ import Backend.Entities exposing (..)
 import Backend.Measurement.Model exposing (..)
 import EverySet exposing (EverySet)
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AnthropometricMeasurement, ContributingFactorsForm, DropZoneFile, HealthEducationForm, HeightForm, MuacForm, NCDAData, NCDAForm, NCDAStep, NextStepsTask, NutritionFollowUpForm, NutritionForm, PhotoForm, SendToHCForm, WeightForm, emptyContributingFactorsForm, emptyHealthEducationForm, emptyHeightForm, emptyMuacForm, emptyNCDAData, emptyNutritionFollowUpForm, emptyNutritionForm, emptyPhotoForm, emptySendToHCForm, emptyWeightForm)
+import Measurement.Model exposing (ContributingFactorsForm, DropZoneFile, HealthEducationForm, HeightForm, MuacForm, NCDAData, NCDAForm, NCDAStep, NextStepsTask, NutritionFollowUpForm, NutritionForm, PhotoForm, RangedMeasurement, SendToHCForm, WeightForm, emptyContributingFactorsForm, emptyHealthEducationForm, emptyHeightForm, emptyMuacForm, emptyNCDAData, emptyNutritionFollowUpForm, emptyNutritionForm, emptyPhotoForm, emptySendToHCForm, emptyWeightForm)
 import Pages.Page exposing (Page)
 
 
@@ -12,7 +12,7 @@ type Msg
     = NoOp
     | SetActivePage Page
     | SetWarningPopupState (List NutritionAssessment)
-    | SetMeasurementOutOfRangePopupState (List AnthropometricMeasurement)
+    | SetMeasurementOutOfRangePopupState (List RangedMeasurement)
     | SetHeight String
     | SetHeightNotTaken Bool
     | PreSaveHeight (EverySet SkippedForm) PersonId (Maybe ( NutritionHeightId, NutritionHeight ))
@@ -66,7 +66,7 @@ type alias Model =
 
     -- Kept apart from warningPopupState, which carries a nutrition assessment,
     -- so that every page names an out-of-range measurement the same way.
-    , measurementOutOfRangePopupState : List AnthropometricMeasurement
+    , measurementOutOfRangePopupState : List RangedMeasurement
     }
 
 

--- a/client/src/elm/Pages/Nutrition/Activity/Test.elm
+++ b/client/src/elm/Pages/Nutrition/Activity/Test.elm
@@ -3,7 +3,7 @@ module Pages.Nutrition.Activity.Test exposing (all)
 import Backend.Model exposing (emptyModelIndexedDb)
 import EverySet
 import Expect
-import Measurement.Model exposing (AnthropometricMeasurement(..), emptyHeightForm, emptyMuacForm, emptyWeightForm)
+import Measurement.Model exposing (RangedMeasurement(..), emptyHeightForm, emptyMuacForm, emptyWeightForm)
 import Pages.Nutrition.Activity.Model exposing (Msg(..), emptyModel)
 import Pages.Nutrition.Activity.Update exposing (update)
 import Restful.Endpoint exposing (toEntityUuid)

--- a/client/src/elm/Pages/Nutrition/Activity/Update.elm
+++ b/client/src/elm/Pages/Nutrition/Activity/Update.elm
@@ -10,7 +10,7 @@ import Backend.NutritionEncounter.Model
 import EverySet
 import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (unwrap)
-import Measurement.Model exposing (AnthropometricMeasurement)
+import Measurement.Model exposing (RangedMeasurement)
 import Measurement.Utils exposing (contributingFactorsFormWithDefault, heightFormWithDefault, heightOutOfRange, muacFormWithDefault, muacOutOfRange, ncdaFormWithDefault, nutritionFormWithDefault, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionValueWithDefault, toSendToHCValueWithDefault, toWeightValueWithDefault, weightFormWithDefault, weightOutOfRange)
 import Pages.Nutrition.Activity.Model exposing (Model, Msg(..), emptyPhotoData)
 import Pages.Page exposing (Page(..), UserPage(..))
@@ -785,7 +785,7 @@ preSaveMeasurement :
     -> ModelIndexedDb
     -> Model
     -> Msg
-    -> List AnthropometricMeasurement
+    -> List RangedMeasurement
     -> ( Model, Cmd Msg, List App.Model.Msg )
 preSaveMeasurement site id db model saveMsg outOfRange =
     let

--- a/client/src/elm/Pages/Prenatal/Activity/Test.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Test.elm
@@ -42,7 +42,7 @@ import Date
 import EverySet exposing (EverySet)
 import Expect
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AnthropometricMeasurement(..))
+import Measurement.Model exposing (RangedMeasurement(..))
 import Pages.Prenatal.Activity.Model exposing (Msg(..), emptyModel)
 import Pages.Prenatal.Activity.Types exposing (PrePregnancyClassification(..), WarningPopupType(..))
 import Pages.Prenatal.Activity.Update exposing (update)

--- a/client/src/elm/Pages/Prenatal/Activity/Types.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Types.elm
@@ -1,6 +1,6 @@
 module Pages.Prenatal.Activity.Types exposing (ExaminationTask(..), GWGClassification(..), HistoryTask(..), ImmunisationTask(..), MedicationTask(..), NextStepsTask(..), ObstetricHistoryStep(..), PrePregnancyClassification(..), SymptomReviewStep(..), TreatmentReviewTask(..), WarningPopupType(..))
 
-import Measurement.Model exposing (AnthropometricMeasurement)
+import Measurement.Model exposing (RangedMeasurement)
 
 
 type ExaminationTask
@@ -56,7 +56,7 @@ type WarningPopupType msg
     | WarningPopupMentalHealth msg
     | WarningPopupTreatmentReview msg
     | WarningPopupVitaminA msg
-    | WarningPopupMeasurementOutOfRange (List AnthropometricMeasurement)
+    | WarningPopupMeasurementOutOfRange (List RangedMeasurement)
 
 
 type ObstetricHistoryStep

--- a/client/src/elm/Pages/Prenatal/Activity/Update.elm
+++ b/client/src/elm/Pages/Prenatal/Activity/Update.elm
@@ -41,7 +41,7 @@ import EverySet
 import Gizra.NominalDate exposing (NominalDate)
 import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (unwrap)
-import Measurement.Model exposing (AnthropometricMeasurement(..), VaccinationFormViewMode(..))
+import Measurement.Model exposing (RangedMeasurement(..), VaccinationFormViewMode(..))
 import Measurement.Utils
     exposing
         ( corePhysicalExamFormWithDefault

--- a/client/src/elm/Pages/WellChild/Activity/Model.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Model.elm
@@ -6,7 +6,7 @@ import Date exposing (Date)
 import DateSelector.Model exposing (DateSelectorConfig)
 import EverySet exposing (EverySet)
 import Gizra.NominalDate exposing (NominalDate)
-import Measurement.Model exposing (AnthropometricMeasurement, ContributingFactorsForm, DropZoneFile, HealthEducationForm, HeightForm, ImmunisationTask, MedicationAdministrationForm, MuacForm, NCDAData, NCDAForm, NCDAStep, NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, PhotoForm, SendToHCForm, VaccinationForm, VaccinationFormViewMode, VitalsForm, WeightForm, emptyContributingFactorsForm, emptyHealthEducationForm, emptyHeightForm, emptyMedicationAdministrationForm, emptyMuacForm, emptyNCDAData, emptyNutritionCaringForm, emptyNutritionFeedingForm, emptyNutritionFollowUpForm, emptyNutritionFoodSecurityForm, emptyNutritionForm, emptyNutritionHygieneForm, emptyPhotoForm, emptySendToHCForm, emptyVaccinationForm, emptyVitalsForm, emptyWeightForm)
+import Measurement.Model exposing (ContributingFactorsForm, DropZoneFile, HealthEducationForm, HeightForm, ImmunisationTask, MedicationAdministrationForm, MuacForm, NCDAData, NCDAForm, NCDAStep, NutritionCaringForm, NutritionFeedingForm, NutritionFollowUpForm, NutritionFoodSecurityForm, NutritionForm, NutritionHygieneForm, PhotoForm, RangedMeasurement, SendToHCForm, VaccinationForm, VaccinationFormViewMode, VitalsForm, WeightForm, emptyContributingFactorsForm, emptyHealthEducationForm, emptyHeightForm, emptyMedicationAdministrationForm, emptyMuacForm, emptyNCDAData, emptyNutritionCaringForm, emptyNutritionFeedingForm, emptyNutritionFollowUpForm, emptyNutritionFoodSecurityForm, emptyNutritionForm, emptyNutritionHygieneForm, emptyPhotoForm, emptySendToHCForm, emptyVaccinationForm, emptyVitalsForm, emptyWeightForm)
 import Pages.Page exposing (Page)
 import Pages.WellChild.Activity.Types exposing (DangerSignsTask, MedicationTask(..), NutritionAssessmentTask)
 
@@ -170,7 +170,7 @@ emptyModel =
 
 type WarningPopupType
     = PopupMacrocephaly PersonId (Maybe ( WellChildHeadCircumferenceId, WellChildHeadCircumference )) (Maybe NutritionAssessmentTask)
-    | PopupMeasurementOutOfRange (List AnthropometricMeasurement)
+    | PopupMeasurementOutOfRange (List RangedMeasurement)
     | PopupMicrocephaly PersonId (Maybe ( WellChildHeadCircumferenceId, WellChildHeadCircumference )) (Maybe NutritionAssessmentTask)
     | PopupNutritionAssessment (List NutritionAssessment)
 

--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -225,9 +225,9 @@ pregnancySummaryMeasurementsOutOfRangeTests =
                         , birthLength = Just (HeightInCm 0.5)
                     }
                     |> Expect.equal
-                        [ MeasurementBirthWeight
-                        , MeasurementApgarOneMinute
+                        [ MeasurementApgarOneMinute
                         , MeasurementApgarFiveMinutes
+                        , MeasurementBirthWeight
                         , MeasurementBirthLength
                         ]
         ]

--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -321,6 +321,14 @@ savedPregnancySummary =
     }
 
 
+{-| The same record with its signs lost, which is what a decoder that cannot
+read them leaves behind. The measurements are still there.
+-}
+savedWithoutSigns : PregnancySummaryValue
+savedWithoutSigns =
+    { savedPregnancySummary | signs = EverySet.singleton NoPregnancySummarySigns }
+
+
 {-| Clearing a value (for example answering "Apgar scores available? No", which
 empties the scores and marks them dirty) must stay cleared when the form is
 rebuilt from the saved value. An untouched field still loads from the saved
@@ -369,4 +377,76 @@ pregnancySummaryFormWithDefaultTests =
                 resolve { emptyPregnancySummaryForm | birthLengthDirty = True }
                     |> .birthLength
                     |> Expect.equal Nothing
+        , describe "a record whose signs were lost"
+            -- The measurement and the sign that says it was asked for are
+            -- stored apart, and the signs fall back to none when they cannot be
+            -- read. The measurement is then live but its input is not drawn: it
+            -- is written back out on every save, and the range check cannot
+            -- reach it because the check asks only for what the form shows.
+            [ test "still asks for the birth length it holds" <|
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm (Just savedWithoutSigns)
+                        |> (\resolved -> ( resolved.birthLengthAvailable, resolved.birthLength ))
+                        |> Expect.equal ( Just True, Just (HeightInCm 50) )
+            , test "still asks for the Apgar scores it holds" <|
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm (Just savedWithoutSigns)
+                        |> (\resolved -> ( resolved.apgarScoresAvailable, resolved.apgarOneMin, resolved.apgarFiveMin ))
+                        |> Expect.equal ( Just True, Just 8, Just 9 )
+            , test "asks for the Apgar scores when it holds only one of them" <|
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just { savedWithoutSigns | apgarOneMin = Nothing })
+                        |> .apgarScoresAvailable
+                        |> Expect.equal (Just True)
+            , test "asks for nothing it does not hold" <|
+                -- Otherwise the form would show empty inputs it never asked
+                -- for, and count them as tasks still to be done.
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just
+                            { savedWithoutSigns
+                                | apgarOneMin = Nothing
+                                , apgarFiveMin = Nothing
+                                , birthLength = Nothing
+                            }
+                        )
+                        |> (\resolved -> ( resolved.apgarScoresAvailable, resolved.birthLengthAvailable ))
+                        |> Expect.equal ( Just False, Just False )
+            , test "a sign with nothing stored is still asked for" <|
+                -- The sign is the answer the nurse gave, so it stands on its
+                -- own: were only the value asked, answering yes and saving
+                -- before entering anything would hide the question again.
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just
+                            { savedPregnancySummary
+                                | apgarOneMin = Nothing
+                                , apgarFiveMin = Nothing
+                                , birthLength = Nothing
+                            }
+                        )
+                        |> (\resolved -> ( resolved.apgarScoresAvailable, resolved.birthLengthAvailable ))
+                        |> Expect.equal ( Just True, Just True )
+            , test "the nurse saying no wins over what is stored" <|
+                -- She has answered the question in front of her; the value is
+                -- cleared alongside the answer.
+                \_ ->
+                    pregnancySummaryFormWithDefault
+                        { emptyPregnancySummaryForm
+                            | birthLengthAvailable = Just False
+                            , birthLengthDirty = True
+                        }
+                        (Just savedWithoutSigns)
+                        |> (\resolved -> ( resolved.birthLengthAvailable, resolved.birthLength ))
+                        |> Expect.equal ( Just False, Nothing )
+            , test "and the measurement it holds is then checked, which was the point" <|
+                -- A length of 0.5 was being written back out untouched, because
+                -- the check only asks for what the form shows.
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just { savedWithoutSigns | birthLength = Just (HeightInCm 0.5), apgarFiveMin = Just 30000 })
+                        |> pregnancySummaryMeasurementsOutOfRange SiteRwanda
+                        |> Expect.equal [ MeasurementApgarFiveMinutes, MeasurementBirthLength ]
+            ]
         ]

--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -11,13 +11,13 @@ import Backend.Model exposing (emptyModelIndexedDb)
 import Date
 import EverySet
 import Expect
-import Measurement.Model exposing (AnthropometricMeasurement(..), emptyHeightForm, emptyMuacForm, emptyWeightForm)
+import Measurement.Model exposing (RangedMeasurement(..), emptyHeightForm, emptyMuacForm, emptyWeightForm)
 import Pages.WellChild.Activity.Model exposing (Msg(..), WarningPopupType(..), emptyModel, emptyPregnancySummaryForm)
 import Pages.WellChild.Activity.Update exposing (update)
 import Pages.WellChild.Activity.Utils
     exposing
-        ( birthLengthOutsideConstraints
-        , pregnancySummaryFormWithDefault
+        ( pregnancySummaryFormWithDefault
+        , pregnancySummaryMeasurementsOutOfRange
         , resolveFirstEncounterDateAfterMilestone
         , resolveNextDateForECDVisit
         )
@@ -33,7 +33,7 @@ all =
         [ resolveFirstEncounterDateAfterMilestoneTests
         , resolveNextDateForECDVisitTests
         , pregnancySummaryFormWithDefaultTests
-        , birthLengthOutsideConstraintsTests
+        , pregnancySummaryMeasurementsOutOfRangeTests
         , nutritionAssessmentGateTests
         ]
 
@@ -106,52 +106,130 @@ nutritionAssessmentGateTests =
         ]
 
 
-birthLengthOutsideConstraintsTests : Test
-birthLengthOutsideConstraintsTests =
-    -- A newborn's length is around 50cm. The height range used elsewhere runs to
-    -- 250cm, which is a grown adult, so birth length has its own range.
+pregnancySummaryMeasurementsOutOfRangeTests : Test
+pregnancySummaryMeasurementsOutOfRangeTests =
     let
-        formWith available length =
+        lengthForm available length =
             { emptyPregnancySummaryForm
                 | birthLengthAvailable = available
                 , birthLength = Maybe.map HeightInCm length
             }
+
+        apgarForm available one five =
+            { emptyPregnancySummaryForm
+                | apgarScoresAvailable = available
+                , apgarOneMin = one
+                , apgarFiveMin = five
+            }
+
+        outOfRange =
+            pregnancySummaryMeasurementsOutOfRange SiteRwanda
     in
-    describe "birthLengthOutsideConstraints"
-        [ test "an ordinary birth length is in range" <|
+    describe "pregnancySummaryMeasurementsOutOfRange"
+        [ describe "the birth length"
+            -- A newborn's length is around 50cm. The height range used elsewhere
+            -- runs to 250cm, which is a grown adult, so birth length has its own.
+            [ test "an ordinary birth length is in range" <|
+                \_ ->
+                    outOfRange (lengthForm (Just True) (Just 50))
+                        |> Expect.equal []
+            , test "a length entered in metres is out of range" <|
+                \_ ->
+                    outOfRange (lengthForm (Just True) (Just 0.5))
+                        |> Expect.equal [ MeasurementBirthLength ]
+            , test "a length entered in millimetres is out of range" <|
+                \_ ->
+                    outOfRange (lengthForm (Just True) (Just 500))
+                        |> Expect.equal [ MeasurementBirthLength ]
+            , test "the ends of the range are accepted" <|
+                \_ ->
+                    ( outOfRange (lengthForm (Just True) (Just 15))
+                    , outOfRange (lengthForm (Just True) (Just 60))
+                    )
+                        |> Expect.equal ( [], [] )
+            , test "just outside either end is refused" <|
+                \_ ->
+                    ( outOfRange (lengthForm (Just True) (Just 14))
+                    , outOfRange (lengthForm (Just True) (Just 61))
+                    )
+                        |> Expect.equal ( [ MeasurementBirthLength ], [ MeasurementBirthLength ] )
+            , test "a length that has not been entered is not reported" <|
+                \_ ->
+                    outOfRange (lengthForm (Just True) Nothing)
+                        |> Expect.equal []
+            , test "a length is not reported when the form does not ask for one" <|
+                -- The input is hidden then, so stopping on it would leave the
+                -- form with nothing on screen to correct.
+                \_ ->
+                    outOfRange (lengthForm (Just False) (Just 0.5))
+                        |> Expect.equal []
+            ]
+        , describe "the Apgar scores"
+            -- A score out of 10. A quarter of the scores already stored are not
+            -- one: they run to 36, 246, and 30000.
+            [ test "an ordinary pair of scores is in range" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) (Just 8) (Just 9))
+                        |> Expect.equal []
+            , test "the ends of the range are accepted" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) (Just 0) (Just 10))
+                        |> Expect.equal []
+            , test "a score above 10 is refused, and says which one" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) (Just 36) (Just 9))
+                        |> Expect.equal [ MeasurementApgarOneMinute ]
+            , test "the five minute score is named on its own" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) (Just 8) (Just 30000))
+                        |> Expect.equal [ MeasurementApgarFiveMinutes ]
+            , test "both are named when both are wrong" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) (Just 11) (Just 246))
+                        |> Expect.equal [ MeasurementApgarOneMinute, MeasurementApgarFiveMinutes ]
+            , test "a score below zero is refused" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) (Just -1) (Just 9))
+                        |> Expect.equal [ MeasurementApgarOneMinute ]
+            , test "scores that have not been entered are not reported" <|
+                \_ ->
+                    outOfRange (apgarForm (Just True) Nothing Nothing)
+                        |> Expect.equal []
+            , test "scores are not reported when the form does not ask for them" <|
+                -- The inputs are hidden then, the same as the birth length.
+                \_ ->
+                    outOfRange (apgarForm (Just False) (Just 36) (Just 30000))
+                        |> Expect.equal []
+            ]
+        , describe "the birth weight, which is asked for every time"
+            [ test "a weight in grams is in range" <|
+                \_ ->
+                    outOfRange { emptyPregnancySummaryForm | birthWeight = Just (WeightInGrm 3200) }
+                        |> Expect.equal []
+            , test "a weight in kilograms is refused, though no question guards it" <|
+                \_ ->
+                    outOfRange { emptyPregnancySummaryForm | birthWeight = Just (WeightInGrm 3) }
+                        |> Expect.equal [ MeasurementBirthWeight ]
+            ]
+        , test "every measurement that is wrong is named, in the order the form asks them" <|
+            -- So that the nurse corrects them together rather than being sent
+            -- back once for each.
             \_ ->
-                birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 50))
-                    |> Expect.equal False
-        , test "a length entered in metres is out of range" <|
-            \_ ->
-                birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 0.5))
-                    |> Expect.equal True
-        , test "a length entered in millimetres is out of range" <|
-            \_ ->
-                birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 500))
-                    |> Expect.equal True
-        , test "the ends of the range are accepted" <|
-            \_ ->
-                ( birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 15))
-                , birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 60))
-                )
-                    |> Expect.equal ( False, False )
-        , test "just outside either end is refused" <|
-            \_ ->
-                ( birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 14))
-                , birthLengthOutsideConstraints SiteRwanda (formWith (Just True) (Just 61))
-                )
-                    |> Expect.equal ( True, True )
-        , test "a length that has not been entered is not reported" <|
-            \_ ->
-                birthLengthOutsideConstraints SiteRwanda (formWith (Just True) Nothing)
-                    |> Expect.equal False
-        , test "a length is not reported when the form does not ask for one" <|
-            -- The input is hidden then, so stopping on it would leave the form
-            -- with nothing on screen to correct.
-            \_ ->
-                birthLengthOutsideConstraints SiteRwanda (formWith (Just False) (Just 0.5))
-                    |> Expect.equal False
+                outOfRange
+                    { emptyPregnancySummaryForm
+                        | birthWeight = Just (WeightInGrm 3)
+                        , apgarScoresAvailable = Just True
+                        , apgarOneMin = Just 36
+                        , apgarFiveMin = Just 36
+                        , birthLengthAvailable = Just True
+                        , birthLength = Just (HeightInCm 0.5)
+                    }
+                    |> Expect.equal
+                        [ MeasurementBirthWeight
+                        , MeasurementApgarOneMinute
+                        , MeasurementApgarFiveMinutes
+                        , MeasurementBirthLength
+                        ]
         ]
 
 

--- a/client/src/elm/Pages/WellChild/Activity/Update.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Update.elm
@@ -16,11 +16,11 @@ import Maybe.Extra exposing (unwrap)
 import Measurement.Model
     exposing
         ( ImmunisationTask(..)
-        , RangedMeasurement(..)
+        , RangedMeasurement
         , VaccinationFormViewMode(..)
         , emptyPhotoForm
         )
-import Measurement.Utils exposing (birthWeightOutsideConstraints, contributingFactorsFormWithDefault, heightFormWithDefault, heightOutOfRange, muacFormWithDefault, muacOutOfRange, ncdaFormWithDefault, nutritionFormWithDefault, toAdministrationNoteWithDefault, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toSendToHCValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, vaccinationFormWithDefault, vaccineDoseToComparable, weightFormWithDefault, weightOutOfRange)
+import Measurement.Utils exposing (contributingFactorsFormWithDefault, heightFormWithDefault, heightOutOfRange, muacFormWithDefault, muacOutOfRange, ncdaFormWithDefault, nutritionFormWithDefault, toAdministrationNoteWithDefault, toContributingFactorsValueWithDefault, toHealthEducationValueWithDefault, toHeightValueWithDefault, toMuacValueWithDefault, toNCDAValueWithDefault, toNutritionCaringValueWithDefault, toNutritionFeedingValueWithDefault, toNutritionFollowUpValueWithDefault, toNutritionFoodSecurityValueWithDefault, toNutritionHygieneValueWithDefault, toNutritionValueWithDefault, toSendToHCValueWithDefault, toVaccinationValueWithDefault, toVitalsValueWithDefault, toWeightValueWithDefault, vaccinationFormWithDefault, vaccineDoseToComparable, weightFormWithDefault, weightOutOfRange)
 import Pages.Page exposing (Page(..), UserPage(..))
 import Pages.Utils exposing (insertIntoSet, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue)
 import Pages.WellChild.Activity.Model exposing (Model, Msg(..), WarningPopupType(..))

--- a/client/src/elm/Pages/WellChild/Activity/Update.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Update.elm
@@ -15,8 +15,8 @@ import Gizra.Update exposing (sequenceExtra)
 import Maybe.Extra exposing (unwrap)
 import Measurement.Model
     exposing
-        ( AnthropometricMeasurement(..)
-        , ImmunisationTask(..)
+        ( ImmunisationTask(..)
+        , RangedMeasurement(..)
         , VaccinationFormViewMode(..)
         , emptyPhotoForm
         )
@@ -24,7 +24,7 @@ import Measurement.Utils exposing (birthWeightOutsideConstraints, contributingFa
 import Pages.Page exposing (Page(..), UserPage(..))
 import Pages.Utils exposing (insertIntoSet, saveMeasurementMsgs, setMuacValueForSite, setMultiSelectInputValue)
 import Pages.WellChild.Activity.Model exposing (Model, Msg(..), WarningPopupType(..))
-import Pages.WellChild.Activity.Utils exposing (birthLengthOutsideConstraints, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, pregnancySummaryFormWithDefault, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType)
+import Pages.WellChild.Activity.Utils exposing (getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, pregnancySummaryFormWithDefault, pregnancySummaryMeasurementsOutOfRange, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType)
 import RemoteData exposing (RemoteData(..))
 import SyncManager.Model exposing (Site)
 
@@ -203,21 +203,10 @@ update currentDate site id db msg model =
         PreSavePregnancySummary personId saved ->
             let
                 outOfRange =
-                    -- Both are asked for behind the one button, so the nurse is
+                    -- They are asked for behind the one button, so the nurse is
                     -- told about each of them that is wrong rather than being
-                    -- sent back a second time for the other.
-                    List.filterMap identity
-                        [ if birthWeightOutsideConstraints site pregnancySummaryForm.birthWeight then
-                            Just MeasurementBirthWeight
-
-                          else
-                            Nothing
-                        , if birthLengthOutsideConstraints site pregnancySummaryForm then
-                            Just MeasurementBirthLength
-
-                          else
-                            Nothing
-                        ]
+                    -- sent back a second time for the next.
+                    pregnancySummaryMeasurementsOutOfRange site pregnancySummaryForm
 
                 extraMsgs =
                     if List.isEmpty outOfRange then
@@ -1993,7 +1982,7 @@ preSaveNutritionAssessment :
     -> ModelIndexedDb
     -> Model
     -> Msg
-    -> List AnthropometricMeasurement
+    -> List RangedMeasurement
     -> ( Model, Cmd Msg, List App.Model.Msg )
 preSaveNutritionAssessment currentDate site id db model saveMsg outOfRange =
     let

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.WellChild.Activity.Utils exposing (activityCompleted, albendazoleAdministrationFormConfig, birthLengthOutsideConstraints, dangerSignsTasksCompletedFromTotal, ecdSigns6To12MonthsMajors, ecdSignsFrom13Weeks, ecdSignsFrom5Weeks, expectActivity, expectImmunisationTask, expectMedicationTask, expectNextStepsTask, expectNutritionAssessmentTask, expectedECDSignsOnMilestone, generateASAPImmunisationDate, generateCompletedECDSigns, generateNextDateForImmunisationVisit, generateNextVisitDates, generateNutritionAssessment, generateRemianingECDSignsAfterCurrentEncounter, generateRemianingECDSignsBeforeCurrentEncounter, generateVitalsFormConfig, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, headCircumferenceFormAndTasks, headCircumferenceFormWithDefault, immunisationTasks, immunisationTasksCompletedFromTotal, mandatoryDangerSignsTasksCompleted, mandatoryNutritionAssessmentTasksCompleted, mebendezoleAdministrationFormConfig, medicationTasksCompletedFromTotal, nextStepsTasks, nextStepsTasksCompletedFromTotal, nextVisitFormWithDefault, nutritionAssessmentTaskCompleted, nutritionAssessmentTasksCompletedFromTotal, pregnancySummaryFormWithDefault, resolveFirstEncounterDateAfterMilestone, resolveNextDateForECDVisit, resolveNextDateForImmunisationVisit, resolveNutritionAssessmentTasks, symptomsReviewFormInputsAndTasks, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType, vaccinationFormDynamicContentAndTasks, vitaminAAdministrationFormConfig, wellChildECDFormWithDefault)
+module Pages.WellChild.Activity.Utils exposing (activityCompleted, albendazoleAdministrationFormConfig, dangerSignsTasksCompletedFromTotal, ecdSigns6To12MonthsMajors, ecdSignsFrom13Weeks, ecdSignsFrom5Weeks, expectActivity, expectImmunisationTask, expectMedicationTask, expectNextStepsTask, expectNutritionAssessmentTask, expectedECDSignsOnMilestone, generateASAPImmunisationDate, generateCompletedECDSigns, generateNextDateForImmunisationVisit, generateNextVisitDates, generateNutritionAssessment, generateRemianingECDSignsAfterCurrentEncounter, generateRemianingECDSignsBeforeCurrentEncounter, generateVitalsFormConfig, getFormByVaccineTypeFunc, getMeasurementByVaccineTypeFunc, headCircumferenceFormAndTasks, headCircumferenceFormWithDefault, immunisationTasks, immunisationTasksCompletedFromTotal, mandatoryDangerSignsTasksCompleted, mandatoryNutritionAssessmentTasksCompleted, mebendezoleAdministrationFormConfig, medicationTasksCompletedFromTotal, nextStepsTasks, nextStepsTasksCompletedFromTotal, nextVisitFormWithDefault, nutritionAssessmentTaskCompleted, nutritionAssessmentTasksCompletedFromTotal, pregnancySummaryFormWithDefault, pregnancySummaryMeasurementsOutOfRange, resolveFirstEncounterDateAfterMilestone, resolveNextDateForECDVisit, resolveNextDateForImmunisationVisit, resolveNutritionAssessmentTasks, symptomsReviewFormInputsAndTasks, symptomsReviewFormWithDefault, toHeadCircumferenceValueWithDefault, toNextVisitValueWithDefault, toPregnancySummaryValueWithDefault, toSymptomsReviewValueWithDefault, toWellChildECDValueWithDefault, updateVaccinationFormByVaccineType, vaccinationFormDynamicContentAndTasks, vitaminAAdministrationFormConfig, wellChildECDFormWithDefault)
 
 import AssocList as Dict exposing (Dict)
 import Backend.Measurement.Model exposing (..)
@@ -25,8 +25,8 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import List.Extra
 import Maybe.Extra exposing (andMap, isJust, or, unwrap)
-import Measurement.Model exposing (AnthropometricMeasurement(..), ImmunisationTask(..), InvokationModule(..), MedicationAdministrationFormConfig, VitalsFormConfig, VitalsFormMode(..))
-import Measurement.Utils exposing (anthropometricOutOfRange, behindOnVaccinationsByHistory, contributingFactorsFormWithDefault, expectVaccineDoseForPerson, generateFutureVaccinationsData, getAllDosesForVaccine, getIntervalForVaccine, getPreviousMeasurements, healthEducationFormWithDefault, heightFormWithDefault, immunisationTaskToVaccineType, initialVaccinationDateByBirthDate, isBehindOnVaccinationsByProgress, medicationAdministrationFormInputsAndTasks, medicationAdministrationFormWithDefault, muacFormWithDefault, nextVaccinationDataForVaccine, nutritionFollowUpFormWithDefault, nutritionFormWithDefault, sendToHCFormWithDefault, vaccinationFormWithDefault, vaccineDoseToComparable, vitalsFormWithDefault, wasFirstDoseAdministeredWithin14DaysFromBirthByVaccinationForm, wasInitialOpvAdministeredByVaccinationProgress, weightFormWithDefault)
+import Measurement.Model exposing (ImmunisationTask(..), InvokationModule(..), MedicationAdministrationFormConfig, RangedMeasurement(..), VitalsFormConfig, VitalsFormMode(..))
+import Measurement.Utils exposing (behindOnVaccinationsByHistory, contributingFactorsFormWithDefault, expectVaccineDoseForPerson, generateFutureVaccinationsData, getAllDosesForVaccine, getIntervalForVaccine, getPreviousMeasurements, healthEducationFormWithDefault, heightFormWithDefault, immunisationTaskToVaccineType, initialVaccinationDateByBirthDate, isBehindOnVaccinationsByProgress, measurementOutOfRange, medicationAdministrationFormInputsAndTasks, medicationAdministrationFormWithDefault, muacFormWithDefault, nextVaccinationDataForVaccine, nutritionFollowUpFormWithDefault, nutritionFormWithDefault, sendToHCFormWithDefault, vaccinationFormWithDefault, vaccineDoseToComparable, vitalsFormWithDefault, wasFirstDoseAdministeredWithin14DaysFromBirthByVaccinationForm, wasInitialOpvAdministeredByVaccinationProgress, weightFormWithDefault)
 import Measurement.View
     exposing
         ( contributingFactorsFormInutsAndTasks
@@ -210,20 +210,49 @@ expectActivity currentDate zscores site features isChw assembled db activity =
             assembled.encounter.encounterType == PediatricCareChw
 
 
-{-| True when a birth length has been entered on the newborn exam and is outside
-the range a newborn's length can take.
+{-| The measurements on the newborn exam that hold a value outside their range.
 
-Only asked when the form says a birth length is available: when it is not, the
-input is not shown, and stopping on a length that is nowhere to be seen would
-leave the form with no way out of it.
+Only what the form asks for is checked. Each of the Apgar scores and the birth
+length is behind a question of its own, and its input is not drawn when the
+answer is no - stopping on one that is nowhere to be seen would leave the form
+impossible to save.
+
+The birth weight is asked for every time, so it is checked every time.
 
 -}
-birthLengthOutsideConstraints : Site -> PregnancySummaryForm -> Bool
-birthLengthOutsideConstraints site form =
-    (form.birthLengthAvailable == Just True)
-        && anthropometricOutOfRange site
-            MeasurementBirthLength
-            (Maybe.map (\(HeightInCm length) -> length) form.birthLength)
+pregnancySummaryMeasurementsOutOfRange : Site -> PregnancySummaryForm -> List RangedMeasurement
+pregnancySummaryMeasurementsOutOfRange site form =
+    let
+        asked available value =
+            if available == Just True then
+                value
+
+            else
+                Nothing
+
+        apgar =
+            -- The score is out of 10, so a number that could not be one is
+            -- almost always something else typed into the box.
+            [ ( MeasurementApgarOneMinute, asked form.apgarScoresAvailable form.apgarOneMin )
+            , ( MeasurementApgarFiveMinutes, asked form.apgarScoresAvailable form.apgarFiveMin )
+            ]
+    in
+    List.filterMap
+        (\( measurement, value ) ->
+            if measurementOutOfRange site measurement value then
+                Just measurement
+
+            else
+                Nothing
+        )
+        (( MeasurementBirthWeight, Maybe.map (\(WeightInGrm weight) -> weight) form.birthWeight )
+            :: apgar
+            ++ [ ( MeasurementBirthLength
+                 , asked form.birthLengthAvailable form.birthLength
+                    |> Maybe.map (\(HeightInCm length) -> length)
+                 )
+               ]
+        )
 
 
 pregnancySummaryFormWithDefault : PregnancySummaryForm -> Maybe PregnancySummaryValue -> PregnancySummaryForm

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -232,7 +232,8 @@ pregnancySummaryMeasurementsOutOfRange site form =
 
         apgar =
             -- The score is out of 10, so a number that could not be one is
-            -- almost always something else typed into the box.
+            -- almost always something else typed into the box. Asked first,
+            -- because that is where the form asks for them.
             [ ( MeasurementApgarOneMinute, asked form.apgarScoresAvailable form.apgarOneMin )
             , ( MeasurementApgarFiveMinutes, asked form.apgarScoresAvailable form.apgarFiveMin )
             ]
@@ -245,9 +246,11 @@ pregnancySummaryMeasurementsOutOfRange site form =
             else
                 Nothing
         )
-        (( MeasurementBirthWeight, Maybe.map (\(WeightInGrm weight) -> weight) form.birthWeight )
-            :: apgar
-            ++ [ ( MeasurementBirthLength
+        (apgar
+            ++ [ ( MeasurementBirthWeight
+                 , Maybe.map (\(WeightInGrm weight) -> weight) form.birthWeight
+                 )
+               , ( MeasurementBirthLength
                  , asked form.birthLengthAvailable form.birthLength
                     |> Maybe.map (\(HeightInCm length) -> length)
                  )

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -281,6 +281,18 @@ pregnancySummaryFormWithDefault form saved =
 
                     signsFromValue =
                         EverySet.toList value.signs
+
+                    -- A record can hold a measurement without the sign that
+                    -- says it was asked for: the two are stored apart, and the
+                    -- signs fall back to none when they cannot be read. Asking
+                    -- the value as well as the sign makes what is stored
+                    -- visible, so the nurse can correct or confirm it and the
+                    -- range check can reach it. Were only the sign asked, the
+                    -- input would stay hidden while the measurement it holds
+                    -- was written back out on every save.
+                    asked sign values =
+                        List.member sign signsFromValue
+                            || List.any isJust values
                 in
                 { expectedDateConcluded = or form.expectedDateConcluded (Just value.expectedDateConcluded)
                 , dateSelectorPopupState = form.dateSelectorPopupState
@@ -288,13 +300,17 @@ pregnancySummaryFormWithDefault form saved =
                     or form.deliveryComplicationsPresent
                         (listNotEmptyWithException NoDeliveryComplications deliveryComplications |> Just)
                 , deliveryComplications = or form.deliveryComplications (Just deliveryComplications)
-                , apgarScoresAvailable = or form.apgarScoresAvailable (List.member ApgarScores signsFromValue |> Just)
+                , apgarScoresAvailable =
+                    or form.apgarScoresAvailable
+                        (asked ApgarScores [ value.apgarOneMin, value.apgarFiveMin ] |> Just)
                 , apgarOneMin = maybeValueConsideringIsDirtyField form.apgarDirty form.apgarOneMin (Maybe.andThen .apgarOneMin saved)
                 , apgarFiveMin = maybeValueConsideringIsDirtyField form.apgarDirty form.apgarFiveMin (Maybe.andThen .apgarFiveMin saved)
                 , apgarDirty = form.apgarDirty
                 , birthWeight = maybeValueConsideringIsDirtyField form.birthWeightDirty form.birthWeight (Maybe.andThen .birthWeight saved)
                 , birthWeightDirty = form.birthWeightDirty
-                , birthLengthAvailable = or form.birthLengthAvailable (List.member BirthLength signsFromValue |> Just)
+                , birthLengthAvailable =
+                    or form.birthLengthAvailable
+                        (asked BirthLength [ Maybe.map (\(HeightInCm length) -> length) value.birthLength ] |> Just)
                 , birthLength = maybeValueConsideringIsDirtyField form.birthLengthDirty form.birthLength (Maybe.andThen .birthLength saved)
                 , birthLengthDirty = form.birthLengthDirty
                 , birthDefectsPresent =

--- a/client/src/elm/Pages/WellChild/Test.elm
+++ b/client/src/elm/Pages/WellChild/Test.elm
@@ -6,7 +6,7 @@ import Date exposing (Unit(..))
 import Expect
 import Gizra.NominalDate exposing (diffMonths)
 import List.Extra
-import Measurement.Model exposing (AnthropometricMeasurement(..), emptyHeightForm, emptyMuacForm, emptyWeightForm)
+import Measurement.Model exposing (RangedMeasurement(..), emptyHeightForm, emptyMuacForm, emptyWeightForm)
 import Measurement.Utils exposing (heightOutOfRange, muacOutOfRange, weightOutOfRange)
 import Pages.WellChild.Activity.Utils exposing (resolveNextDateForImmunisationVisit)
 import Pages.WellChild.ProgressReport.View exposing (distributeByListIndex, resolveLastDayForMonthX)

--- a/client/src/elm/Translate.elm
+++ b/client/src/elm/Translate.elm
@@ -1059,7 +1059,7 @@ type TranslationId
     | MastitisRecommendedTreatmentHeader Bool
     | MastitisRecommendedTreatmentHelper
     | MeasurementNotTaken
-    | MeasurementOutOfRangeWarning Site Measurement.Model.AnthropometricMeasurement
+    | MeasurementOutOfRangeWarning Site Measurement.Model.RangedMeasurement
     | MedicationCausingHypertension MedicationCausingHypertension
     | MedicationCausingHypertensionQuestion
     | MedicalCondition MedicalCondition
@@ -12060,6 +12060,20 @@ translationSet trans =
 
         MeasurementOutOfRangeWarning site measurement ->
             case measurement of
+                Measurement.Model.MeasurementApgarFiveMinutes ->
+                    { english = "The Apgar score at five minutes is a score out of 10, not a measurement."
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
+                Measurement.Model.MeasurementApgarOneMinute ->
+                    { english = "The Apgar score at one minute is a score out of 10, not a measurement."
+                    , kinyarwanda = Nothing
+                    , kirundi = Nothing
+                    , somali = Nothing
+                    }
+
                 Measurement.Model.MeasurementBirthLength ->
                     { english = "Birth length is recorded in centimetres."
                     , kinyarwanda = Nothing


### PR DESCRIPTION
Fixes #2022. Part of #2006. Based on `i1998-birth-length-range` (#2007), where the newborn exam gate lives.

Noticed while investigating #2009, but a separate defect — #2009 stays open for the hidden-value shape it was written about (see the end of this description).

## Why this first

Production data (read-only query on `ihangane.live`, 596 pregnancy summaries):

| field | min | max | recorded | out of range |
|---|---|---|---|---|
| birth length | 4.5 | 65 | 32 | 3 (9%) |
| Apgar 1-minute | 0 | **3000** | 129 | **25 (19%)** |
| Apgar 5-minute | 0 | **30000** | 129 | **32 (25%)** |

The Apgar score is a score out of 10. A quarter of every five-minute score on record cannot be one. The out-of-range values cluster at 30–40 — 36 appears six times, then 30, 35, 15 — with a tail through 246, 3000, 30000. Whatever is being typed, it is not an Apgar score.

Nothing checked them: #2006 scoped itself to anthropometrics, so the worst-affected field on the form was the one field the mechanism never covered.

## The change

`AnthropometricMeasurement` becomes **`RangedMeasurement`**. Its own docblock said "a measurement of the body", which an Apgar score is not — the honest common property is "a number entered on a form, with a range it has to be within". `measurementConstraints` and `measurementOutOfRange` are renamed to match. Mechanical, 21 files.

Two variants are added, `MeasurementApgarOneMinute` and `MeasurementApgarFiveMinutes`, with a 0–10 range, and both are named on the warning the newborn exam already shows for a birth weight or birth length.

`birthLengthOutsideConstraints` is replaced by **`pregnancySummaryMeasurementsOutOfRange`**, which asks the whole form at once and returns everything wrong with it. The nurse is told about all of them together rather than being sent back once per measurement.

Each score is only checked when `apgarScoresAvailable == Just True`, exactly as the length is gated on `birthLengthAvailable` — the inputs are not drawn otherwise, and stopping on a field that is nowhere to be seen would leave the form impossible to save (#1983, #1998).

## Tests

20 cases replacing the 7 that were there, each existing birth-length case kept. Two conditions discrimination-tested separately:

| Broken | Caught by |
|---|---|
| the question no longer hides its scores | `scores are not reported when the form does not ask for them` (and the birth length equivalent) |
| the 0–10 range widened | the three "refused" cases, and only those |

2940 unit tests pass; `elm make src/elm/Main.elm` compiles 548 modules; `elm-format --validate` clean.

## Not in this PR

The rest of #2009 — a value stored without the sign that shows its input, then re-saved unchecked. **The production query found zero such records** (0 of 32 heights, 0 of 129 Apgar scores), so it is a latent hole rather than live damage, and it wants its own change.

The 57 records already holding impossible scores are not repaired here: a nurse only meets the check on re-save. Worth deciding separately whether they need a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)