### PR TITLE
Measurements: make sure a measurement the record still holds is asked for

### DIFF
--- a/client/src/elm/Pages/WellChild/Activity/Test.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Test.elm
@@ -321,6 +321,14 @@ savedPregnancySummary =
     }
 
 
+{-| The same record with its signs lost, which is what a decoder that cannot
+read them leaves behind. The measurements are still there.
+-}
+savedWithoutSigns : PregnancySummaryValue
+savedWithoutSigns =
+    { savedPregnancySummary | signs = EverySet.singleton NoPregnancySummarySigns }
+
+
 {-| Clearing a value (for example answering "Apgar scores available? No", which
 empties the scores and marks them dirty) must stay cleared when the form is
 rebuilt from the saved value. An untouched field still loads from the saved
@@ -369,4 +377,76 @@ pregnancySummaryFormWithDefaultTests =
                 resolve { emptyPregnancySummaryForm | birthLengthDirty = True }
                     |> .birthLength
                     |> Expect.equal Nothing
+        , describe "a record whose signs were lost"
+            -- The measurement and the sign that says it was asked for are
+            -- stored apart, and the signs fall back to none when they cannot be
+            -- read. The measurement is then live but its input is not drawn: it
+            -- is written back out on every save, and the range check cannot
+            -- reach it because the check asks only for what the form shows.
+            [ test "still asks for the birth length it holds" <|
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm (Just savedWithoutSigns)
+                        |> (\resolved -> ( resolved.birthLengthAvailable, resolved.birthLength ))
+                        |> Expect.equal ( Just True, Just (HeightInCm 50) )
+            , test "still asks for the Apgar scores it holds" <|
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm (Just savedWithoutSigns)
+                        |> (\resolved -> ( resolved.apgarScoresAvailable, resolved.apgarOneMin, resolved.apgarFiveMin ))
+                        |> Expect.equal ( Just True, Just 8, Just 9 )
+            , test "asks for the Apgar scores when it holds only one of them" <|
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just { savedWithoutSigns | apgarOneMin = Nothing })
+                        |> .apgarScoresAvailable
+                        |> Expect.equal (Just True)
+            , test "asks for nothing it does not hold" <|
+                -- Otherwise the form would show empty inputs it never asked
+                -- for, and count them as tasks still to be done.
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just
+                            { savedWithoutSigns
+                                | apgarOneMin = Nothing
+                                , apgarFiveMin = Nothing
+                                , birthLength = Nothing
+                            }
+                        )
+                        |> (\resolved -> ( resolved.apgarScoresAvailable, resolved.birthLengthAvailable ))
+                        |> Expect.equal ( Just False, Just False )
+            , test "a sign with nothing stored is still asked for" <|
+                -- The sign is the answer the nurse gave, so it stands on its
+                -- own: were only the value asked, answering yes and saving
+                -- before entering anything would hide the question again.
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just
+                            { savedPregnancySummary
+                                | apgarOneMin = Nothing
+                                , apgarFiveMin = Nothing
+                                , birthLength = Nothing
+                            }
+                        )
+                        |> (\resolved -> ( resolved.apgarScoresAvailable, resolved.birthLengthAvailable ))
+                        |> Expect.equal ( Just True, Just True )
+            , test "the nurse saying no wins over what is stored" <|
+                -- She has answered the question in front of her; the value is
+                -- cleared alongside the answer.
+                \_ ->
+                    pregnancySummaryFormWithDefault
+                        { emptyPregnancySummaryForm
+                            | birthLengthAvailable = Just False
+                            , birthLengthDirty = True
+                        }
+                        (Just savedWithoutSigns)
+                        |> (\resolved -> ( resolved.birthLengthAvailable, resolved.birthLength ))
+                        |> Expect.equal ( Just False, Nothing )
+            , test "and the measurement it holds is then checked, which was the point" <|
+                -- A length of 0.5 was being written back out untouched, because
+                -- the check only asks for what the form shows.
+                \_ ->
+                    pregnancySummaryFormWithDefault emptyPregnancySummaryForm
+                        (Just { savedWithoutSigns | birthLength = Just (HeightInCm 0.5), apgarFiveMin = Just 30000 })
+                        |> pregnancySummaryMeasurementsOutOfRange SiteRwanda
+                        |> Expect.equal [ MeasurementApgarFiveMinutes, MeasurementBirthLength ]
+            ]
         ]

--- a/client/src/elm/Pages/WellChild/Activity/Utils.elm
+++ b/client/src/elm/Pages/WellChild/Activity/Utils.elm
@@ -281,6 +281,18 @@ pregnancySummaryFormWithDefault form saved =
 
                     signsFromValue =
                         EverySet.toList value.signs
+
+                    -- A record can hold a measurement without the sign that
+                    -- says it was asked for: the two are stored apart, and the
+                    -- signs fall back to none when they cannot be read. Asking
+                    -- the value as well as the sign makes what is stored
+                    -- visible, so the nurse can correct or confirm it and the
+                    -- range check can reach it. Were only the sign asked, the
+                    -- input would stay hidden while the measurement it holds
+                    -- was written back out on every save.
+                    asked sign values =
+                        List.member sign signsFromValue
+                            || List.any isJust values
                 in
                 { expectedDateConcluded = or form.expectedDateConcluded (Just value.expectedDateConcluded)
                 , dateSelectorPopupState = form.dateSelectorPopupState
@@ -288,13 +300,17 @@ pregnancySummaryFormWithDefault form saved =
                     or form.deliveryComplicationsPresent
                         (listNotEmptyWithException NoDeliveryComplications deliveryComplications |> Just)
                 , deliveryComplications = or form.deliveryComplications (Just deliveryComplications)
-                , apgarScoresAvailable = or form.apgarScoresAvailable (List.member ApgarScores signsFromValue |> Just)
+                , apgarScoresAvailable =
+                    or form.apgarScoresAvailable
+                        (asked ApgarScores [ value.apgarOneMin, value.apgarFiveMin ] |> Just)
                 , apgarOneMin = maybeValueConsideringIsDirtyField form.apgarDirty form.apgarOneMin (Maybe.andThen .apgarOneMin saved)
                 , apgarFiveMin = maybeValueConsideringIsDirtyField form.apgarDirty form.apgarFiveMin (Maybe.andThen .apgarFiveMin saved)
                 , apgarDirty = form.apgarDirty
                 , birthWeight = maybeValueConsideringIsDirtyField form.birthWeightDirty form.birthWeight (Maybe.andThen .birthWeight saved)
                 , birthWeightDirty = form.birthWeightDirty
-                , birthLengthAvailable = or form.birthLengthAvailable (List.member BirthLength signsFromValue |> Just)
+                , birthLengthAvailable =
+                    or form.birthLengthAvailable
+                        (asked BirthLength [ Maybe.map (\(HeightInCm length) -> length) value.birthLength ] |> Just)
                 , birthLength = maybeValueConsideringIsDirtyField form.birthLengthDirty form.birthLength (Maybe.andThen .birthLength saved)
                 , birthLengthDirty = form.birthLengthDirty
                 , birthDefectsPresent =


### PR DESCRIPTION
Fixes #2009. Part of #2006. Based on #2021, which renames the type this touches and replaces `birthLengthOutsideConstraints`.

## The problem

A measurement and the sign that says it was asked for are stored apart, and `decodePregnancySummaryValue` falls back to `NoPregnancySummarySigns` when the signs cannot be read. A record in that state loads as:

- `birthLengthAvailable = Just False` → **the input is not drawn**
- `birthLength = Just (HeightInCm 0.5)` → **the value is still live**

The nurse sees nothing, can correct nothing, and every save writes `0.5` straight back out. The range check cannot reach it either, because it deliberately asks only about what the form shows — so the one thing #1998 was built to stop goes through untouched. The Apgar scores have the same shape behind their own question.

## The fix — option 2 from the issue

`pregnancySummaryFormWithDefault` now derives availability from **the value as well as the sign**:

```elm
asked sign values =
    List.member sign signsFromValue
        || List.any isJust values
```

What is stored becomes visible; the nurse confirms or corrects it; saving writes the sign back, so the record heals itself. The range check then covers it, with no change to the check.

**Nothing is cleared.** Option 1 in the issue (don not write unless available) would silently delete a stored length whenever the sign was missing — data loss rather than a display problem.

**The sign is still asked on its own**, so answering "yes" and saving before entering anything does not hide the question again.

## Production data — this is latent, not live

Read-only query against `ihangane.live`, all 596 `well_child_pregnancy_summary` records:

| | records | value without its sign | sign without a value |
|---|---|---|---|
| birth length | 32 | **0** | 0 |
| Apgar scores | 129 | **0** | 0 |

So the decoder fallback has never actually fired in production. This closes the hole before it opens rather than repairing damage — which is also why it costs nothing: deriving availability from a value does nothing when there is no value.

## Tests

7 new cases, and both halves of the condition discrimination-tested separately:

| Broken | Caught by |
|---|---|
| only the sign is asked (the bug) | `still asks for the birth length it holds`, `…the Apgar scores it holds`, `…when it holds only one of them`, `and the measurement it holds is then checked` |
| only the value is asked | `a sign with nothing stored is still asked for` |

That second one closed a gap in my own tests: the first run of that mutation failed nothing, so nothing pinned the sign-present-value-absent case.

Also covered: a form holding nothing is asked for nothing (so no empty inputs appear as tasks still to do), and the nurse answering "no" wins over what is stored.

2953 unit tests pass; `elm make src/elm/Main.elm` compiles 548 modules; `elm-format --validate` and `elm-review` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)