### PR TITLE
Exports: stop one export from swallowing another

### DIFF
--- a/server/hedley/modules/custom/hedley_view_export/hedley_view_export.module
+++ b/server/hedley/modules/custom/hedley_view_export/hedley_view_export.module
@@ -168,9 +168,29 @@ function hedley_view_export_add_item(string $type, string $view_name, string $di
     'range' => variable_get("hedley_view_export_range__{$view_name}", 500),
     'title' => $title,
   ];
-  hedley_general_add_task_to_advanced_queue_by_id(HEDLEY_VIEW_EXPORT_EXPORT_VIEW_QUEUE, 0, $arguments);
-  // Display a message and a link back to the view.
-  drupal_set_message(t('Exporting view. We will soon email you a link to @email', ['@email' => $user->mail]));
+  // The unique id has to name what is being exported. It was a hardcoded 0, so
+  // every export shared the title export_view_0: while one was queued - and a
+  // multi-batch export is queued again between batches, so that is its whole
+  // life - every other export request in the system was refused.
+  $unique_id = implode('_', [
+    $user->uid,
+    $view_name,
+    $display,
+    md5(serialize([$exposed_inputs, $context])),
+  ]);
+  $queued = hedley_general_add_task_to_advanced_queue_by_id(HEDLEY_VIEW_EXPORT_EXPORT_VIEW_QUEUE, $unique_id, $arguments);
+
+  if (!$queued) {
+    // Nothing will process the file that was created for this request, and the
+    // cleanup cron only removes files a queue item points at.
+    file_delete($file);
+    drupal_set_message(t('This export was not started. If you have just asked for the same one, it is already running.'), 'warning');
+  }
+  else {
+    drupal_set_message(t('Exporting view. We will soon email you a link to @email', ['@email' => $user->mail]));
+  }
+
+  // A link back to the view, whichever of the two messages was shown.
   return '<a href="javascript:history.back()">' . t('Go back') . '</a>';
 }
 


### PR DESCRIPTION
Fixes #2029.

Every export was queued under the title `export_view_0`, because the unique id passed to `hedley_general_add_task_to_advanced_queue_by_id()` was a hardcoded `0`. While any export was queued — and a multi-batch export returns to queued between batches, so that is its whole life — every other export request in the system was refused. Silently: the return was discarded and the same "we will soon email you a link" message was shown either way, so the second person to ask was told their export was coming and then never received an email.

## The change

The id now names what is being exported — user, view, display and a hash of the filters. The filters matter: the same view of health center A and of health center B are different exports. A refusal now says so, and deletes the empty file created for the request, which the cleanup cron cannot collect because it only walks files a queue item points at.

The message deliberately does not say *which* refusal it was. The two possibilities are a duplicate and a failed queue insert; the second already reports itself, and distinguishing them afterwards costs more than it is worth here.

23 lines, one file.

## Verification

`php -l` and phpcs Drupal + DrupalPractice clean. The dedup behaviour was exercised against the real queue on a local site — same helper, same table:

```
first request (user 7, view A):       queued
same user, same view again:           refused   <- as intended
different user, same view:            queued
same user, different view:            queued
--- old hardcoded 0 ---
user 7 asks:                          queued
unrelated user 9, different view:     refused   <- the bug
```

## Scope

This PR covers B-005 only. **B-087** — the worker abandoning a fully built CSV when the final-batch email fails — was originally in this branch and has since been parked: it needs the mail step retried in isolation, which is expensive to get right, on a feature that has produced three exports in its lifetime, the most recent in June 2025.

Note the branch name still carries `b005-b087` from that earlier scope, and the review threads above refer to a larger version of this change that was reset and rewritten.