### PR TITLE
Sync: skip what has no shards when recomputing a person's content

### DIFF
--- a/server/hedley/modules/custom/hedley_patient/hedley_patient.module
+++ b/server/hedley/modules/custom/hedley_patient/hedley_patient.module
@@ -199,6 +199,14 @@ function hedley_patient_recalculate_shards_for_person_content($person_id) {
 
   $nodes = node_load_multiple($ids);
   foreach ($nodes as $node) {
+    // Not everything that names a person is sharded. A whatsapp_record points
+    // at its person with field_person, so the query above returns it, but the
+    // bundle has no field_shards instance at all - asking a wrapper for it
+    // throws, and the person save this runs from would be aborted.
+    if (!field_info_instance('node', 'field_shards', $node->type)) {
+      continue;
+    }
+
     $wrapper = entity_metadata_wrapper('node', $node);
     $node_shards = $wrapper->field_shards->value(['identifier' => TRUE]);
 

--- a/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
+++ b/server/hedley/modules/custom/hedley_patient/tests/HedleyPatientConsolidation.test
@@ -416,6 +416,19 @@ class HedleyPatientConsolidation extends HedleyWebTestBase {
       $union,
       'Recalculating the child keeps the union on the relationship.'
     );
+
+    // A person can own content that is not sharded at all. A whatsapp_record
+    // names its person with field_person, so the recalculation finds it, but
+    // the bundle has no field_shards instance - asking a wrapper for one
+    // throws, and takes the person save that triggered this down with it.
+    $shared = $this->createPerson('SharedAboutB057', [$hc1]);
+    $record = $this->drupalCreateNode(['type' => 'whatsapp_record']);
+    $wrapper = entity_metadata_wrapper('node', $record);
+    $wrapper->field_person->set($shared);
+    $wrapper->save();
+
+    hedley_patient_recalculate_shards_for_person_content($shared);
+    $this->pass('Recalculating a person who has a WhatsApp record does not throw.');
   }
 
 }


### PR DESCRIPTION
Fixes #2027.

`hedley_patient_recalculate_shards_for_person_content()` asks for everything that names a person through `field_person`, `field_adult` or `field_related_to`, then reads `field_shards` off each node it loaded. A `whatsapp_record` names its person with `field_person`, so the query returns it — and the bundle has **no `field_shards` instance at all**, so `entity_metadata_wrapper(...)->field_shards->value()` throws `EntityMetadataWrapperException`, aborting the person save that triggered the recompute.

## Reaching it

Nothing unusual is required: **change the health center of a person who has ever had a report shared over WhatsApp.** `hedley_patient_node_update` calls the recompute only when a person's shards actually change, so that is the whole trigger. Live volumes on 2026-08-03: 275 whatsapp_records on Rwanda, 22 on Burundi.

## The fix

Ask each bundle whether it is sharded, rather than assuming everything that names a person is:

```php
if (!field_info_instance('node', 'field_shards', $node->type)) {
  continue;
}
```

`field_info_instance()` reads the cached field-info map, so this costs nothing per node.

Worth noting why the neighbouring code does not have the same bug: `hedley_person_content_affected_by_deletion()` runs the same query but filters to three known bundles (`pmtct_participant`, `relationship`, `individual_participant`). The recompute takes whatever comes back, so it needs the check.

## Test

Added to the existing `testLinkingRecordShardsSurviveRecalculation()` rather than a new method, so the class keeps paying for one profile install: a person with a WhatsApp record has their content recalculated, and the test asserts it completes. On `develop` this throws and fails the test.

## Provenance

Found by `/code-review medium` while reviewing #2026, and unrelated to it. That PR teaches the patient merge to re-point `whatsapp_record.field_person`; this one stops an unrelated code path crashing on the same bundle. They touch different functions and can merge in either order — both edit `HedleyPatientConsolidation.test`, in different places, so whichever lands second may want a trivial conflict resolution.

## Verification

`php -l` and phpcs Drupal + DrupalPractice clean on both files.