### PR TITLE
Send backend error logs to GlitchTip instead of Rollbar

### DIFF
--- a/server/default.config.sh
+++ b/server/default.config.sh
@@ -33,6 +33,15 @@ MYSQL_HOSTNAME="127.0.0.1"
 MYSQL_DB_NAME="drupal_elm_starter"
 
 
+# GlitchTip error reporting.
+# The DSN is an ingest key, so it is never committed. Leave it empty to keep
+# error reporting off, which is what local and CI environments want.
+# The environment name is what identifies a self-hosted server as a real
+# deployment; without it nothing is sent even when a DSN is present.
+GLITCHTIP_DSN=""
+GLITCHTIP_ENVIRONMENT=""
+
+
 # Pantheon deployment details
 PROFILE="hedley"
 MAKE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/server/hedley/drupal-org.make
+++ b/server/hedley/drupal-org.make
@@ -66,6 +66,10 @@ projects[jquery_update][version] = "2.4"
 projects[libraries][subdir] = "contrib"
 projects[libraries][version] = "2.5"
 
+; Superseded by the logs_glitchtip module, but still enabled in databases that
+; have not run hedley_update_7048() yet. Since logs_rollbar implements
+; hook_boot(), dropping the code before that update runs would break the
+; bootstrap. Remove once every environment is updated.
 projects[logs_rollbar][type] = "module"
 projects[logs_rollbar][subdir] = "contrib"
 projects[logs_rollbar][download][type] = "git"

--- a/server/hedley/hedley.info
+++ b/server/hedley/hedley.info
@@ -40,6 +40,9 @@ dependencies[] = token
 dependencies[] = views
 dependencies[] = views_bulk_operations
 
+; Error reporting
+dependencies[] = logs_glitchtip
+
 ; Hedley
 dependencies[] = hedley_activity
 dependencies[] = hedley_acute_illness

--- a/server/hedley/hedley.install
+++ b/server/hedley/hedley.install
@@ -753,3 +753,17 @@ function hedley_update_7046() {
 function hedley_update_7047() {
   module_enable(['hedley_family_nutrition']);
 }
+
+/**
+ * Replace Rollbar error reporting with GlitchTip.
+ *
+ * The old module is only disabled, not uninstalled, so its code can stay in
+ * the build until every environment has run this update.
+ */
+function hedley_update_7048() {
+  module_disable(['logs_rollbar']);
+  module_enable(['logs_glitchtip']);
+
+  variable_del('logs_rollbar_enabled');
+  variable_del('logs_rollbar_rollbar_access_token');
+}

--- a/server/hedley/hedley.profile
+++ b/server/hedley/hedley.profile
@@ -55,9 +55,10 @@ function hedley_setup_variables() {
     'restful_file_upload' => 1,
     // Files settings.
     'file_default_scheme' => 'public',
-    // Rollbar settings.
-    'logs_rollbar_enabled' => TRUE,
-    'logs_rollbar_rollbar_access_token' => '4cd2c323d59d422bb838f87a8bc84ba7',
+    // Error reporting. The GlitchTip DSN is deliberately not set here: it is
+    // an ingest key and this repository is public. See the logs_glitchtip
+    // README for where operators configure it.
+    'logs_glitchtip_enabled' => TRUE,
   );
 
   foreach ($variables as $key => $value) {

--- a/server/hedley/modules/custom/logs_glitchtip/README.md
+++ b/server/hedley/modules/custom/logs_glitchtip/README.md
@@ -25,6 +25,32 @@ For a scripted install, put the DSN in `server/config.sh` (gitignored, copied
 from `server/default.config.sh`); the install and reset scripts push it into
 the Drupal variable.
 
+### On Pantheon
+
+Pantheon offers no way to set an environment variable for a Drupal 7 site, so
+the DSN has to reach the Drupal variable instead. Two options, per Pantheon
+site:
+
+- **Drush, once per environment.** Simplest, and the value travels along when
+  the database is cloned Dev ← Live:
+  ```bash
+  terminus remote:drush <site>.<env> -- vset logs_glitchtip_dsn '<dsn>'
+  ```
+- **`sites/default/settings.php` in the Pantheon repository** (private, and
+  excluded from the deploy rsync, so it is never overwritten):
+  ```php
+  $conf['logs_glitchtip_dsn'] = '<dsn>';
+  ```
+  This wins over the database value, so the settings form then has no effect.
+
+The environment name needs no configuration here: it is derived from
+`PANTHEON_SITE_NAME` and `PANTHEON_ENVIRONMENT`, which keeps Dev, Test and Live
+apart even though they share a cloned database.
+
+The `sentry/sdk` package must be present in `sites/all/vendor` before a deploy
+— Composer runs locally, not on Pantheon, and the deploy commits the vendor
+directory. Without it the module silently reports nothing.
+
 ## Environment name
 
 The environment reported to GlitchTip is taken from the

--- a/server/hedley/modules/custom/logs_glitchtip/README.md
+++ b/server/hedley/modules/custom/logs_glitchtip/README.md
@@ -1,0 +1,38 @@
+# Logs GlitchTip
+
+Sends watchdog events to GlitchTip over the Sentry protocol, using the
+`sentry/sdk` package pulled in by Composer Manager.
+
+Events at or below the configured severity threshold (`WATCHDOG_ERROR` by
+default) are collected during the request, deduplicated, and sent in a single
+batch on shutdown. Uncaught exceptions are captured with their trace.
+
+## Configuring the DSN
+
+This repository is public and a GlitchTip DSN is an ingest key, so no DSN is
+committed. Nothing is sent until one is configured; a fresh checkout, DDEV and
+CI therefore stay silent.
+
+The DSN is read from, in order of precedence:
+
+1. The `logs_glitchtip_dsn` Drupal variable. Set it with
+   `drush vset logs_glitchtip_dsn '<dsn>'`, from `$conf['logs_glitchtip_dsn']`
+   in `settings.php`, or on the settings form at
+   `/admin/config/services/logs-glitchtip-settings`.
+2. The `GLITCHTIP_DSN` environment variable.
+
+For a scripted install, put the DSN in `server/config.sh` (gitignored, copied
+from `server/default.config.sh`); the install and reset scripts push it into
+the Drupal variable.
+
+## Environment name
+
+The environment reported to GlitchTip is taken from the
+`logs_glitchtip_environment` variable, then the `GLITCHTIP_ENVIRONMENT`
+environment variable, then `<pantheon site>.<pantheon environment>`, and
+finally `local`.
+
+The country servers are self-hosted and expose no vendor environment variable,
+so they must set one of the first two. That is also what tells the module the
+site is a real deployment rather than a developer machine — without it,
+`logs_glitchtip_auto_disable_on_local` suppresses everything.

--- a/server/hedley/modules/custom/logs_glitchtip/composer.json
+++ b/server/hedley/modules/custom/logs_glitchtip/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "sentry/sdk": "^3.6"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/server/hedley/modules/custom/logs_glitchtip/composer.json
+++ b/server/hedley/modules/custom/logs_glitchtip/composer.json
@@ -1,10 +1,10 @@
 {
-    "require": {
-        "sentry/sdk": "^3.6"
-    },
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true
-        }
+  "require": {
+    "sentry/sdk": "^3.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
     }
+  }
 }

--- a/server/hedley/modules/custom/logs_glitchtip/composer.json
+++ b/server/hedley/modules/custom/logs_glitchtip/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "sentry/sdk": "^3.6"
+    }
+}

--- a/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.admin.inc
+++ b/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.admin.inc
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Admin settings for the Logs GlitchTip module.
+ */
+
+/**
+ * Admin settings form.
+ *
+ * @param array $form
+ *   The form array.
+ * @param array $form_state
+ *   The form state array.
+ *
+ * @return array
+ *   The settings form.
+ */
+function logs_glitchtip_admin_settings(array $form, array &$form_state) {
+  $form['logs_glitchtip_enabled'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enabled'),
+    '#description' => t('Send watchdog events to GlitchTip.'),
+    '#default_value' => variable_get('logs_glitchtip_enabled', TRUE),
+  ];
+
+  $form['logs_glitchtip_dsn'] = [
+    '#type' => 'textfield',
+    '#title' => t('DSN'),
+    '#description' => t('The GlitchTip project DSN. Leave empty to fall back to the GLITCHTIP_DSN environment variable; when neither is set, nothing is sent.'),
+    '#default_value' => variable_get('logs_glitchtip_dsn', ''),
+  ];
+
+  $form['logs_glitchtip_severity_level'] = [
+    '#type' => 'select',
+    '#title' => t('Severity threshold'),
+    '#description' => t('Events with this severity or worse are sent.'),
+    '#options' => watchdog_severity_levels(),
+    '#default_value' => variable_get('logs_glitchtip_severity_level', WATCHDOG_ERROR),
+  ];
+
+  $form['logs_glitchtip_environment'] = [
+    '#type' => 'textfield',
+    '#title' => t('Environment'),
+    '#description' => t('Environment name reported to GlitchTip, for example "rwanda-live". Leave empty to auto-detect.'),
+    '#default_value' => variable_get('logs_glitchtip_environment', ''),
+  ];
+
+  $form['logs_glitchtip_auto_disable_on_local'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Auto disable on local'),
+    '#description' => t('Do not send events from environments that were not identified as a real deployment.'),
+    '#default_value' => variable_get('logs_glitchtip_auto_disable_on_local', TRUE),
+  ];
+
+  return system_settings_form($form);
+}

--- a/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.info
+++ b/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.info
@@ -1,0 +1,6 @@
+name = Logs GlitchTip
+description = "Sends watchdog errors to GlitchTip over the Sentry protocol."
+core = "7.x"
+package = "Hedley"
+
+dependencies[] = composer_manager

--- a/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.install
+++ b/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Install hooks for the Logs GlitchTip module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function logs_glitchtip_uninstall() {
+  variable_del('logs_glitchtip_enabled');
+  variable_del('logs_glitchtip_dsn');
+  variable_del('logs_glitchtip_severity_level');
+  variable_del('logs_glitchtip_environment');
+  variable_del('logs_glitchtip_auto_disable_on_local');
+}

--- a/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.module
+++ b/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.module
@@ -51,6 +51,13 @@ function logs_glitchtip_permission() {
  * Runs even for cached pages.
  */
 function logs_glitchtip_boot() {
+  // Replacing the global exception handler is a visible behaviour change, so
+  // only do it where events are actually reported. Unconfigured sites, local
+  // machines and CI keep Drupal's own handler.
+  if (!logs_glitchtip_is_active()) {
+    return;
+  }
+
   drupal_register_shutdown_function('logs_glitchtip_shutdown');
   set_exception_handler('_logs_glitchtip_exception_handler');
 }
@@ -105,7 +112,8 @@ function _logs_glitchtip_decode_exception(Throwable $exception) {
   $return = _drupal_decode_exception($exception);
 
   // Serialize and encode so the trace survives the watchdog variables
-  // round-trip without notices; decoded again in hook_watchdog().
+  // round-trip without notices; _logs_glitchtip_decode_trace() turns it back
+  // into readable frames.
   try {
     $return['exception_trace'] = drupal_base64_encode(serialize($exception->getTrace()));
   }
@@ -159,9 +167,7 @@ function logs_glitchtip_register_event(array $log_entry) {
   ];
 
   if (!empty($log_entry['variables']['exception_trace'])) {
-    // drupal_base64_encode() produces URL-safe base64; map it back before
-    // decoding, as base64_decode() would silently drop '-' and '_'.
-    $event['exception_trace'] = base64_decode(strtr($log_entry['variables']['exception_trace'], ['-' => '+', '_' => '/']));
+    $event['exception_trace'] = _logs_glitchtip_decode_trace($log_entry['variables']['exception_trace']);
   }
 
   // Prevent identical events.
@@ -169,6 +175,53 @@ function logs_glitchtip_register_event(array $log_entry) {
   unset($event_clone['timestamp']);
   $key = md5(serialize($event_clone));
   $events[$key] = $event;
+}
+
+/**
+ * Turn an encoded exception trace back into readable frames.
+ *
+ * Call arguments are dropped: they can hold entities, passwords or unbounded
+ * structures, none of which belong in an error report.
+ *
+ * @param string $encoded
+ *   The trace as put on the watchdog variables by
+ *   _logs_glitchtip_decode_exception().
+ *
+ * @return array|string
+ *   One "file(line): Class::method()" string per frame, or the raw decoded
+ *   value when it does not hold a trace.
+ */
+function _logs_glitchtip_decode_trace($encoded) {
+  // drupal_base64_encode() produces URL-safe base64; map it back before
+  // decoding, as base64_decode() would silently drop '-' and '_'.
+  $decoded = base64_decode(strtr($encoded, ['-' => '+', '_' => '/']));
+
+  // Objects held by the frames are never restored: only their file, line and
+  // name are read.
+  $trace = @unserialize($decoded, ['allowed_classes' => FALSE]);
+  if (!is_array($trace)) {
+    // The failed-to-serialize path stores a plain message instead of a trace;
+    // a truncated value does not unserialize at all.
+    return is_string($trace) ? $trace : $decoded;
+  }
+
+  $frames = [];
+  foreach ($trace as $frame) {
+    $call = '';
+    if (!empty($frame['class'])) {
+      $call = $frame['class'] . (isset($frame['type']) ? $frame['type'] : '::');
+    }
+    $call .= (isset($frame['function']) ? $frame['function'] : '[unknown]') . '()';
+
+    $location = isset($frame['file']) ? $frame['file'] : '[internal function]';
+    if (isset($frame['line'])) {
+      $location .= '(' . $frame['line'] . ')';
+    }
+
+    $frames[] = $location . ': ' . $call;
+  }
+
+  return $frames;
 }
 
 /**
@@ -277,7 +330,35 @@ function logs_glitchtip_get_dsn() {
     return $dsn;
   }
 
-  return (string) getenv('GLITCHTIP_DSN');
+  return _logs_glitchtip_getenv('GLITCHTIP_DSN');
+}
+
+/**
+ * Read an environment variable.
+ *
+ * Pantheon injects PANTHEON_* into the superglobals rather than the process
+ * environment, so getenv() alone reports nothing there and every deployment
+ * would look local.
+ *
+ * @param string $name
+ *   The variable name.
+ *
+ * @return string
+ *   The value, or an empty string when it is not set.
+ */
+function _logs_glitchtip_getenv($name) {
+  $value = getenv($name);
+  if ($value !== FALSE && $value !== '') {
+    return (string) $value;
+  }
+
+  foreach ([$_ENV, $_SERVER] as $source) {
+    if (!empty($source[$name])) {
+      return (string) $source[$name];
+    }
+  }
+
+  return '';
 }
 
 /**
@@ -315,14 +396,14 @@ function logs_glitchtip_get_environment() {
     return $environment;
   }
 
-  if ($environment = getenv('GLITCHTIP_ENVIRONMENT')) {
+  if ($environment = _logs_glitchtip_getenv('GLITCHTIP_ENVIRONMENT')) {
     return $environment;
   }
 
   // The same codebase runs on several Pantheon sites (one per country), so
   // the site name is needed to tell "live" apart from "live".
-  $pantheon_site = getenv('PANTHEON_SITE_NAME');
-  $pantheon_env = getenv('PANTHEON_ENVIRONMENT');
+  $pantheon_site = _logs_glitchtip_getenv('PANTHEON_SITE_NAME');
+  $pantheon_env = _logs_glitchtip_getenv('PANTHEON_ENVIRONMENT');
   if ($pantheon_site && $pantheon_env) {
     return $pantheon_site . '.' . $pantheon_env;
   }
@@ -341,22 +422,22 @@ function logs_glitchtip_get_environment() {
  *   TRUE when the site is considered local.
  */
 function logs_glitchtip_is_local() {
-  if (variable_get('logs_glitchtip_environment', '') || getenv('GLITCHTIP_ENVIRONMENT')) {
+  if (variable_get('logs_glitchtip_environment', '') || _logs_glitchtip_getenv('GLITCHTIP_ENVIRONMENT')) {
     return FALSE;
   }
 
   // Pantheon unique ID.
-  if (getenv('PANTHEON_SITE_NAME')) {
+  if (_logs_glitchtip_getenv('PANTHEON_SITE_NAME')) {
     return FALSE;
   }
 
   // Platform.sh unique ID.
-  if (getenv('PLATFORM_ENVIRONMENT')) {
+  if (_logs_glitchtip_getenv('PLATFORM_ENVIRONMENT')) {
     return FALSE;
   }
 
   // Acquia unique ID.
-  if (getenv('AH_SITE_GROUP')) {
+  if (_logs_glitchtip_getenv('AH_SITE_GROUP')) {
     return FALSE;
   }
 

--- a/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.module
+++ b/server/hedley/modules/custom/logs_glitchtip/logs_glitchtip.module
@@ -1,0 +1,364 @@
+<?php
+
+/**
+ * @file
+ * Sends watchdog events to GlitchTip via the Sentry PHP SDK.
+ *
+ * Events are collected during the request by hook_watchdog(), deduplicated,
+ * and sent in one batch on shutdown.
+ *
+ * The DSN is never hardcoded: this repository is public and a DSN is an
+ * ingest key. See README.md for where operators are expected to set it.
+ */
+
+use Sentry\Severity;
+
+/**
+ * Implements hook_menu().
+ */
+function logs_glitchtip_menu() {
+  $items = [];
+
+  $items['admin/config/services/logs-glitchtip-settings'] = [
+    'type' => MENU_NORMAL_ITEM,
+    'title' => 'Logs GlitchTip Client',
+    'description' => 'Administer GlitchTip Client settings.',
+    'access arguments' => ['administer glitchtip'],
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['logs_glitchtip_admin_settings'],
+    'file' => 'logs_glitchtip.admin.inc',
+  ];
+
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function logs_glitchtip_permission() {
+  $permissions = [];
+
+  $permissions['administer glitchtip'] = [
+    'title' => t('Administer GlitchTip'),
+  ];
+
+  return $permissions;
+}
+
+/**
+ * Implements hook_boot().
+ *
+ * Runs even for cached pages.
+ */
+function logs_glitchtip_boot() {
+  drupal_register_shutdown_function('logs_glitchtip_shutdown');
+  set_exception_handler('_logs_glitchtip_exception_handler');
+}
+
+/**
+ * Provides custom PHP exception handling.
+ *
+ * Uncaught exceptions are those not enclosed in a try/catch block. They are
+ * always fatal: the execution of the script will stop as soon as the exception
+ * handler exits.
+ *
+ * @param Throwable $exception
+ *   The exception object that was thrown.
+ *
+ * @see _drupal_exception_handler()
+ */
+function _logs_glitchtip_exception_handler(Throwable $exception) {
+  require_once DRUPAL_ROOT . '/includes/errors.inc';
+
+  try {
+    // Log the message to the watchdog and return an error page to the user.
+    _drupal_log_error(_logs_glitchtip_decode_exception($exception), TRUE);
+  }
+  catch (Exception $exception2) {
+    // Add a 500 status code in case an exception was thrown before the 500
+    // status could be set.
+    drupal_add_http_header('Status', '500 Internal Server Error');
+
+    // Another uncaught exception was thrown while handling the first one.
+    // If we are displaying errors, then do so with no possibility of a
+    // further uncaught exception being thrown.
+    if (error_displayable()) {
+      print '<h1>Additional uncaught exception thrown while handling exception.</h1>';
+      print '<h2>Original</h2><p>' . _drupal_render_exception_safe($exception) . '</p>';
+      print '<h2>Additional</h2><p>' . _drupal_render_exception_safe($exception2) . '</p><hr />';
+    }
+  }
+}
+
+/**
+ * Decodes an exception and retrieves the correct caller.
+ *
+ * @param Throwable $exception
+ *   The exception object that was thrown.
+ *
+ * @return array
+ *   An error in the format expected by _drupal_log_error().
+ *
+ * @see _drupal_decode_exception()
+ */
+function _logs_glitchtip_decode_exception(Throwable $exception) {
+  $return = _drupal_decode_exception($exception);
+
+  // Serialize and encode so the trace survives the watchdog variables
+  // round-trip without notices; decoded again in hook_watchdog().
+  try {
+    $return['exception_trace'] = drupal_base64_encode(serialize($exception->getTrace()));
+  }
+  catch (Exception $e) {
+    // Some structures (e.g. Closures) are not serializable; prevent a fatal
+    // when such a construct appears in the trace.
+    $return['exception_trace'] = drupal_base64_encode(serialize($e->getMessage()));
+  }
+
+  return $return;
+}
+
+/**
+ * Implements hook_watchdog().
+ */
+function logs_glitchtip_watchdog(array $log_entry) {
+  if ($log_entry['severity'] > variable_get('logs_glitchtip_severity_level', WATCHDOG_ERROR)) {
+    // Severity level is above the ones we want to log.
+    return;
+  }
+
+  logs_glitchtip_register_event($log_entry);
+}
+
+/**
+ * Register an event in a static cache.
+ *
+ * Identical events are only captured once, reducing the payload sent on
+ * shutdown.
+ *
+ * @param array $log_entry
+ *   The entry log as passed from hook_watchdog().
+ */
+function logs_glitchtip_register_event(array $log_entry) {
+  if (!logs_glitchtip_is_active()) {
+    return;
+  }
+
+  $events = &drupal_static('logs_glitchtip_events', []);
+
+  $event = [
+    'timestamp' => $log_entry['timestamp'],
+    'type' => $log_entry['type'],
+    'ip' => $log_entry['ip'],
+    'request_uri' => $log_entry['request_uri'],
+    'referer' => $log_entry['referer'],
+    'uid' => $log_entry['uid'],
+    'link' => strip_tags($log_entry['link']),
+    'message' => empty($log_entry['variables']) ? $log_entry['message'] : strtr($log_entry['message'], $log_entry['variables']),
+    'severity' => $log_entry['severity'],
+  ];
+
+  if (!empty($log_entry['variables']['exception_trace'])) {
+    // drupal_base64_encode() produces URL-safe base64; map it back before
+    // decoding, as base64_decode() would silently drop '-' and '_'.
+    $event['exception_trace'] = base64_decode(strtr($log_entry['variables']['exception_trace'], ['-' => '+', '_' => '/']));
+  }
+
+  // Prevent identical events.
+  $event_clone = $event;
+  unset($event_clone['timestamp']);
+  $key = md5(serialize($event_clone));
+  $events[$key] = $event;
+}
+
+/**
+ * Get the registered events from the static cache.
+ *
+ * @return array
+ *   Array of events.
+ */
+function logs_glitchtip_get_registered_events() {
+  $events = &drupal_static('logs_glitchtip_events', []);
+  return $events;
+}
+
+/**
+ * Runs on shutdown, sends the registered events to GlitchTip.
+ */
+function logs_glitchtip_shutdown() {
+  if (!$events = logs_glitchtip_get_registered_events()) {
+    return;
+  }
+
+  if (!logs_glitchtip_is_active()) {
+    return;
+  }
+
+  logs_glitchtip_sentry_post($events);
+}
+
+/**
+ * Send events via the Sentry SDK.
+ *
+ * @param array $events
+ *   Events as registered by logs_glitchtip_register_event().
+ */
+function logs_glitchtip_sentry_post(array $events) {
+  global $user;
+
+  if (!function_exists('\Sentry\init')) {
+    // Composer dependencies not (re)built yet; silently skip rather than
+    // taking the site down from inside the error handler.
+    return;
+  }
+
+  \Sentry\init([
+    'dsn' => logs_glitchtip_get_dsn(),
+    'environment' => logs_glitchtip_get_environment(),
+    // Error tracking only; tracing is not used, so do not sample
+    // transactions at all.
+    'traces_sample_rate' => 0.0,
+  ]);
+
+  foreach ($events as $event) {
+    switch ($event['severity']) {
+      case WATCHDOG_EMERGENCY:
+      case WATCHDOG_ALERT:
+      case WATCHDOG_CRITICAL:
+        $level = Severity::fatal();
+        break;
+
+      case WATCHDOG_ERROR:
+        $level = Severity::error();
+        break;
+
+      case WATCHDOG_WARNING:
+        $level = Severity::warning();
+        break;
+
+      default:
+        $level = Severity::info();
+        break;
+    }
+
+    \Sentry\withScope(function ($scope) use ($event, $level, $user) {
+      $scope->setUser([
+        'id' => $event['uid'],
+        'username' => isset($user->name) ? $user->name : 'anonymous',
+        'ip_address' => $event['ip'],
+      ]);
+      $scope->setTag('watchdog_type', $event['type']);
+      foreach (['request_uri', 'referer', 'link', 'timestamp'] as $key) {
+        if (!empty($event[$key])) {
+          $scope->setExtra($key, $event[$key]);
+        }
+      }
+      if (!empty($event['exception_trace'])) {
+        $scope->setExtra('exception_trace', $event['exception_trace']);
+      }
+
+      \Sentry\captureMessage($event['type'] . ' : ' . $event['message'], $level);
+    });
+  }
+}
+
+/**
+ * Get the GlitchTip DSN.
+ *
+ * The Drupal variable wins so a site can be redirected or silenced without a
+ * redeploy; the environment variable covers hosts that inject configuration
+ * into the process instead of into settings.php.
+ *
+ * @return string
+ *   The DSN, or an empty string when reporting is not configured.
+ */
+function logs_glitchtip_get_dsn() {
+  if ($dsn = variable_get('logs_glitchtip_dsn', '')) {
+    return $dsn;
+  }
+
+  return (string) getenv('GLITCHTIP_DSN');
+}
+
+/**
+ * Check whether sending to GlitchTip is enabled for this environment.
+ *
+ * @return bool
+ *   TRUE when events should be sent.
+ */
+function logs_glitchtip_is_active() {
+  if (!variable_get('logs_glitchtip_enabled', TRUE)) {
+    return FALSE;
+  }
+
+  // No DSN means reporting was never configured, which is the case for fresh
+  // checkouts, DDEV and CI. Stay silent there.
+  if (!logs_glitchtip_get_dsn()) {
+    return FALSE;
+  }
+
+  if (variable_get('logs_glitchtip_auto_disable_on_local', TRUE) && logs_glitchtip_is_local()) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * Determine the environment name reported to GlitchTip.
+ *
+ * @return string
+ *   The environment name.
+ */
+function logs_glitchtip_get_environment() {
+  if ($environment = variable_get('logs_glitchtip_environment', '')) {
+    return $environment;
+  }
+
+  if ($environment = getenv('GLITCHTIP_ENVIRONMENT')) {
+    return $environment;
+  }
+
+  // The same codebase runs on several Pantheon sites (one per country), so
+  // the site name is needed to tell "live" apart from "live".
+  $pantheon_site = getenv('PANTHEON_SITE_NAME');
+  $pantheon_env = getenv('PANTHEON_ENVIRONMENT');
+  if ($pantheon_site && $pantheon_env) {
+    return $pantheon_site . '.' . $pantheon_env;
+  }
+
+  return 'local';
+}
+
+/**
+ * Check if this is a local development environment.
+ *
+ * The self-hosted country servers expose no vendor environment variable, so
+ * an explicitly configured environment name is what marks a machine as a
+ * real deployment.
+ *
+ * @return bool
+ *   TRUE when the site is considered local.
+ */
+function logs_glitchtip_is_local() {
+  if (variable_get('logs_glitchtip_environment', '') || getenv('GLITCHTIP_ENVIRONMENT')) {
+    return FALSE;
+  }
+
+  // Pantheon unique ID.
+  if (getenv('PANTHEON_SITE_NAME')) {
+    return FALSE;
+  }
+
+  // Platform.sh unique ID.
+  if (getenv('PLATFORM_ENVIRONMENT')) {
+    return FALSE;
+  }
+
+  // Acquia unique ID.
+  if (getenv('AH_SITE_GROUP')) {
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/server/install
+++ b/server/install
@@ -142,6 +142,9 @@ install_drupal_profile
 # Composer install
 composer_install
 
+# Configure GlitchTip error reporting.
+configure_glitchtip
+
 # Setup the files directory.
 create_sites_default_files_directory
 

--- a/server/prepare_db_for_dev.example.sh
+++ b/server/prepare_db_for_dev.example.sh
@@ -72,8 +72,8 @@ drush vset preprocess_js 0
 drush vset preprocess_css 0
 
 echo
-echo -e "Disable the logs_rollbar module"
-drush vset logs_rollbar_enabled 0
+echo -e "Disable GlitchTip error reporting"
+drush vset logs_glitchtip_enabled 0
 
 echo
 echo -e "${LBLUE} > Clearing all cache.${RESTORE}"

--- a/server/scripts/helper-functions.sh
+++ b/server/scripts/helper-functions.sh
@@ -210,6 +210,35 @@ function composer_install {
   cd "$ROOT"
 }
 
+
+##
+# Configure GlitchTip error reporting from the config file.
+#
+# Both values are optional and empty in default.config.sh, so a checkout that
+# was never configured simply reports nothing.
+##
+function configure_glitchtip {
+  if [ -z "$GLITCHTIP_DSN" ] && [ -z "$GLITCHTIP_ENVIRONMENT" ]; then
+    return
+  fi
+
+  echo -e "${LBLUE}> Configure GlitchTip error reporting${RESTORE}"
+
+  cd "$ROOT"/www
+
+  if [ -n "$GLITCHTIP_DSN" ]; then
+    drush vset logs_glitchtip_dsn "$GLITCHTIP_DSN"
+  fi
+
+  if [ -n "$GLITCHTIP_ENVIRONMENT" ]; then
+    drush vset logs_glitchtip_environment "$GLITCHTIP_ENVIRONMENT"
+  fi
+
+  echo
+
+  cd "$ROOT"
+}
+
 ##
 # Create (if not exists) and set the proper file permissions
 # on the sites/default/files directory.

--- a/server/scripts/reset
+++ b/server/scripts/reset
@@ -141,6 +141,9 @@ install_drupal_profile
 # Composer install
 composer_install
 
+# Configure GlitchTip error reporting.
+configure_glitchtip
+
 # Setup the files directory.
 create_sites_default_files_directory
 

--- a/server/upgrade
+++ b/server/upgrade
@@ -152,6 +152,9 @@ drush -y updb
 cd $ROOT
 echo
 
+# Configure GlitchTip error reporting.
+configure_glitchtip
+
 if [ $DEMO_CONTENT ]; then
   import_demo_content
 fi


### PR DESCRIPTION
Adds a `logs_glitchtip` module that reports watchdog events and uncaught exceptions over the Sentry protocol, replacing `logs_rollbar`, which an update hook disables (its code stays in the make file for now, since it implements hook_boot and removing it before every environment has run the update would break bootstrap). The DSN is deliberately not committed: set `GLITCHTIP_DSN` and `GLITCHTIP_ENVIRONMENT` in `server/config.sh`, or $conf['logs_glitchtip_dsn'] / `logs_glitchtip_environment` in settings.php — with neither set nothing is reported, so DDEV and CI stay silent. Pantheon environments are auto-detected; self-hosted country servers need the environment name set explicitly or reporting stays suppressed.

The Elm client still uses Rollbar and is untouched here — that is a separate follow-up.