### PR TITLE
Child scoreboard: convert birth weights that were recorded in kilograms

### DIFF
--- a/server/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
+++ b/server/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * @file
+ * Converts birth weights that were recorded in kilograms into grams.
+ *
+ * The birth weight is asked for and stored in grams, but a share of the
+ * records hold the weight in kilograms - a 3.4 where 3400 was meant. They read
+ * as far below any threshold, so the child counts as born underweight on their
+ * scorecard and in the aggregated one, while the weight itself is nonsense.
+ *
+ * Only weights that can be read as kilograms are converted. Two groups are
+ * left as they are:
+ * - Weights that would convert to more than a newborn can weigh. They are not
+ *   kilograms of birth weight either, and are most likely the weight the child
+ *   had on the day, entered in the wrong field. The script names them so they
+ *   can be looked at.
+ * - Weights between the two scales, which are neither grams nor kilograms and
+ *   which nothing says how to read.
+ *
+ * Converting changes which children the aggregated indicator applies to, so
+ * this recalculates every child it converts a weight for. That leaves it
+ * independent of recalculate-low-birth-weight.php, which covers the children
+ * whose weight was already in grams.
+ *
+ * Execution: drush scr profiles/hedley/modules/custom/hedley_ncda/scripts/
+ *   convert-kilogram-birth-weights.php [--dry_run] [--batch=50].
+ */
+
+if (!drupal_is_cli()) {
+  // Prevent execution from browser.
+  return;
+}
+
+// Report what would be converted, without converting it.
+$dry_run = (bool) drush_get_option('dry_run', FALSE);
+
+// Get the number of nodes to be processed at once.
+$batch = drush_get_option('batch', 50);
+
+// Get allowed memory limit.
+$memory_limit = drush_get_option('memory_limit', 800);
+
+// A weight below this can only be kilograms: it is far under what the lightest
+// newborn on record weighs in grams.
+$kilograms_ceiling = 10;
+
+// The heaviest a newborn can be, in grams. Mirrors
+// getInputConstraintsBirthWeight.maxVal on the client, which refuses anything
+// above it on entry.
+$grams_ceiling = 7000;
+
+// Birth weight is recorded at the newborn exam, and at the NCDA questionnaire
+// for children who did not have one.
+$sources = [
+  [
+    'field' => 'field_weight',
+    'table' => 'field_data_field_weight',
+    'column' => 'field_weight_value',
+    // The field carries every weight measurement, so it is the bundle that
+    // says which rows are birth weights.
+    'bundle' => HEDLEY_ACTIVITY_WELL_CHILD_PREGNANCY_SUMMARY_CONTENT_TYPE,
+  ],
+  [
+    'field' => 'field_birth_weight',
+    'table' => 'field_data_field_birth_weight',
+    'column' => 'field_birth_weight_value',
+    // The field exists only on the NCDA questionnaires.
+    'bundle' => NULL,
+  ],
+];
+
+$convert = [];
+$skipped = [];
+foreach ($sources as $source) {
+  $query = db_select($source['table'], 'f');
+  $query->join('node', 'n', 'n.nid = f.entity_id');
+  hedley_general_apply_exclude_deleted($query, 'n');
+
+  $query
+    ->fields('f', ['entity_id', $source['column']])
+    ->condition('f.deleted', 0)
+    ->condition('f.entity_type', 'node')
+    ->condition('n.status', NODE_PUBLISHED)
+    ->condition('f.' . $source['column'], 0, '>')
+    ->condition('f.' . $source['column'], $kilograms_ceiling, '<');
+
+  if (!empty($source['bundle'])) {
+    $query->condition('f.bundle', $source['bundle']);
+  }
+
+  foreach ($query->execute() as $row) {
+    $grams = $row->{$source['column']} * 1000;
+    $item = [
+      'nid' => $row->entity_id,
+      'field' => $source['field'],
+      'from' => $row->{$source['column']},
+      'to' => $grams,
+    ];
+
+    if ($grams > $grams_ceiling) {
+      $skipped[] = $item;
+      continue;
+    }
+
+    $convert[] = $item;
+  }
+}
+
+if (empty($convert) && empty($skipped)) {
+  drush_print('No birth weight is recorded in kilograms. Nothing to convert.');
+  return;
+}
+
+drush_print(count($convert) . ' birth weights are recorded in kilograms.');
+
+if (!empty($skipped)) {
+  drush_print(count($skipped) . ' more would convert to more than a newborn can weigh, and are left as they are:');
+  foreach ($skipped as $item) {
+    drush_print("  Measurement {$item['nid']}: {$item['from']} would become {$item['to']}");
+  }
+}
+
+if ($dry_run) {
+  drush_print('Dry run. Nothing was converted.');
+  return;
+}
+
+// Convert, remembering whose aggregated data the conversion invalidates.
+$persons = [];
+$converted = 0;
+foreach (array_chunk($convert, $batch) as $chunk) {
+  $nodes = node_load_multiple(array_column($chunk, 'nid'));
+  foreach ($chunk as $item) {
+    if (empty($nodes[$item['nid']])) {
+      drush_print("  Measurement {$item['nid']} could not be loaded. Skipping.");
+      continue;
+    }
+
+    $node = $nodes[$item['nid']];
+    $node->{$item['field']}[LANGUAGE_NONE][0]['value'] = $item['to'];
+    node_save($node);
+    $converted++;
+
+    $person = field_get_items('node', $node, 'field_person');
+    if ($person) {
+      $persons[$person[0]['target_id']] = $person[0]['target_id'];
+    }
+  }
+
+  $memory = round(memory_get_usage() / 1048576);
+  if ($memory >= $memory_limit) {
+    drush_print(dt('Stopped before running out of memory, after @converted weights. Run again to continue.', [
+      '@converted' => $converted,
+    ]));
+    return;
+  }
+
+  // Free up memory.
+  drupal_static_reset();
+}
+
+drush_print("Converted $converted birth weights. Recalculating " . count($persons) . ' children.');
+
+$recalculated = 0;
+foreach (array_chunk($persons, $batch) as $chunk) {
+  foreach (node_load_multiple($chunk) as $person) {
+    if (hedley_ncda_calculate_aggregated_data_for_person($person)) {
+      $recalculated++;
+    }
+  }
+
+  $memory = round(memory_get_usage() / 1048576);
+  if ($memory >= $memory_limit) {
+    drush_print(dt('Ran out of memory while recalculating, after @total children. The weights are converted; run recalculate-low-birth-weight.php to finish.', [
+      '@total' => $recalculated,
+    ]));
+    return;
+  }
+
+  // Free up memory.
+  drupal_static_reset();
+}
+
+drush_print("Done! Converted $converted birth weights and recalculated $recalculated children.");

--- a/server/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
+++ b/server/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
@@ -10,20 +10,25 @@
  * scorecard and in the aggregated one, while the weight itself is nonsense.
  *
  * Only weights that can be read as kilograms are converted. Two groups are
- * left as they are:
+ * left as they are, and the script reports both:
  * - Weights that would convert to more than a newborn can weigh. They are not
  *   kilograms of birth weight either, and are most likely the weight the child
- *   had on the day, entered in the wrong field. The script names them so they
- *   can be looked at.
+ *   had on the day, entered in the wrong field. Their measurements are named
+ *   so they can be looked at.
  * - Weights between the two scales, which are neither grams nor kilograms and
  *   which nothing says how to read.
  *
  * Converting changes which children the aggregated indicator applies to, so
- * this recalculates each child as soon as their weight is converted. That
+ * this recalculates each child once all of their weights are converted. That
  * leaves it independent of recalculate-low-birth-weight.php, which covers the
  * children whose weight was already in grams, and it means anything the script
  * has finished is finished: a converted weight no longer matches what the
  * script looks for, so a run that stops early can simply be run again.
+ *
+ * Note that saving a measurement queues the ordinary recalculation for its
+ * child as well, so a run leaves one queued job per child behind, repeating
+ * work this script has already done. They are harmless, but they occupy the
+ * queue for a while - the run says how many.
  *
  * Execution: drush scr profiles/hedley/modules/custom/hedley_ncda/scripts/
  *   convert-kilogram-birth-weights.php [--dry_run] [--batch=50].
@@ -37,7 +42,7 @@ if (!drupal_is_cli()) {
 // Report what would be converted, without converting it.
 $dry_run = (bool) drush_get_option('dry_run', FALSE);
 
-// Get the number of nodes to be processed at once.
+// Get the number of children to be processed at once.
 $batch = drush_get_option('batch', 50);
 
 // Get allowed memory limit.
@@ -72,54 +77,85 @@ $sources = [
   ],
 ];
 
+// Convertible weights, grouped by the child they belong to: a child with more
+// than one of them has to have all of them converted before being
+// recalculated, or the recalculation reads whichever the module resolves
+// first, which may be one this run has not reached yet.
 $convert = [];
-$skipped = [];
+$orphans = [];
+$too_heavy = [];
+$unreadable = [];
 foreach ($sources as $source) {
   $query = db_select($source['table'], 'f');
   $query->join('node', 'n', 'n.nid = f.entity_id');
+  $query->leftJoin('field_data_field_person', 'fp', 'fp.entity_id = f.entity_id AND fp.entity_type = f.entity_type AND fp.deleted = 0');
   hedley_general_apply_exclude_deleted($query, 'n');
 
   $query
     ->fields('f', ['entity_id', $source['column']])
+    ->fields('fp', ['field_person_target_id'])
     ->condition('f.deleted', 0)
     ->condition('f.entity_type', 'node')
     ->condition('n.status', NODE_PUBLISHED)
     ->condition('f.' . $source['column'], 0, '>')
-    ->condition('f.' . $source['column'], $kilograms_ceiling, '<');
+    ->condition('f.' . $source['column'], HEDLEY_NCDA_MINIMAL_PLAUSIBLE_BIRTH_WEIGHT, '<');
 
   if (!empty($source['bundle'])) {
     $query->condition('f.bundle', $source['bundle']);
   }
 
   foreach ($query->execute() as $row) {
-    $grams = $row->{$source['column']} * 1000;
+    $value = $row->{$source['column']};
     $item = [
       'nid' => $row->entity_id,
       'field' => $source['field'],
-      'from' => $row->{$source['column']},
-      'to' => $grams,
+      'from' => $value,
+      'to' => $value * 1000,
     ];
 
-    if ($grams > $grams_ceiling) {
-      $skipped[] = $item;
+    if ($value >= $kilograms_ceiling) {
+      // Between the two scales. Neither reading makes it a birth weight.
+      $unreadable[] = $item;
       continue;
     }
 
-    $convert[] = $item;
+    if ($item['to'] > $grams_ceiling) {
+      $too_heavy[] = $item;
+      continue;
+    }
+
+    if (empty($row->field_person_target_id)) {
+      $orphans[] = $item;
+      continue;
+    }
+
+    $convert[$row->field_person_target_id][] = $item;
   }
 }
 
-if (empty($convert) && empty($skipped)) {
+$weights = array_sum(array_map('count', $convert)) + count($orphans);
+if ($weights == 0 && empty($too_heavy) && empty($unreadable)) {
   drush_print('No birth weight is recorded in kilograms. Nothing to convert.');
   return;
 }
 
-drush_print(count($convert) . ' birth weights are recorded in kilograms.');
+drush_print("$weights birth weights are recorded in kilograms, belonging to " . count($convert) . ' children.');
 
-if (!empty($skipped)) {
-  drush_print(count($skipped) . ' more would convert to more than a newborn can weigh, and are left as they are:');
-  foreach ($skipped as $item) {
+if (!empty($orphans)) {
+  drush_print(count($orphans) . ' of them belong to no child, and are converted without a recalculation.');
+}
+
+if (!empty($too_heavy)) {
+  drush_print(count($too_heavy) . ' weights would convert to more than a newborn can weigh, and are left as they are:');
+  foreach ($too_heavy as $item) {
     drush_print("  Measurement {$item['nid']}: {$item['from']} would become {$item['to']}");
+  }
+}
+
+if (!empty($unreadable)) {
+  drush_print(count($unreadable) . ' weights are between the two scales and cannot be read either way. They are left as they are, and the children they belong to read as unknown:');
+  foreach ($unreadable as $item) {
+    drush_print("  Measurement {$item['nid']}: {$item['from']}");
   }
 }
 
@@ -128,49 +164,54 @@ if ($dry_run) {
   return;
 }
 
-// Convert each weight and recalculate the child it belongs to, so that a
-// child is either untouched or wholly done.
-$recalculated = [];
+/**
+ * Writes a birth weight in grams over the one recorded in kilograms.
+ *
+ * @param array $item
+ *   The measurement, its field, and the value to write.
+ *
+ * @return bool
+ *   TRUE if the weight was converted.
+ */
+function _hedley_ncda_convert_birth_weight(array $item) {
+  $node = node_load($item['nid']);
+  if (!$node) {
+    drush_print("  Measurement {$item['nid']} could not be loaded. Skipping.");
+    return FALSE;
+  }
+
+  $node->{$item['field']}[LANGUAGE_NONE][0]['value'] = $item['to'];
+  node_save($node);
+
+  return TRUE;
+}
+
 $converted = 0;
-foreach (array_chunk($convert, $batch) as $chunk) {
-  $nodes = node_load_multiple(array_column($chunk, 'nid'));
-  foreach ($chunk as $item) {
-    if (empty($nodes[$item['nid']])) {
-      drush_print("  Measurement {$item['nid']} could not be loaded. Skipping.");
-      continue;
+$recalculated = 0;
+foreach ($orphans as $item) {
+  $converted += (int) _hedley_ncda_convert_birth_weight($item);
+}
+
+foreach (array_chunk($convert, $batch, TRUE) as $chunk) {
+  foreach ($chunk as $person_id => $items) {
+    foreach ($items as $item) {
+      $converted += (int) _hedley_ncda_convert_birth_weight($item);
     }
 
-    $node = $nodes[$item['nid']];
-    $node->{$item['field']}[LANGUAGE_NONE][0]['value'] = $item['to'];
-    node_save($node);
-    $converted++;
-
-    $person = field_get_items('node', $node, 'field_person');
-    if (!$person) {
-      drush_print("  Measurement {$item['nid']} has no person. Converted, but nothing to recalculate.");
-      continue;
-    }
-
-    $person_id = $person[0]['target_id'];
-    if (isset($recalculated[$person_id])) {
-      // A child can have more than one weight to convert, and one
-      // recalculation covers them all.
-      continue;
-    }
-
-    $recalculated[$person_id] = $person_id;
     $child = node_load($person_id);
     if (!$child) {
-      drush_print("  Measurement {$item['nid']} points at person {$person_id}, which does not load. Converted, but not recalculated.");
+      drush_print("  Person {$person_id} does not load. Their weights are converted, but nothing was recalculated.");
       continue;
     }
 
-    hedley_ncda_calculate_aggregated_data_for_person($child);
+    if (hedley_ncda_calculate_aggregated_data_for_person($child)) {
+      $recalculated++;
+    }
   }
 
   $memory = round(memory_get_usage() / 1048576);
   if ($memory >= $memory_limit) {
-    drush_print(dt('Stopped before running out of memory, after @converted weights. Everything converted so far is recalculated, so run again to continue.', [
+    drush_print(dt('Stopped before running out of memory, after @converted weights. Every child converted so far is recalculated, so run again to continue.', [
       '@converted' => $converted,
     ]));
     return;
@@ -180,4 +221,5 @@ foreach (array_chunk($convert, $batch) as $chunk) {
   drupal_static_reset();
 }
 
-drush_print("Done! Converted $converted birth weights and recalculated " . count($recalculated) . ' children.');
+drush_print("Done! Converted $converted birth weights and recalculated $recalculated children.");
+drush_print("Saving the measurements also queued a recalculation for each of those children. Those jobs repeat what this run has done, and will occupy the queue until they are through.");

--- a/server/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
+++ b/server/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
@@ -19,9 +19,11 @@
  *   which nothing says how to read.
  *
  * Converting changes which children the aggregated indicator applies to, so
- * this recalculates every child it converts a weight for. That leaves it
- * independent of recalculate-low-birth-weight.php, which covers the children
- * whose weight was already in grams.
+ * this recalculates each child as soon as their weight is converted. That
+ * leaves it independent of recalculate-low-birth-weight.php, which covers the
+ * children whose weight was already in grams, and it means anything the script
+ * has finished is finished: a converted weight no longer matches what the
+ * script looks for, so a run that stops early can simply be run again.
  *
  * Execution: drush scr profiles/hedley/modules/custom/hedley_ncda/scripts/
  *   convert-kilogram-birth-weights.php [--dry_run] [--batch=50].
@@ -126,8 +128,9 @@ if ($dry_run) {
   return;
 }
 
-// Convert, remembering whose aggregated data the conversion invalidates.
-$persons = [];
+// Convert each weight and recalculate the child it belongs to, so that a
+// child is either untouched or wholly done.
+$recalculated = [];
 $converted = 0;
 foreach (array_chunk($convert, $batch) as $chunk) {
   $nodes = node_load_multiple(array_column($chunk, 'nid'));
@@ -143,14 +146,31 @@ foreach (array_chunk($convert, $batch) as $chunk) {
     $converted++;
 
     $person = field_get_items('node', $node, 'field_person');
-    if ($person) {
-      $persons[$person[0]['target_id']] = $person[0]['target_id'];
+    if (!$person) {
+      drush_print("  Measurement {$item['nid']} has no person. Converted, but nothing to recalculate.");
+      continue;
     }
+
+    $person_id = $person[0]['target_id'];
+    if (isset($recalculated[$person_id])) {
+      // A child can have more than one weight to convert, and one
+      // recalculation covers them all.
+      continue;
+    }
+
+    $recalculated[$person_id] = $person_id;
+    $child = node_load($person_id);
+    if (!$child) {
+      drush_print("  Measurement {$item['nid']} points at person {$person_id}, which does not load. Converted, but not recalculated.");
+      continue;
+    }
+
+    hedley_ncda_calculate_aggregated_data_for_person($child);
   }
 
   $memory = round(memory_get_usage() / 1048576);
   if ($memory >= $memory_limit) {
-    drush_print(dt('Stopped before running out of memory, after @converted weights. Run again to continue.', [
+    drush_print(dt('Stopped before running out of memory, after @converted weights. Everything converted so far is recalculated, so run again to continue.', [
       '@converted' => $converted,
     ]));
     return;
@@ -160,26 +180,4 @@ foreach (array_chunk($convert, $batch) as $chunk) {
   drupal_static_reset();
 }
 
-drush_print("Converted $converted birth weights. Recalculating " . count($persons) . ' children.');
-
-$recalculated = 0;
-foreach (array_chunk($persons, $batch) as $chunk) {
-  foreach (node_load_multiple($chunk) as $person) {
-    if (hedley_ncda_calculate_aggregated_data_for_person($person)) {
-      $recalculated++;
-    }
-  }
-
-  $memory = round(memory_get_usage() / 1048576);
-  if ($memory >= $memory_limit) {
-    drush_print(dt('Ran out of memory while recalculating, after @total children. The weights are converted; run recalculate-low-birth-weight.php to finish.', [
-      '@total' => $recalculated,
-    ]));
-    return;
-  }
-
-  // Free up memory.
-  drupal_static_reset();
-}
-
-drush_print("Done! Converted $converted birth weights and recalculated $recalculated children.");
+drush_print("Done! Converted $converted birth weights and recalculated " . count($recalculated) . ' children.');

--- a/server/hedley/modules/custom/hedley_ncda/scripts/recalculate-low-birth-weight.php
+++ b/server/hedley/modules/custom/hedley_ncda/scripts/recalculate-low-birth-weight.php
@@ -27,6 +27,11 @@ if (!drupal_is_cli()) {
 // Report what would be recalculated, without recalculating it.
 $dry_run = (bool) drush_get_option('dry_run', FALSE);
 
+// Resume after this person, for a run that stopped on memory. Recalculating a
+// child does not change what this script selects, so a plain re-run would stop
+// in the same place; the run says which id to pass.
+$nid = drush_get_option('nid', 0);
+
 // Get the number of nodes to be processed at once.
 $batch = drush_get_option('batch', 50);
 
@@ -67,6 +72,16 @@ foreach ($sources as $source) {
   $query->join('node', 'n', 'n.nid = fp.field_person_target_id');
   hedley_general_apply_exclude_deleted($query, 'n');
 
+  // The measurement holding the weight has to count as well - a deleted one is
+  // not what the indicator was calculated from.
+  $query->join('node', 'mn', 'mn.nid = f.entity_id');
+  $query->leftJoin('field_data_field_deleted', 'mfd', 'mfd.entity_id = mn.nid');
+  $query->condition(
+    db_or()
+      ->isNull('mfd.field_deleted_value')
+      ->condition('mfd.field_deleted_value', 0)
+  );
+
   $bands = db_or()
     ->condition('f.' . $source['column'], HEDLEY_NCDA_MINIMAL_PLAUSIBLE_BIRTH_WEIGHT, '<')
     ->condition(
@@ -82,6 +97,7 @@ foreach ($sources as $source) {
     ->condition('fp.deleted', 0)
     ->condition('n.status', NODE_PUBLISHED)
     ->condition('n.type', 'person')
+    ->condition('mn.status', NODE_PUBLISHED)
     ->condition($bands);
 
   if (!empty($source['bundle'])) {
@@ -93,6 +109,12 @@ foreach ($sources as $source) {
 
 $affected = array_values(array_unique($affected));
 sort($affected);
+
+if ($nid) {
+  $affected = array_values(array_filter($affected, function ($person_id) use ($nid) {
+    return $person_id > $nid;
+  }));
+}
 
 $count = count($affected);
 if ($count == 0) {
@@ -131,9 +153,10 @@ foreach (array_chunk($affected, $batch) as $chunk) {
 
   $memory = round(memory_get_usage() / 1048576);
   if ($memory >= $memory_limit) {
-    drush_print(dt('Stopped before running out of memory, after @total of @count children. Run again to continue.', [
+    drush_print(dt('Stopped before running out of memory, after @total of @count children. Run again with --nid=@nid to continue.', [
       '@total' => $total,
       '@count' => $count,
+      '@nid' => end($chunk),
     ]));
     return;
   }


### PR DESCRIPTION
Fixes #2008

Stacked on #2036 — **base is `b149-low-birth-weight-threshold`, retarget to develop once that merges.** The recalculation this performs has to run with the corrected threshold and the plausibility floor already in place, or it would write answers that are wrong in a different way.

The birth weight is asked for and stored in grams, and a share of the records hold kilograms — a `3.4` where `3400` was meant. Those read far below any threshold, so the child counts as born underweight on their own scorecard and in the aggregated one, from a number that says nothing about them.

## Measured against a copy of the live database

| Band | Records | Treatment |
|---|---|---|
| `0 < v < 10` — kilograms | **2,029** | **2,013 converted**, `× 1000` |
| of those, converting above 7,000 g | **16** | **Left alone**, and named in the output |
| `10 <= v < 300` — between the scales | 71 | Left alone, permanently |

Range of the convertible values is 0.3 to 9.8 kg; none converts below the 300 g floor.

**The 16 are not birth weights in kilograms either.** They run from 7.1 to 9.8, and all but two are `child_scoreboard_ncda` — they read like the weight the child had on the day, entered in the wrong field. 7,000 g is what the app itself accepts on entry, so converting them would write values the input gate would refuse. The script prints their node ids so someone can decide what they actually were.

## Why it recalculates, rather than leaving that to the other script

Converting changes which children the indicator applies to. Once a `3.4` becomes `3400`, that child no longer matches any band `recalculate-low-birth-weight.php` looks for — while their stored answer is precisely the one the conversion just invalidated. Run the conversion first and the other script second, and those ~2,000 children are silently skipped.

So this recalculates each child **as soon as their weight is converted**, rather than collecting them for a second pass. A child is then either untouched or wholly done, and since a converted weight no longer matches what this script looks for either, **a run that stops early can simply be run again** — no bookkeeping, no order to remember. The deduplication a second pass would have bought is worth fourteen recalculations out of two thousand: 2,013 conversions belong to 1,999 distinct children.

It saves through `node_save` rather than writing the field tables, so the corrected weights reach devices; and it recalculates directly rather than relying on the queue, because B-153 records ~1,317 children whose stored data the current code already disagrees with. A data repair should not be built on a mechanism with evidence of losing work.

Side effect worth knowing: each `node_save` also enqueues the ordinary NCDA recalculation for that person, so the queue will redo work this script has already done. Harmless, and deduplicated per person.

## Verification

`php -l` clean; `phpcs` Drupal and DrupalPractice clean.

**Dry run against a copy of the live database**: reports 2,013 to convert and lists the 16 it holds back. 2,013 + 16 = 2,029, matching the row counts measured independently in SQL.

The conversion itself has not been run yet — that is the next step, on the local copy, before it goes near a real site.

## Running it

```
drush scr profiles/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php --dry_run
drush scr profiles/hedley/modules/custom/hedley_ncda/scripts/convert-kilogram-birth-weights.php
```

Then `recalculate-low-birth-weight.php` for the children whose weight was already in grams. Order does not matter.

