### PR TITLE
Patient merge: move the person references a merge leaves behind

### DIFF
--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -242,6 +242,11 @@ function _consolidate_patients_execute($original, $duplicate) {
   // person who no longer exists.
   $messages[] = _consolidate_patient_newborn_references($original, $duplicate);
 
+  // A group participation names the adult who brings the child, and that is
+  // the reference the delete cascade DOES follow - so leaving it behind would
+  // not dangle, it would soft-delete another child's enrolment.
+  $messages[] = _consolidate_patient_group_participations($original, $duplicate);
+
   // A WhatsApp record names the person a report was shared about. It carries no
   // encounter indicator, so it is not a measurement and the loop above never
   // sees it either.
@@ -521,6 +526,84 @@ function _consolidate_patient_whatsapp_records($original, $duplicate) {
 
   return format_string('WhatsApp records: @count re-pointed to the original.', [
     '@count' => count($record_ids),
+  ]);
+}
+
+/**
+ * Re-points group participations the duplicate patient holds as the adult.
+ *
+ * A pmtct_participant enrols a child in a group, and names the adult who brings
+ * them in field_adult. That is the one person reference where leaving the
+ * duplicate in place does not merely dangle: field_adult IS followed by the
+ * person-delete cascade, so marking the duplicate deleted soft-deletes the
+ * participation - and the child, who has nothing to do with this merge, loses
+ * a group enrolment.
+ *
+ * Participations where the duplicate is the CHILD are a separate matter, left
+ * alone here: _consolidate_session_content_validate() refuses the merge unless
+ * the original already participates in every group the duplicate has
+ * measurements in, so the enrolment the child needs is already there.
+ *
+ * Shards are cleared so the presave hook recomputes them. A participant is a
+ * two-person node - hedley_device_assign_shards() gives it the union of both
+ * persons' shards - and it leaves an already-populated field alone, so without
+ * this the participation would keep the duplicate's shards and miss any health
+ * center only the original belongs to.
+ *
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_patient_group_participations($original, $duplicate) {
+  $participant_ids = _hedley_patient_content_referencing_person($duplicate, [
+    'field_adult',
+  ], 'pmtct_participant');
+
+  // What the original already brings a child to, keyed child + group, so a
+  // participation it already holds is not created twice.
+  $existing = [];
+  $original_ids = _hedley_patient_content_referencing_person($original, [
+    'field_adult',
+  ], 'pmtct_participant');
+  foreach ($original_ids as $id) {
+    $wrapper = entity_metadata_wrapper('node', $id);
+    $key = $wrapper->field_person->getIdentifier() . ':' . $wrapper->field_clinic->getIdentifier();
+    $existing[$key] = TRUE;
+  }
+
+  $repointed = $dropped = 0;
+  foreach ($participant_ids as $id) {
+    $wrapper = entity_metadata_wrapper('node', $id);
+    $child = $wrapper->field_person->getIdentifier();
+    $key = $child . ':' . $wrapper->field_clinic->getIdentifier();
+
+    if ($child == $original || isset($existing[$key])) {
+      // Either the original is the child of this participation, so re-pointing
+      // would make it its own adult, or it already brings that child to that
+      // group. Redundant either way.
+      $wrapper->field_deleted->set(TRUE);
+      $wrapper->save();
+      $dropped++;
+      continue;
+    }
+
+    $wrapper->field_adult->set($original);
+    $wrapper->field_shards->set([]);
+    $wrapper->save();
+    // A later participation of the duplicate might now duplicate this one.
+    $existing[$key] = TRUE;
+    $repointed++;
+  }
+
+  return format_string('Group participations: @repointed re-pointed to the original, @dropped dropped as redundant.', [
+    '@repointed' => $repointed,
+    '@dropped' => $dropped,
   ]);
 }
 

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.drush.inc
@@ -242,6 +242,16 @@ function _consolidate_patients_execute($original, $duplicate) {
   // person who no longer exists.
   $messages[] = _consolidate_patient_newborn_references($original, $duplicate);
 
+  // A WhatsApp record names the person a report was shared about. It carries no
+  // encounter indicator, so it is not a measurement and the loop above never
+  // sees it either.
+  $messages[] = _consolidate_patient_whatsapp_records($original, $duplicate);
+
+  // A trace contact IS a measurement, so the loop above re-pointed the person
+  // who reported it. It holds a second reference - the person who was contacted
+  // - which the loop does not touch.
+  $messages[] = _consolidate_patient_trace_contact_referrals($original, $duplicate);
+
   // Mark duplicate patient as Deleted.
   $wrapper_duplicate->field_deleted->set(TRUE);
   $wrapper_duplicate->save();
@@ -476,6 +486,75 @@ function _consolidate_patient_newborn_references($original, $duplicate) {
 
   return format_string('Newborn references: @count re-pointed to the original.', [
     '@count' => count($participant_ids),
+  ]);
+}
+
+/**
+ * Re-points the duplicate patient's WhatsApp records at the original.
+ *
+ * A whatsapp_record names the person a report was shared about, through
+ * field_person. It carries no encounter indicator, so it is not a measurement
+ * type and the consolidation's measurement sweep never sees it. Left alone, the
+ * record of a report that was sent keeps naming a person who no longer exists.
+ *
+ * No shard handling: the bundle carries no field_shards at all, so there is
+ * nothing to recompute. It has no field_deleted either, which is why the
+ * person-delete cascade leaves the record in place rather than soft-deleting
+ * it along with the duplicate.
+ *
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_patient_whatsapp_records($original, $duplicate) {
+  $record_ids = _hedley_patient_content_referencing_person($duplicate, [
+    'field_person',
+  ], 'whatsapp_record');
+
+  _associate_content_by_field($record_ids, 'field_person', $original);
+
+  return format_string('WhatsApp records: @count re-pointed to the original.', [
+    '@count' => count($record_ids),
+  ]);
+}
+
+/**
+ * Re-points trace contacts that refer to the duplicate patient.
+ *
+ * An acute_illness_trace_contact is a measurement, so the sweep above already
+ * re-points its field_person - the person who reported the contact. It holds a
+ * second person reference the sweep does not touch: field_referred_person, the
+ * person who was contacted. When the duplicate is that person, the trace
+ * contact keeps naming them after the merge.
+ *
+ * No shard handling: a trace contact's shards derive from field_person, which
+ * the measurement sweep has already dealt with, not from field_referred_person.
+ *
+ * @param int $original
+ *   Node ID of the 'original' patient.
+ * @param int $duplicate
+ *   Node ID of the 'duplicate' patient.
+ *
+ * @return string
+ *   Success message.
+ *
+ * @throws EntityMetadataWrapperException
+ */
+function _consolidate_patient_trace_contact_referrals($original, $duplicate) {
+  $contact_ids = _hedley_patient_content_referencing_person($duplicate, [
+    'field_referred_person',
+  ], 'acute_illness_trace_contact');
+
+  _associate_content_by_field($contact_ids, 'field_referred_person', $original);
+
+  return format_string('Trace contact referrals: @count re-pointed to the original.', [
+    '@count' => count($contact_ids),
   ]);
 }
 

--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.module
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.module
@@ -157,10 +157,12 @@ function hedley_patient_recalculate_shards_for_person_content($person_id) {
   // and group and individual participants.
   //
   // The remaining person-reference fields are deliberately left out, because
-  // the content they point from does not take its shards from this person:
-  // an education session takes its shards from its health center, a pregnancy
-  // participant takes them from the parent, and a trace contact takes them
-  // from the encounter it was recorded at.
+  // the content they point from does not take its shards from the person named
+  // by THAT field: an education session takes its shards from its health
+  // center, a pregnancy participant takes them from the parent rather than the
+  // newborn, and a trace contact takes them from the person who reported it -
+  // its field_person - rather than from the person it refers to. A trace
+  // contact is still reached here, through field_person, which is correct.
   $association_fields = array_values(array_diff(
     hedley_general_get_person_association_fields(),
     [

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -224,30 +224,6 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   }
 
   /**
-   * Enrols a child in a group, brought by an adult.
-   *
-   * @param int $adult
-   *   The person who brings the child, held in field_adult.
-   * @param int $child
-   *   The enrolled child, held in field_person.
-   * @param int $clinic
-   *   The group node ID.
-   *
-   * @return int
-   *   The pmtct_participant node ID.
-   */
-  protected function createGroupParticipation($adult, $child, $clinic) {
-    $node = $this->drupalCreateNode(['type' => 'pmtct_participant']);
-    $wrapper = entity_metadata_wrapper('node', $node);
-    $wrapper->field_person->set($child);
-    $wrapper->field_adult->set($adult);
-    $wrapper->field_clinic->set($clinic);
-    $wrapper->save();
-
-    return $node->nid;
-  }
-
-  /**
    * Whether a node is still live, that is not marked deleted.
    *
    * @param int $nid
@@ -534,11 +510,11 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
     // participation moves to the original. Without this the cascade would
     // soft-delete it, and the child would lose an enrolment because someone
     // else was merged.
-    $clinic = $this->drupalCreateNode(['type' => 'clinic'])->nid;
+    $clinic = $this->createClinic();
     $child = $this->createPerson('Child16');
     $original = $this->createPerson('Original16');
     $duplicate = $this->createPerson('Duplicate16');
-    $participation = $this->createGroupParticipation($duplicate, $child, $clinic);
+    $participation = $this->createPMTCT($child, $duplicate, $clinic);
 
     _consolidate_patients_execute($original, $duplicate);
 
@@ -559,12 +535,12 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
 
     // 17. A participation the original already holds for the same child and
     // group is dropped rather than duplicated.
-    $clinic = $this->drupalCreateNode(['type' => 'clinic'])->nid;
+    $clinic = $this->createClinic();
     $child = $this->createPerson('Child17');
     $original = $this->createPerson('Original17');
     $duplicate = $this->createPerson('Duplicate17');
-    $kept = $this->createGroupParticipation($original, $child, $clinic);
-    $redundant = $this->createGroupParticipation($duplicate, $child, $clinic);
+    $kept = $this->createPMTCT($child, $original, $clinic);
+    $redundant = $this->createPMTCT($child, $duplicate, $clinic);
 
     _consolidate_patient_group_participations($original, $duplicate);
 
@@ -576,10 +552,10 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
 
     // 18. A participation where the original is the enrolled child is dropped,
     // rather than making the original its own adult.
-    $clinic = $this->drupalCreateNode(['type' => 'clinic'])->nid;
+    $clinic = $this->createClinic();
     $original = $this->createPerson('Original18');
     $duplicate = $this->createPerson('Duplicate18');
-    $selfReferential = $this->createGroupParticipation($duplicate, $original, $clinic);
+    $selfReferential = $this->createPMTCT($original, $duplicate, $clinic);
 
     _consolidate_patient_group_participations($original, $duplicate);
 

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -185,13 +185,69 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   }
 
   /**
+   * Creates a WhatsApp record about a person.
+   *
+   * @param int $person
+   *   The person the shared report is about.
+   *
+   * @return int
+   *   The whatsapp_record node ID.
+   */
+  protected function createWhatsAppRecord($person) {
+    $node = $this->drupalCreateNode(['type' => 'whatsapp_record']);
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_person->set($person);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * Creates a trace contact, reported by one person about another.
+   *
+   * @param int $reporter
+   *   The person who reported the contact, held in field_person.
+   * @param int $referred
+   *   The person who was contacted, held in field_referred_person.
+   *
+   * @return int
+   *   The acute_illness_trace_contact node ID.
+   */
+  protected function createTraceContact($reporter, $referred) {
+    $node = $this->drupalCreateNode(['type' => 'acute_illness_trace_contact']);
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_person->set($reporter);
+    $wrapper->field_referred_person->set($referred);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * The person a node names through a single-value person reference.
+   *
+   * @param int $nid
+   *   The node ID.
+   * @param string $field
+   *   The field name, for example 'field_referred_person'.
+   *
+   * @return int|null
+   *   The person node ID, or NULL.
+   */
+  protected function personNamedBy($nid, $field) {
+    return entity_metadata_wrapper('node', node_load($nid, NULL, TRUE))
+      ->{$field}->getIdentifier();
+  }
+
+  /**
    * Merging a duplicate transfers the content that references it.
    *
    * Covers the non-measurement links the merge has to move by hand:
-   * relationships (cases 1-6), education-session attendance (cases 7-9) and the
-   * pregnancy->newborn link (cases 10-11). All cases operate on disjoint
-   * people, so bundling them under one test method keeps the hedley-profile
-   * install (~5 min in CI) paid once.
+   * relationships (cases 1-6), education-session attendance (cases 7-9), the
+   * pregnancy->newborn link (cases 10-11), WhatsApp records (cases 12-13) and
+   * the second person reference on a trace contact (cases 14-15). All cases
+   * operate on disjoint people, so bundling them under one test method keeps
+   * the hedley-profile install (~5 min in CI) paid once.
    */
   public function testContentIsTransferredOnMerge() {
     // 1. A duplicate child's link to its mother moves to the original child.
@@ -369,6 +425,68 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
       $this->participantNewborn($participant),
       $originalChild,
       'The full merge re-points the pregnancy participant to the original child.'
+    );
+
+    // 12. A WhatsApp record about the duplicate names the original instead.
+    $original = $this->createPerson('Original12');
+    $duplicate = $this->createPerson('Duplicate12');
+    $record = $this->createWhatsAppRecord($duplicate);
+
+    _consolidate_patient_whatsapp_records($original, $duplicate);
+
+    $this->assertEqual(
+      $this->personNamedBy($record, 'field_person'),
+      $original,
+      'The WhatsApp record is about the original.'
+    );
+
+    // 13. The same through the full merge path, which is what proves the
+    // re-point happens before the duplicate is marked deleted.
+    $original = $this->createPerson('Original13');
+    $duplicate = $this->createPerson('Duplicate13');
+    $record = $this->createWhatsAppRecord($duplicate);
+
+    _consolidate_patients_execute($original, $duplicate);
+
+    $this->assertEqual(
+      $this->personNamedBy($record, 'field_person'),
+      $original,
+      'The full merge re-points the WhatsApp record to the original.'
+    );
+
+    // 14. A trace contact referring to the duplicate refers to the original.
+    // The reporter is a third person, which is the real shape: the duplicate is
+    // the person who was contacted, not the one who reported it.
+    $reporter = $this->createPerson('Reporter14');
+    $original = $this->createPerson('Original14');
+    $duplicate = $this->createPerson('Duplicate14');
+    $contact = $this->createTraceContact($reporter, $duplicate);
+
+    _consolidate_patient_trace_contact_referrals($original, $duplicate);
+
+    $this->assertEqual(
+      $this->personNamedBy($contact, 'field_referred_person'),
+      $original,
+      'The trace contact refers to the original.'
+    );
+    $this->assertEqual(
+      $this->personNamedBy($contact, 'field_person'),
+      $reporter,
+      'The person who reported the contact is left alone.'
+    );
+
+    // 15. The same through the full merge path.
+    $reporter = $this->createPerson('Reporter15');
+    $original = $this->createPerson('Original15');
+    $duplicate = $this->createPerson('Duplicate15');
+    $contact = $this->createTraceContact($reporter, $duplicate);
+
+    _consolidate_patients_execute($original, $duplicate);
+
+    $this->assertEqual(
+      $this->personNamedBy($contact, 'field_referred_person'),
+      $original,
+      'The full merge re-points the trace contact to the original.'
     );
   }
 

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -224,6 +224,46 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   }
 
   /**
+   * Enrols a child in a group, brought by an adult.
+   *
+   * @param int $adult
+   *   The person who brings the child, held in field_adult.
+   * @param int $child
+   *   The enrolled child, held in field_person.
+   * @param int $clinic
+   *   The group node ID.
+   *
+   * @return int
+   *   The pmtct_participant node ID.
+   */
+  protected function createGroupParticipation($adult, $child, $clinic) {
+    $node = $this->drupalCreateNode(['type' => 'pmtct_participant']);
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_person->set($child);
+    $wrapper->field_adult->set($adult);
+    $wrapper->field_clinic->set($clinic);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * Whether a node is still live, that is not marked deleted.
+   *
+   * @param int $nid
+   *   The node ID.
+   *
+   * @return bool
+   *   TRUE when field_deleted is not set.
+   */
+  protected function isLive($nid) {
+    $deleted = entity_metadata_wrapper('node', node_load($nid, NULL, TRUE))
+      ->field_deleted->value();
+
+    return empty($deleted);
+  }
+
+  /**
    * The person a node names through a single-value person reference.
    *
    * @param int $nid
@@ -244,8 +284,9 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
    *
    * Covers the non-measurement links the merge has to move by hand:
    * relationships (cases 1-6), education-session attendance (cases 7-9), the
-   * pregnancy->newborn link (cases 10-11), WhatsApp records (cases 12-13) and
-   * the second person reference on a trace contact (cases 14-15). All cases
+   * pregnancy->newborn link (cases 10-11), WhatsApp records (cases 12-13), the
+   * second person reference on a trace contact (cases 14-15) and the adult who
+   * brings a child to a group (cases 16-18). All cases
    * operate on disjoint people, so bundling them under one test method keeps
    * the hedley-profile install (~5 min in CI) paid once.
    */
@@ -487,6 +528,64 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
       $this->personNamedBy($contact, 'field_referred_person'),
       $original,
       'The full merge re-points the trace contact to the original.'
+    );
+
+    // 16. When the duplicate is the adult who brings a child to a group, the
+    // participation moves to the original. Without this the cascade would
+    // soft-delete it, and the child would lose an enrolment because someone
+    // else was merged.
+    $clinic = $this->drupalCreateNode(['type' => 'clinic'])->nid;
+    $child = $this->createPerson('Child16');
+    $original = $this->createPerson('Original16');
+    $duplicate = $this->createPerson('Duplicate16');
+    $participation = $this->createGroupParticipation($duplicate, $child, $clinic);
+
+    _consolidate_patients_execute($original, $duplicate);
+
+    $this->assertTrue(
+      $this->isLive($participation),
+      'The group participation survives the merge.'
+    );
+    $this->assertEqual(
+      $this->personNamedBy($participation, 'field_adult'),
+      $original,
+      'The original is now the adult who brings the child.'
+    );
+    $this->assertEqual(
+      $this->personNamedBy($participation, 'field_person'),
+      $child,
+      'The enrolled child is left alone.'
+    );
+
+    // 17. A participation the original already holds for the same child and
+    // group is dropped rather than duplicated.
+    $clinic = $this->drupalCreateNode(['type' => 'clinic'])->nid;
+    $child = $this->createPerson('Child17');
+    $original = $this->createPerson('Original17');
+    $duplicate = $this->createPerson('Duplicate17');
+    $kept = $this->createGroupParticipation($original, $child, $clinic);
+    $redundant = $this->createGroupParticipation($duplicate, $child, $clinic);
+
+    _consolidate_patient_group_participations($original, $duplicate);
+
+    $this->assertTrue($this->isLive($kept), 'The original keeps its own participation.');
+    $this->assertFalse(
+      $this->isLive($redundant),
+      'The duplicate participation for the same child and group is dropped.'
+    );
+
+    // 18. A participation where the original is the enrolled child is dropped,
+    // rather than making the original its own adult.
+    $clinic = $this->drupalCreateNode(['type' => 'clinic'])->nid;
+    $original = $this->createPerson('Original18');
+    $duplicate = $this->createPerson('Duplicate18');
+    $selfReferential = $this->createGroupParticipation($duplicate, $original, $clinic);
+
+    _consolidate_patient_group_participations($original, $duplicate);
+
+    $this->assertFalse(
+      $this->isLive($selfReferential),
+      'A participation naming the original on both sides is dropped.'
     );
   }
 

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -196,7 +196,13 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
   protected function createWhatsAppRecord($person) {
     $node = $this->drupalCreateNode(['type' => 'whatsapp_record']);
     $wrapper = entity_metadata_wrapper('node', $node);
+    // Everything the bundle marks required, so the fixture is a record that
+    // could exist rather than one that only survives because Drupal 7 skips
+    // field validation on a programmatic save.
     $wrapper->field_person->set($person);
+    $wrapper->field_date_measured->set(REQUEST_TIME);
+    $wrapper->field_phone_number->set('250780000000');
+    $wrapper->field_report_type->set('antenatal');
     $wrapper->save();
 
     return $node->nid;
@@ -218,6 +224,12 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
     $wrapper = entity_metadata_wrapper('node', $node);
     $wrapper->field_person->set($reporter);
     $wrapper->field_referred_person->set($referred);
+    $wrapper->field_date_measured->set(REQUEST_TIME);
+    // The bundle also marks field_acute_illness_encounter and field_nurse
+    // required, and both are left out on purpose. Without an encounter the
+    // contact is not discoverable as a measurement of the reporter, which is
+    // the state under test: field_referred_person has to be re-pointed by the
+    // new helper rather than swept up with the reporter's measurements.
     $wrapper->save();
 
     return $node->nid;


### PR DESCRIPTION
Fixes #2025.

The merge walks the duplicate patient's measurements, then re-points the references that are not measurements by hand. Three were still missed — the last three of the six in `hedley_general_get_person_association_fields()`.

## The change

**`_consolidate_patient_group_participations()`** — a `pmtct_participant` names the enrolled child in `field_person` and the adult who brings them in `field_adult`. **This is the one that loses data rather than dangling.** `field_adult` IS followed by `hedley_person_content_affected_by_deletion()`, so marking the duplicate deleted soft-deleted the participation — and a child with no involvement in the merge silently lost a group enrolment. Dedups against a participation the original already holds for the same child and group, and drops one where the original is the enrolled child rather than making it its own adult. Shards are cleared so the presave hook recomputes the union of both persons, as the relationship transfer does.

Participations where the duplicate is the *child* are deliberately untouched: `_consolidate_session_content_validate()` already refuses the merge unless the original participates in every group the duplicate has measurements in.

**`_consolidate_patient_whatsapp_records()`** — a `whatsapp_record` names the person a report was shared about, carries no encounter indicator (so the measurement sweep never finds it) and has no `field_deleted` (so the delete cascade leaves it in place). It kept naming a person who is no longer there.

**`_consolidate_patient_trace_contact_referrals()`** — a trace contact IS a measurement, so the sweep re-points `field_person`, the person who reported it. Its second reference, `field_referred_person`, stayed on the duplicate.

All three use `_hedley_patient_content_referencing_person()`, so none adds a new way of discovering content that references a person.

## Also

Corrects a comment in `hedley_patient.module` that said a trace contact takes its shards from the encounter it was recorded at. It takes them from `field_person`, which is why that field reaches trace contacts in the recompute and `field_referred_person` is the one excluded.

## Shards, checked rather than assumed

- `pmtct_participant` — two-person node, union of both, and `hedley_device_assign_shards()` skips an already-populated field, so the field is cleared before save.
- `whatsapp_record` — **has no `field_shards` at all**. My first draft cleared it and would have thrown.
- `acute_illness_trace_contact` — has shards, but they derive from `field_person`, which the measurement sweep already handles.

## Tests

Seven cases, 12-18, folded into `HedleyPatientConsolidation::testContentIsTransferredOnMerge()` as extra assertions rather than new methods, so the group keeps paying for one profile install:

- 12-13 WhatsApp records, directly and through the full merge
- 14-15 trace-contact referrals, including that the reporter in `field_person` is left alone
- 16 the participation survives the full merge, with the original as the adult and the child untouched — the case that fails on `develop`, where the cascade soft-deletes it
- 17 a participation the original already holds for the same child and group is dropped, not duplicated
- 18 a participation naming the original on both sides is dropped

## Scope, honestly

The WhatsApp and trace-contact halves repair nothing on live: zero records of either kind point at a soft-deleted person today, against 159 soft-deleted persons on Rwanda. The `field_adult` half is different in kind — it is silent data loss, and any past merge of an adult who brought a child to a group has already caused it. Repairing those is not in this PR; it belongs with B-120, which scopes retroactive repair of what past merges destroyed.

## Verification

`php -l` and phpcs Drupal + DrupalPractice clean on all three files. SimpleTest runs in CI — `ddev simpletest` executes the main tree, not a worktree.

## Review

`/code-review medium` found three, all verified and all handled: the missing `field_adult` (this PR now covers it), the trace-contact shard comment (corrected), and an unrelated pre-existing crash in `hedley_patient_recalculate_shards_for_person_content()`, which is being fixed separately.