### PR TITLE
Child scoreboard: keep one value per month by the month it was taken in

### DIFF
--- a/server/elm/src/App/Update.elm
+++ b/server/elm/src/App/Update.elm
@@ -133,7 +133,7 @@ update msg model =
                 subMsg
                 model.backend
                 (\subMsg_ subModel ->
-                    Backend.Update.updateBackend (fromLocalDateTime model.currentTime)
+                    Backend.Update.updateBackend
                         model.backendUrl
                         model.csrfToken
                         subMsg_

--- a/server/elm/src/Backend/Scoreboard/Decoder.elm
+++ b/server/elm/src/Backend/Scoreboard/Decoder.elm
@@ -5,9 +5,10 @@ import Backend.Components.Decoder exposing (decodeReportParams, decodeSelectedEn
 import Backend.Decoder exposing (decodeSite)
 import Backend.Scoreboard.Model exposing (ANCNewbornData, CriterionBySeverities, InfrastructureEnvironmentWashData, NCDAData, NutritionBehaviorData, NutritionCriterionsData, PatientData, RawVaccinationData, ScoreboardData, SyncResponse, TargetedInterventionsData, UniversalInterventionData, VaccinationProgressDict, VaccineType(..), emptyANCNewbornData, emptyInfrastructureEnvironmentWashData, emptyNCDAData, emptyNutritionBehaviorData, emptyNutritionCriterionsData, emptyTargetedInterventionsData, emptyUniversalInterventionData)
 import Backend.Scoreboard.Utils exposing (generateVaccinationProgressForVaccine)
+import Date
 import EverySet exposing (EverySet)
 import Gizra.Json exposing (decodeInt)
-import Gizra.NominalDate exposing (NominalDate, decodeYYYYMMDD, diffMonths)
+import Gizra.NominalDate exposing (NominalDate, decodeYYYYMMDD)
 import Json.Decode exposing (Decoder, bool, field, list, map, maybe, string, succeed)
 import Json.Decode.Pipeline exposing (hardcoded, optional, required)
 import Maybe.Extra exposing (isNothing)
@@ -24,70 +25,71 @@ decodeScoreboardData =
         |> hardcoded Nothing
 
 
-decodeSyncResponse : NominalDate -> Decoder SyncResponse
-decodeSyncResponse currentDate =
+decodeSyncResponse : Decoder SyncResponse
+decodeSyncResponse =
     field "data"
         (succeed SyncResponse
-            |> required "batch" (list (decodePatientData currentDate))
+            |> required "batch" (list decodePatientData)
             |> required "total_remaining" decodeInt
             |> required "last" decodeInt
         )
 
 
-decodePatientData : NominalDate -> Decoder PatientData
-decodePatientData currentDate =
+decodePatientData : Decoder PatientData
+decodePatientData =
     succeed PatientData
         |> required "created" decodeYYYYMMDD
         |> required "birth_date" decodeYYYYMMDD
         |> required "edd_date" decodeYYYYMMDD
         |> optional "low_birth_weight" (maybe bool) Nothing
-        |> optional "nutrition" (decodeNutritionCriterionsData currentDate) emptyNutritionCriterionsData
-        |> optional "ncda" (decodeNCDAData currentDate) emptyNCDAData
+        |> optional "nutrition" decodeNutritionCriterionsData emptyNutritionCriterionsData
+        |> optional "ncda" decodeNCDAData emptyNCDAData
 
 
-decodeNutritionCriterionsData : NominalDate -> Decoder NutritionCriterionsData
-decodeNutritionCriterionsData currentDate =
+decodeNutritionCriterionsData : Decoder NutritionCriterionsData
+decodeNutritionCriterionsData =
     succeed NutritionCriterionsData
-        |> required "stunting" (decodeCriterionBySeverities currentDate)
-        |> required "underweight" (decodeCriterionBySeverities currentDate)
-        |> required "wasting" (decodeCriterionBySeverities currentDate)
-        |> required "muac" (decodeCriterionBySeverities currentDate)
+        |> required "stunting" decodeCriterionBySeverities
+        |> required "underweight" decodeCriterionBySeverities
+        |> required "wasting" decodeCriterionBySeverities
+        |> required "muac" decodeCriterionBySeverities
 
 
-decodeCriterionBySeverities : NominalDate -> Decoder CriterionBySeverities
-decodeCriterionBySeverities currentDate =
+decodeCriterionBySeverities : Decoder CriterionBySeverities
+decodeCriterionBySeverities =
     succeed CriterionBySeverities
         |> optional "severe" (list decodeYYYYMMDD) []
         |> optional "moderate" (list decodeYYYYMMDD) []
         |> optional "normal" (list decodeYYYYMMDD) []
-        |> map (sainitzeCriterionBySeverities currentDate)
+        |> map sanitizeCriterionBySeverities
 
 
 {-| Guiding rule is that patient should have only one severity value
 during calendar month.
 In case there are multuple severities, most severe one needs to be selected.
 -}
-sainitzeCriterionBySeverities : NominalDate -> CriterionBySeverities -> CriterionBySeverities
-sainitzeCriterionBySeverities currentDate data =
+calendarMonth : NominalDate -> ( Int, Int )
+calendarMonth date =
+    ( Date.year date, Date.monthNumber date )
+
+
+sanitizeCriterionBySeverities : CriterionBySeverities -> CriterionBySeverities
+sanitizeCriterionBySeverities data =
     let
-        -- Transfering from list to dict with diff months as key makes
-        -- sure we get only single value for given months.
+        -- Keying by the month the measurement was taken in leaves one value
+        -- per month, which is the month the scorecard presents it under.
         severeDict =
-            List.map (\date -> ( diffMonths date currentDate, date ))
+            List.map (\date -> ( calendarMonth date, date ))
                 data.severe
                 |> Dict.fromList
 
-        -- Transfering from list to dict with diff months as key makes
-        -- sure we get only single value for given months.
         moderateDict =
-            List.map (\date -> ( diffMonths date currentDate, date ))
+            List.map (\date -> ( calendarMonth date, date ))
                 data.moderate
                 |> Dict.fromList
 
-        -- Transfering from list to dict with diff months as key makes
-        -- sure we get only single value for given months.
         normalDict =
-            List.map (\date -> ( diffMonths date currentDate, date ))
+            List.map (\date -> ( calendarMonth date, date ))
                 data.normal
                 |> Dict.fromList
 
@@ -127,31 +129,31 @@ sainitzeCriterionBySeverities currentDate data =
     }
 
 
-decodeNCDAData : NominalDate -> Decoder NCDAData
-decodeNCDAData currentDate =
+decodeNCDAData : Decoder NCDAData
+decodeNCDAData =
     succeed NCDAData
-        |> optional "pane1" (decodeANCNewbornData currentDate) emptyANCNewbornData
-        |> optional "pane2" (decodeUniversalInterventionData currentDate) emptyUniversalInterventionData
-        |> optional "pane3" (decodeNutritionBehaviorData currentDate) emptyNutritionBehaviorData
-        |> optional "pane4" (decodeTargetedInterventionsData currentDate) emptyTargetedInterventionsData
-        |> optional "pane5" (decodeInfrastructureEnvironmentWashData currentDate) emptyInfrastructureEnvironmentWashData
+        |> optional "pane1" decodeANCNewbornData emptyANCNewbornData
+        |> optional "pane2" decodeUniversalInterventionData emptyUniversalInterventionData
+        |> optional "pane3" decodeNutritionBehaviorData emptyNutritionBehaviorData
+        |> optional "pane4" decodeTargetedInterventionsData emptyTargetedInterventionsData
+        |> optional "pane5" decodeInfrastructureEnvironmentWashData emptyInfrastructureEnvironmentWashData
 
 
-decodeANCNewbornData : NominalDate -> Decoder ANCNewbornData
-decodeANCNewbornData currentDate =
+decodeANCNewbornData : Decoder ANCNewbornData
+decodeANCNewbornData =
     succeed ANCNewbornData
-        |> optional "row1" (decodeMonthlyValues currentDate) []
+        |> optional "row1" decodeMonthlyValues []
         |> optional "row2" bool False
 
 
-decodeUniversalInterventionData : NominalDate -> Decoder UniversalInterventionData
-decodeUniversalInterventionData currentDate =
+decodeUniversalInterventionData : Decoder UniversalInterventionData
+decodeUniversalInterventionData =
     succeed UniversalInterventionData
         |> optional "row1" decodeVaccinationProgressDict Dict.empty
-        |> optional "row2" (decodeMonthlyValues currentDate) []
-        |> optional "row3" (decodeMonthlyValues currentDate) []
-        |> optional "row4" (decodeMonthlyValues currentDate) []
-        |> optional "row5" (decodeMonthlyValues currentDate) []
+        |> optional "row2" decodeMonthlyValues []
+        |> optional "row3" decodeMonthlyValues []
+        |> optional "row4" decodeMonthlyValues []
+        |> optional "row5" decodeMonthlyValues []
 
 
 decodeVaccinationProgressDict : Decoder VaccinationProgressDict
@@ -188,47 +190,47 @@ rawVaccinationDataToVaccinationProgressDict data =
         |> Dict.fromList
 
 
-decodeNutritionBehaviorData : NominalDate -> Decoder NutritionBehaviorData
-decodeNutritionBehaviorData currentDate =
+decodeNutritionBehaviorData : Decoder NutritionBehaviorData
+decodeNutritionBehaviorData =
     succeed NutritionBehaviorData
         |> optional "row1" bool False
-        |> optional "row2" (decodeMonthlyValues currentDate) []
-        |> optional "row3" (decodeMonthlyValues currentDate) []
-        |> optional "row4" (decodeMonthlyValues currentDate) []
+        |> optional "row2" decodeMonthlyValues []
+        |> optional "row3" decodeMonthlyValues []
+        |> optional "row4" decodeMonthlyValues []
 
 
-decodeTargetedInterventionsData : NominalDate -> Decoder TargetedInterventionsData
-decodeTargetedInterventionsData currentDate =
+decodeTargetedInterventionsData : Decoder TargetedInterventionsData
+decodeTargetedInterventionsData =
     succeed TargetedInterventionsData
-        |> optional "row1" (decodeMonthlyValues currentDate) []
-        |> optional "row2" (decodeMonthlyValues currentDate) []
-        |> optional "row3" (decodeMonthlyValues currentDate) []
-        |> optional "row4" (decodeMonthlyValues currentDate) []
-        |> optional "row5" (decodeMonthlyValues currentDate) []
-        |> optional "row6" (decodeMonthlyValues currentDate) []
+        |> optional "row1" decodeMonthlyValues []
+        |> optional "row2" decodeMonthlyValues []
+        |> optional "row3" decodeMonthlyValues []
+        |> optional "row4" decodeMonthlyValues []
+        |> optional "row5" decodeMonthlyValues []
+        |> optional "row6" decodeMonthlyValues []
 
 
-decodeInfrastructureEnvironmentWashData : NominalDate -> Decoder InfrastructureEnvironmentWashData
-decodeInfrastructureEnvironmentWashData currentDate =
+decodeInfrastructureEnvironmentWashData : Decoder InfrastructureEnvironmentWashData
+decodeInfrastructureEnvironmentWashData =
     succeed InfrastructureEnvironmentWashData
-        |> optional "row1" (decodeMonthlyValues currentDate) []
-        |> optional "row2" (decodeMonthlyValues currentDate) []
-        |> optional "row3" (decodeMonthlyValues currentDate) []
-        |> optional "row4" (decodeMonthlyValues currentDate) []
-        |> optional "row5" (decodeMonthlyValues currentDate) []
+        |> optional "row1" decodeMonthlyValues []
+        |> optional "row2" decodeMonthlyValues []
+        |> optional "row3" decodeMonthlyValues []
+        |> optional "row4" decodeMonthlyValues []
+        |> optional "row5" decodeMonthlyValues []
 
 
-decodeMonthlyValues : NominalDate -> Decoder (List NominalDate)
-decodeMonthlyValues currentDate =
+decodeMonthlyValues : Decoder (List NominalDate)
+decodeMonthlyValues =
     list decodeYYYYMMDD
-        |> map (sanitizeSingleValuePerMonth currentDate)
+        |> map sanitizeSingleValuePerMonth
 
 
-sanitizeSingleValuePerMonth : NominalDate -> List NominalDate -> List NominalDate
-sanitizeSingleValuePerMonth currentDate dates =
-    -- Transfering from list to dict with diff months as key makes
-    -- sure we get only single value for given months.
-    List.map (\date -> ( diffMonths date currentDate, date ))
+sanitizeSingleValuePerMonth : List NominalDate -> List NominalDate
+sanitizeSingleValuePerMonth dates =
+    -- Keying by the month the measurement was taken in leaves one value per
+    -- month, which is the month the scorecard presents it under.
+    List.map (\date -> ( calendarMonth date, date ))
         dates
         |> Dict.fromList
         |> Dict.values

--- a/server/elm/src/Backend/Scoreboard/Decoder.elm
+++ b/server/elm/src/Backend/Scoreboard/Decoder.elm
@@ -5,13 +5,13 @@ import Backend.Components.Decoder exposing (decodeReportParams, decodeSelectedEn
 import Backend.Decoder exposing (decodeSite)
 import Backend.Scoreboard.Model exposing (ANCNewbornData, CriterionBySeverities, InfrastructureEnvironmentWashData, NCDAData, NutritionBehaviorData, NutritionCriterionsData, PatientData, RawVaccinationData, ScoreboardData, SyncResponse, TargetedInterventionsData, UniversalInterventionData, VaccinationProgressDict, VaccineType(..), emptyANCNewbornData, emptyInfrastructureEnvironmentWashData, emptyNCDAData, emptyNutritionBehaviorData, emptyNutritionCriterionsData, emptyTargetedInterventionsData, emptyUniversalInterventionData)
 import Backend.Scoreboard.Utils exposing (generateVaccinationProgressForVaccine)
-import Date
 import EverySet exposing (EverySet)
 import Gizra.Json exposing (decodeInt)
 import Gizra.NominalDate exposing (NominalDate, decodeYYYYMMDD)
 import Json.Decode exposing (Decoder, bool, field, list, map, maybe, string, succeed)
 import Json.Decode.Pipeline exposing (hardcoded, optional, required)
 import Maybe.Extra exposing (isNothing)
+import Utils.NominalDate exposing (calendarMonth)
 
 
 decodeScoreboardData : Decoder ScoreboardData
@@ -68,11 +68,6 @@ decodeCriterionBySeverities =
 during calendar month.
 In case there are multuple severities, most severe one needs to be selected.
 -}
-calendarMonth : NominalDate -> ( Int, Int )
-calendarMonth date =
-    ( Date.year date, Date.monthNumber date )
-
-
 sanitizeCriterionBySeverities : CriterionBySeverities -> CriterionBySeverities
 sanitizeCriterionBySeverities data =
     let

--- a/server/elm/src/Backend/Scoreboard/Update.elm
+++ b/server/elm/src/Backend/Scoreboard/Update.elm
@@ -5,18 +5,17 @@ import Backend.Model exposing (ModelBackend)
 import Backend.Scoreboard.Decoder exposing (decodeScoreboardData, decodeSyncResponse)
 import Backend.Scoreboard.Model exposing (Msg(..))
 import Backend.Types exposing (BackendReturn)
-import Gizra.NominalDate exposing (NominalDate)
 
 
-update : NominalDate -> String -> String -> Msg -> ModelBackend -> BackendReturn Msg
-update currentDate backendUrl csrfToken msg model =
+update : String -> String -> Msg -> ModelBackend -> BackendReturn Msg
+update backendUrl csrfToken msg model =
     let
         config =
             { appType = "scoreboard"
             , backendUrl = backendUrl
             , csrfToken = csrfToken
             , dataDecoder = decodeScoreboardData
-            , syncResponseDecoder = decodeSyncResponse currentDate
+            , syncResponseDecoder = decodeSyncResponse
             , getData = .scoreboardData
             , setData = \v m -> { m | scoreboardData = v }
             , getParams = .params

--- a/server/elm/src/Backend/Update.elm
+++ b/server/elm/src/Backend/Update.elm
@@ -9,11 +9,10 @@ import Backend.Scoreboard.Update
 import Backend.ScoreboardMenu.Update
 import Backend.Types exposing (BackendReturn)
 import Backend.Utils exposing (updateSubModel)
-import Gizra.NominalDate exposing (NominalDate)
 
 
-updateBackend : NominalDate -> String -> String -> Msg -> ModelBackend -> BackendReturn Msg
-updateBackend currentDate backendUrl csrfToken msg model =
+updateBackend : String -> String -> Msg -> ModelBackend -> BackendReturn Msg
+updateBackend backendUrl csrfToken msg model =
     case msg of
         MsgScoreboardMenu subMsg ->
             updateSubModel
@@ -25,7 +24,7 @@ updateBackend currentDate backendUrl csrfToken msg model =
         MsgScoreboard subMsg ->
             updateSubModel
                 subMsg
-                (\subMsg_ model_ -> Backend.Scoreboard.Update.update currentDate backendUrl csrfToken subMsg_ model_)
+                (\subMsg_ model_ -> Backend.Scoreboard.Update.update backendUrl csrfToken subMsg_ model_)
                 (\subCmds -> MsgScoreboard subCmds)
                 model
 

--- a/server/elm/src/Utils/NominalDate.elm
+++ b/server/elm/src/Utils/NominalDate.elm
@@ -8,7 +8,15 @@ import Date
 import Gizra.NominalDate exposing (NominalDate)
 
 
+{-| The month a date falls in, as a value that can be compared or used as a
+key. Anything that groups dates by month should say so with this, so that the
+grouping and the comparison below cannot come to disagree.
+-}
+calendarMonth : NominalDate -> ( Int, Int )
+calendarMonth date =
+    ( Date.year date, Date.monthNumber date )
+
+
 equalByYearAndMonth : NominalDate -> NominalDate -> Bool
 equalByYearAndMonth first second =
-    (Date.year first == Date.year second)
-        && (Date.month first == Date.month second)
+    calendarMonth first == calendarMonth second

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -11649,11 +11649,11 @@ var $author$project$Backend$Scoreboard$Model$ANCNewbornData = F2(
 	function (row1, row2) {
 		return {row1: row1, row2: row2};
 	});
-var $justinmimbs$date$Date$Months = {$: 'Months'};
-var $author$project$Gizra$NominalDate$diffMonths = F2(
-	function (low, high) {
-		return A3($justinmimbs$date$Date$diff, $justinmimbs$date$Date$Months, low, high);
-	});
+var $author$project$Backend$Scoreboard$Decoder$calendarMonth = function (date) {
+	return _Utils_Tuple2(
+		$justinmimbs$date$Date$year(date),
+		$justinmimbs$date$Date$monthNumber(date));
+};
 var $elm$core$Tuple$second = function (_v0) {
 	var y = _v0.b;
 	return y;
@@ -11662,134 +11662,123 @@ var $pzp1997$assoc_list$AssocList$values = function (_v0) {
 	var alist = _v0.a;
 	return A2($elm$core$List$map, $elm$core$Tuple$second, alist);
 };
-var $author$project$Backend$Scoreboard$Decoder$sanitizeSingleValuePerMonth = F2(
-	function (currentDate, dates) {
-		return $pzp1997$assoc_list$AssocList$values(
-			$pzp1997$assoc_list$AssocList$fromList(
-				A2(
-					$elm$core$List$map,
-					function (date) {
-						return _Utils_Tuple2(
-							A2($author$project$Gizra$NominalDate$diffMonths, date, currentDate),
-							date);
-					},
-					dates)));
-	});
-var $author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues = function (currentDate) {
-	return A2(
-		$elm$json$Json$Decode$map,
-		$author$project$Backend$Scoreboard$Decoder$sanitizeSingleValuePerMonth(currentDate),
-		$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD));
+var $author$project$Backend$Scoreboard$Decoder$sanitizeSingleValuePerMonth = function (dates) {
+	return $pzp1997$assoc_list$AssocList$values(
+		$pzp1997$assoc_list$AssocList$fromList(
+			A2(
+				$elm$core$List$map,
+				function (date) {
+					return _Utils_Tuple2(
+						$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+						date);
+				},
+				dates)));
 };
-var $author$project$Backend$Scoreboard$Decoder$decodeANCNewbornData = function (currentDate) {
-	return A4(
+var $author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues = A2(
+	$elm$json$Json$Decode$map,
+	$author$project$Backend$Scoreboard$Decoder$sanitizeSingleValuePerMonth,
+	$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD));
+var $author$project$Backend$Scoreboard$Decoder$decodeANCNewbornData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'row2',
+	$elm$json$Json$Decode$bool,
+	false,
+	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-		'row2',
-		$elm$json$Json$Decode$bool,
-		false,
-		A4(
-			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'row1',
-			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-			_List_Nil,
-			$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$ANCNewbornData)));
-};
+		'row1',
+		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+		_List_Nil,
+		$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$ANCNewbornData)));
 var $author$project$Backend$Scoreboard$Model$InfrastructureEnvironmentWashData = F5(
 	function (row1, row2, row3, row4, row5) {
 		return {row1: row1, row2: row2, row3: row3, row4: row4, row5: row5};
 	});
-var $author$project$Backend$Scoreboard$Decoder$decodeInfrastructureEnvironmentWashData = function (currentDate) {
-	return A4(
-		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-		'row5',
-		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-		_List_Nil,
-		A4(
-			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'row4',
-			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-			_List_Nil,
-			A4(
-				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-				'row3',
-				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-				_List_Nil,
-				A4(
-					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-					'row2',
-					$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-					_List_Nil,
-					A4(
-						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-						'row1',
-						$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-						_List_Nil,
-						$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$InfrastructureEnvironmentWashData))))));
-};
-var $author$project$Backend$Scoreboard$Model$NutritionBehaviorData = F4(
-	function (row1, row2, row3, row4) {
-		return {row1: row1, row2: row2, row3: row3, row4: row4};
-	});
-var $author$project$Backend$Scoreboard$Decoder$decodeNutritionBehaviorData = function (currentDate) {
-	return A4(
+var $author$project$Backend$Scoreboard$Decoder$decodeInfrastructureEnvironmentWashData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'row5',
+	$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+	_List_Nil,
+	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
 		'row4',
-		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 		_List_Nil,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
 			'row3',
-			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 			_List_Nil,
 			A4(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
 				'row2',
-				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 				_List_Nil,
 				A4(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
 					'row1',
-					$elm$json$Json$Decode$bool,
-					false,
-					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$NutritionBehaviorData)))));
-};
+					$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+					_List_Nil,
+					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$InfrastructureEnvironmentWashData))))));
+var $author$project$Backend$Scoreboard$Model$NutritionBehaviorData = F4(
+	function (row1, row2, row3, row4) {
+		return {row1: row1, row2: row2, row3: row3, row4: row4};
+	});
+var $author$project$Backend$Scoreboard$Decoder$decodeNutritionBehaviorData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'row4',
+	$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+	_List_Nil,
+	A4(
+		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+		'row3',
+		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+		_List_Nil,
+		A4(
+			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+			'row2',
+			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+			_List_Nil,
+			A4(
+				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+				'row1',
+				$elm$json$Json$Decode$bool,
+				false,
+				$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$NutritionBehaviorData)))));
 var $author$project$Backend$Scoreboard$Model$TargetedInterventionsData = F6(
 	function (row1, row2, row3, row4, row5, row6) {
 		return {row1: row1, row2: row2, row3: row3, row4: row4, row5: row5, row6: row6};
 	});
-var $author$project$Backend$Scoreboard$Decoder$decodeTargetedInterventionsData = function (currentDate) {
-	return A4(
+var $author$project$Backend$Scoreboard$Decoder$decodeTargetedInterventionsData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'row6',
+	$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+	_List_Nil,
+	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-		'row6',
-		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+		'row5',
+		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 		_List_Nil,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'row5',
-			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+			'row4',
+			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 			_List_Nil,
 			A4(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-				'row4',
-				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+				'row3',
+				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 				_List_Nil,
 				A4(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-					'row3',
-					$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+					'row2',
+					$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 					_List_Nil,
 					A4(
 						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-						'row2',
-						$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+						'row1',
+						$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 						_List_Nil,
-						A4(
-							$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-							'row1',
-							$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-							_List_Nil,
-							$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$TargetedInterventionsData)))))));
-};
+						$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$TargetedInterventionsData)))))));
 var $author$project$Backend$Scoreboard$Model$UniversalInterventionData = F5(
 	function (row1, row2, row3, row4, row5) {
 		return {row1: row1, row2: row2, row3: row3, row4: row4, row5: row5};
@@ -11923,67 +11912,63 @@ var $author$project$Backend$Scoreboard$Decoder$decodeVaccinationProgressDict = A
 									'bcg',
 									$author$project$Backend$Scoreboard$Decoder$decodeUniqueDates,
 									$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$RawVaccinationData))))))))));
-var $author$project$Backend$Scoreboard$Decoder$decodeUniversalInterventionData = function (currentDate) {
-	return A4(
+var $author$project$Backend$Scoreboard$Decoder$decodeUniversalInterventionData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'row5',
+	$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
+	_List_Nil,
+	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-		'row5',
-		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+		'row4',
+		$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 		_List_Nil,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'row4',
-			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+			'row3',
+			$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 			_List_Nil,
 			A4(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-				'row3',
-				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
+				'row2',
+				$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues,
 				_List_Nil,
 				A4(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-					'row2',
-					$author$project$Backend$Scoreboard$Decoder$decodeMonthlyValues(currentDate),
-					_List_Nil,
-					A4(
-						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-						'row1',
-						$author$project$Backend$Scoreboard$Decoder$decodeVaccinationProgressDict,
-						$pzp1997$assoc_list$AssocList$empty,
-						$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$UniversalInterventionData))))));
-};
+					'row1',
+					$author$project$Backend$Scoreboard$Decoder$decodeVaccinationProgressDict,
+					$pzp1997$assoc_list$AssocList$empty,
+					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$UniversalInterventionData))))));
 var $author$project$Backend$Scoreboard$Model$emptyANCNewbornData = A2($author$project$Backend$Scoreboard$Model$ANCNewbornData, _List_Nil, false);
 var $author$project$Backend$Scoreboard$Model$emptyInfrastructureEnvironmentWashData = A5($author$project$Backend$Scoreboard$Model$InfrastructureEnvironmentWashData, _List_Nil, _List_Nil, _List_Nil, _List_Nil, _List_Nil);
 var $author$project$Backend$Scoreboard$Model$emptyNutritionBehaviorData = A4($author$project$Backend$Scoreboard$Model$NutritionBehaviorData, false, _List_Nil, _List_Nil, _List_Nil);
 var $author$project$Backend$Scoreboard$Model$emptyTargetedInterventionsData = A6($author$project$Backend$Scoreboard$Model$TargetedInterventionsData, _List_Nil, _List_Nil, _List_Nil, _List_Nil, _List_Nil, _List_Nil);
 var $author$project$Backend$Scoreboard$Model$emptyUniversalInterventionData = A5($author$project$Backend$Scoreboard$Model$UniversalInterventionData, $pzp1997$assoc_list$AssocList$empty, _List_Nil, _List_Nil, _List_Nil, _List_Nil);
-var $author$project$Backend$Scoreboard$Decoder$decodeNCDAData = function (currentDate) {
-	return A4(
+var $author$project$Backend$Scoreboard$Decoder$decodeNCDAData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'pane5',
+	$author$project$Backend$Scoreboard$Decoder$decodeInfrastructureEnvironmentWashData,
+	$author$project$Backend$Scoreboard$Model$emptyInfrastructureEnvironmentWashData,
+	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-		'pane5',
-		$author$project$Backend$Scoreboard$Decoder$decodeInfrastructureEnvironmentWashData(currentDate),
-		$author$project$Backend$Scoreboard$Model$emptyInfrastructureEnvironmentWashData,
+		'pane4',
+		$author$project$Backend$Scoreboard$Decoder$decodeTargetedInterventionsData,
+		$author$project$Backend$Scoreboard$Model$emptyTargetedInterventionsData,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'pane4',
-			$author$project$Backend$Scoreboard$Decoder$decodeTargetedInterventionsData(currentDate),
-			$author$project$Backend$Scoreboard$Model$emptyTargetedInterventionsData,
+			'pane3',
+			$author$project$Backend$Scoreboard$Decoder$decodeNutritionBehaviorData,
+			$author$project$Backend$Scoreboard$Model$emptyNutritionBehaviorData,
 			A4(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-				'pane3',
-				$author$project$Backend$Scoreboard$Decoder$decodeNutritionBehaviorData(currentDate),
-				$author$project$Backend$Scoreboard$Model$emptyNutritionBehaviorData,
+				'pane2',
+				$author$project$Backend$Scoreboard$Decoder$decodeUniversalInterventionData,
+				$author$project$Backend$Scoreboard$Model$emptyUniversalInterventionData,
 				A4(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-					'pane2',
-					$author$project$Backend$Scoreboard$Decoder$decodeUniversalInterventionData(currentDate),
-					$author$project$Backend$Scoreboard$Model$emptyUniversalInterventionData,
-					A4(
-						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-						'pane1',
-						$author$project$Backend$Scoreboard$Decoder$decodeANCNewbornData(currentDate),
-						$author$project$Backend$Scoreboard$Model$emptyANCNewbornData,
-						$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$NCDAData))))));
-};
+					'pane1',
+					$author$project$Backend$Scoreboard$Decoder$decodeANCNewbornData,
+					$author$project$Backend$Scoreboard$Model$emptyANCNewbornData,
+					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$NCDAData))))));
 var $author$project$Backend$Scoreboard$Model$NutritionCriterionsData = F4(
 	function (stunting, underweight, wasting, muac) {
 		return {muac: muac, stunting: stunting, underweight: underweight, wasting: wasting};
@@ -12003,156 +11988,146 @@ var $pzp1997$assoc_list$AssocList$toList = function (_v0) {
 	var alist = _v0.a;
 	return alist;
 };
-var $author$project$Backend$Scoreboard$Decoder$sainitzeCriterionBySeverities = F2(
-	function (currentDate, data) {
-		var severeDict = $pzp1997$assoc_list$AssocList$fromList(
-			A2(
-				$elm$core$List$map,
-				function (date) {
-					return _Utils_Tuple2(
-						A2($author$project$Gizra$NominalDate$diffMonths, date, currentDate),
-						date);
-				},
-				data.severe));
-		var normalDict = $pzp1997$assoc_list$AssocList$fromList(
-			A2(
-				$elm$core$List$map,
-				function (date) {
-					return _Utils_Tuple2(
-						A2($author$project$Gizra$NominalDate$diffMonths, date, currentDate),
-						date);
-				},
-				data.normal));
-		var moderateDict = $pzp1997$assoc_list$AssocList$fromList(
-			A2(
-				$elm$core$List$map,
-				function (date) {
-					return _Utils_Tuple2(
-						A2($author$project$Gizra$NominalDate$diffMonths, date, currentDate),
-						date);
-				},
-				data.moderate));
-		var sanitizedModerate = A2(
-			$elm$core$List$filterMap,
-			function (_v1) {
-				var months = _v1.a;
-				var date = _v1.b;
-				return $elm_community$maybe_extra$Maybe$Extra$isNothing(
-					A2($pzp1997$assoc_list$AssocList$get, months, severeDict)) ? $elm$core$Maybe$Just(date) : $elm$core$Maybe$Nothing;
+var $author$project$Backend$Scoreboard$Decoder$sanitizeCriterionBySeverities = function (data) {
+	var severeDict = $pzp1997$assoc_list$AssocList$fromList(
+		A2(
+			$elm$core$List$map,
+			function (date) {
+				return _Utils_Tuple2(
+					$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+					date);
 			},
-			$pzp1997$assoc_list$AssocList$toList(moderateDict));
-		var sanitizedNormal = A2(
-			$elm$core$List$filterMap,
-			function (_v0) {
-				var months = _v0.a;
-				var date = _v0.b;
-				return ($elm_community$maybe_extra$Maybe$Extra$isNothing(
-					A2($pzp1997$assoc_list$AssocList$get, months, severeDict)) && $elm_community$maybe_extra$Maybe$Extra$isNothing(
-					A2($pzp1997$assoc_list$AssocList$get, months, moderateDict))) ? $elm$core$Maybe$Just(date) : $elm$core$Maybe$Nothing;
+			data.severe));
+	var normalDict = $pzp1997$assoc_list$AssocList$fromList(
+		A2(
+			$elm$core$List$map,
+			function (date) {
+				return _Utils_Tuple2(
+					$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+					date);
 			},
-			$pzp1997$assoc_list$AssocList$toList(normalDict));
-		return _Utils_update(
-			data,
-			{
-				moderate: sanitizedModerate,
-				normal: sanitizedNormal,
-				severe: $pzp1997$assoc_list$AssocList$values(severeDict)
-			});
-	});
-var $author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities = function (currentDate) {
-	return A2(
-		$elm$json$Json$Decode$map,
-		$author$project$Backend$Scoreboard$Decoder$sainitzeCriterionBySeverities(currentDate),
+			data.normal));
+	var moderateDict = $pzp1997$assoc_list$AssocList$fromList(
+		A2(
+			$elm$core$List$map,
+			function (date) {
+				return _Utils_Tuple2(
+					$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+					date);
+			},
+			data.moderate));
+	var sanitizedModerate = A2(
+		$elm$core$List$filterMap,
+		function (_v1) {
+			var months = _v1.a;
+			var date = _v1.b;
+			return $elm_community$maybe_extra$Maybe$Extra$isNothing(
+				A2($pzp1997$assoc_list$AssocList$get, months, severeDict)) ? $elm$core$Maybe$Just(date) : $elm$core$Maybe$Nothing;
+		},
+		$pzp1997$assoc_list$AssocList$toList(moderateDict));
+	var sanitizedNormal = A2(
+		$elm$core$List$filterMap,
+		function (_v0) {
+			var months = _v0.a;
+			var date = _v0.b;
+			return ($elm_community$maybe_extra$Maybe$Extra$isNothing(
+				A2($pzp1997$assoc_list$AssocList$get, months, severeDict)) && $elm_community$maybe_extra$Maybe$Extra$isNothing(
+				A2($pzp1997$assoc_list$AssocList$get, months, moderateDict))) ? $elm$core$Maybe$Just(date) : $elm$core$Maybe$Nothing;
+		},
+		$pzp1997$assoc_list$AssocList$toList(normalDict));
+	return _Utils_update(
+		data,
+		{
+			moderate: sanitizedModerate,
+			normal: sanitizedNormal,
+			severe: $pzp1997$assoc_list$AssocList$values(severeDict)
+		});
+};
+var $author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities = A2(
+	$elm$json$Json$Decode$map,
+	$author$project$Backend$Scoreboard$Decoder$sanitizeCriterionBySeverities,
+	A4(
+		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+		'normal',
+		$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD),
+		_List_Nil,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'normal',
+			'moderate',
 			$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD),
 			_List_Nil,
 			A4(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-				'moderate',
+				'severe',
 				$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD),
 				_List_Nil,
-				A4(
-					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-					'severe',
-					$elm$json$Json$Decode$list($author$project$Gizra$NominalDate$decodeYYYYMMDD),
-					_List_Nil,
-					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$CriterionBySeverities)))));
-};
-var $author$project$Backend$Scoreboard$Decoder$decodeNutritionCriterionsData = function (currentDate) {
-	return A3(
+				$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$CriterionBySeverities)))));
+var $author$project$Backend$Scoreboard$Decoder$decodeNutritionCriterionsData = A3(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
+	'muac',
+	$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities,
+	A3(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-		'muac',
-		$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities(currentDate),
+		'wasting',
+		$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities,
 		A3(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-			'wasting',
-			$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities(currentDate),
+			'underweight',
+			$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities,
 			A3(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-				'underweight',
-				$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities(currentDate),
-				A3(
-					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-					'stunting',
-					$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities(currentDate),
-					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$NutritionCriterionsData)))));
-};
+				'stunting',
+				$author$project$Backend$Scoreboard$Decoder$decodeCriterionBySeverities,
+				$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$NutritionCriterionsData)))));
 var $author$project$Backend$Scoreboard$Model$emptyNCDAData = {ancNewborn: $author$project$Backend$Scoreboard$Model$emptyANCNewbornData, infrastructureEnvironmentWash: $author$project$Backend$Scoreboard$Model$emptyInfrastructureEnvironmentWashData, nutritionBehavior: $author$project$Backend$Scoreboard$Model$emptyNutritionBehaviorData, targetedInterventions: $author$project$Backend$Scoreboard$Model$emptyTargetedInterventionsData, universalIntervention: $author$project$Backend$Scoreboard$Model$emptyUniversalInterventionData};
 var $author$project$Backend$Scoreboard$Model$emptyCriterionBySeverities = {moderate: _List_Nil, normal: _List_Nil, severe: _List_Nil};
 var $author$project$Backend$Scoreboard$Model$emptyNutritionCriterionsData = {muac: $author$project$Backend$Scoreboard$Model$emptyCriterionBySeverities, stunting: $author$project$Backend$Scoreboard$Model$emptyCriterionBySeverities, underweight: $author$project$Backend$Scoreboard$Model$emptyCriterionBySeverities, wasting: $author$project$Backend$Scoreboard$Model$emptyCriterionBySeverities};
-var $author$project$Backend$Scoreboard$Decoder$decodePatientData = function (currentDate) {
-	return A4(
+var $author$project$Backend$Scoreboard$Decoder$decodePatientData = A4(
+	$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
+	'ncda',
+	$author$project$Backend$Scoreboard$Decoder$decodeNCDAData,
+	$author$project$Backend$Scoreboard$Model$emptyNCDAData,
+	A4(
 		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-		'ncda',
-		$author$project$Backend$Scoreboard$Decoder$decodeNCDAData(currentDate),
-		$author$project$Backend$Scoreboard$Model$emptyNCDAData,
+		'nutrition',
+		$author$project$Backend$Scoreboard$Decoder$decodeNutritionCriterionsData,
+		$author$project$Backend$Scoreboard$Model$emptyNutritionCriterionsData,
 		A4(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-			'nutrition',
-			$author$project$Backend$Scoreboard$Decoder$decodeNutritionCriterionsData(currentDate),
-			$author$project$Backend$Scoreboard$Model$emptyNutritionCriterionsData,
-			A4(
-				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$optional,
-				'low_birth_weight',
-				$elm$json$Json$Decode$maybe($elm$json$Json$Decode$bool),
-				$elm$core$Maybe$Nothing,
+			'low_birth_weight',
+			$elm$json$Json$Decode$maybe($elm$json$Json$Decode$bool),
+			$elm$core$Maybe$Nothing,
+			A3(
+				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
+				'edd_date',
+				$author$project$Gizra$NominalDate$decodeYYYYMMDD,
 				A3(
 					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-					'edd_date',
+					'birth_date',
 					$author$project$Gizra$NominalDate$decodeYYYYMMDD,
 					A3(
 						$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-						'birth_date',
+						'created',
 						$author$project$Gizra$NominalDate$decodeYYYYMMDD,
-						A3(
-							$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-							'created',
-							$author$project$Gizra$NominalDate$decodeYYYYMMDD,
-							$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$PatientData)))))));
-};
-var $author$project$Backend$Scoreboard$Decoder$decodeSyncResponse = function (currentDate) {
-	return A2(
-		$elm$json$Json$Decode$field,
-		'data',
+						$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$PatientData)))))));
+var $author$project$Backend$Scoreboard$Decoder$decodeSyncResponse = A2(
+	$elm$json$Json$Decode$field,
+	'data',
+	A3(
+		$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
+		'last',
+		$author$project$Gizra$Json$decodeInt,
 		A3(
 			$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-			'last',
+			'total_remaining',
 			$author$project$Gizra$Json$decodeInt,
 			A3(
 				$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-				'total_remaining',
-				$author$project$Gizra$Json$decodeInt,
-				A3(
-					$NoRedInk$elm_json_decode_pipeline$Json$Decode$Pipeline$required,
-					'batch',
-					$elm$json$Json$Decode$list(
-						$author$project$Backend$Scoreboard$Decoder$decodePatientData(currentDate)),
-					$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$SyncResponse)))));
-};
-var $author$project$Backend$Scoreboard$Update$update = F5(
-	function (currentDate, backendUrl, csrfToken, msg, model) {
+				'batch',
+				$elm$json$Json$Decode$list($author$project$Backend$Scoreboard$Decoder$decodePatientData),
+				$elm$json$Json$Decode$succeed($author$project$Backend$Scoreboard$Model$SyncResponse)))));
+var $author$project$Backend$Scoreboard$Update$update = F4(
+	function (backendUrl, csrfToken, msg, model) {
 		var config = {
 			appType: 'scoreboard',
 			backendUrl: backendUrl,
@@ -12185,7 +12160,7 @@ var $author$project$Backend$Scoreboard$Update$update = F5(
 						m,
 						{scoreboardData: v});
 				}),
-			syncResponseDecoder: $author$project$Backend$Scoreboard$Decoder$decodeSyncResponse(currentDate),
+			syncResponseDecoder: $author$project$Backend$Scoreboard$Decoder$decodeSyncResponse,
 			wrapHandleResponse: $author$project$Backend$Scoreboard$Model$HandleSyncResponse
 		};
 		switch (msg.$) {
@@ -12230,8 +12205,8 @@ var $author$project$Backend$Utils$updateSubModel = F4(
 			model: backendReturn.model
 		};
 	});
-var $author$project$Backend$Update$updateBackend = F5(
-	function (currentDate, backendUrl, csrfToken, msg, model) {
+var $author$project$Backend$Update$updateBackend = F4(
+	function (backendUrl, csrfToken, msg, model) {
 		switch (msg.$) {
 			case 'MsgScoreboardMenu':
 				var subMsg = msg.a;
@@ -12253,7 +12228,7 @@ var $author$project$Backend$Update$updateBackend = F5(
 					subMsg,
 					F2(
 						function (subMsg_, model_) {
-							return A5($author$project$Backend$Scoreboard$Update$update, currentDate, backendUrl, csrfToken, subMsg_, model_);
+							return A4($author$project$Backend$Scoreboard$Update$update, backendUrl, csrfToken, subMsg_, model_);
 						}),
 					function (subCmds) {
 						return $author$project$Backend$Model$MsgScoreboard(subCmds);
@@ -12369,13 +12344,7 @@ var $author$project$App$Update$update = F2(
 					model.backend,
 					F2(
 						function (subMsg_, subModel) {
-							return A5(
-								$author$project$Backend$Update$updateBackend,
-								$author$project$Gizra$NominalDate$fromLocalDateTime(model.currentTime),
-								model.backendUrl,
-								model.csrfToken,
-								subMsg_,
-								subModel);
+							return A4($author$project$Backend$Update$updateBackend, model.backendUrl, model.csrfToken, subMsg_, subModel);
 						}),
 					F2(
 						function (subModel, model_) {
@@ -16518,6 +16487,7 @@ var $author$project$DateSelector$Selector$isSelectable = function (state) {
 var $justinmimbs$date$Date$Day = {$: 'Day'};
 var $justinmimbs$date$Date$Days = {$: 'Days'};
 var $justinmimbs$date$Date$Monday = {$: 'Monday'};
+var $justinmimbs$date$Date$Months = {$: 'Months'};
 var $justinmimbs$date$Date$add = F3(
 	function (unit, n, _v0) {
 		var rd = _v0.a;
@@ -21080,6 +21050,10 @@ var $author$project$Pages$Reports$Utils$allVaccineTypes = function (site) {
 				[$author$project$Backend$Scoreboard$Model$VaccineHPV]));
 	}
 };
+var $author$project$Gizra$NominalDate$diffMonths = F2(
+	function (low, high) {
+		return A3($justinmimbs$date$Date$diff, $justinmimbs$date$Date$Months, low, high);
+	});
 var $author$project$Gizra$NominalDate$diffWeeks = F2(
 	function (low, high) {
 		return A3($justinmimbs$date$Date$diff, $justinmimbs$date$Date$Weeks, low, high);

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -11649,7 +11649,7 @@ var $author$project$Backend$Scoreboard$Model$ANCNewbornData = F2(
 	function (row1, row2) {
 		return {row1: row1, row2: row2};
 	});
-var $author$project$Backend$Scoreboard$Decoder$calendarMonth = function (date) {
+var $author$project$Utils$NominalDate$calendarMonth = function (date) {
 	return _Utils_Tuple2(
 		$justinmimbs$date$Date$year(date),
 		$justinmimbs$date$Date$monthNumber(date));
@@ -11669,7 +11669,7 @@ var $author$project$Backend$Scoreboard$Decoder$sanitizeSingleValuePerMonth = fun
 				$elm$core$List$map,
 				function (date) {
 					return _Utils_Tuple2(
-						$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+						$author$project$Utils$NominalDate$calendarMonth(date),
 						date);
 				},
 				dates)));
@@ -11994,7 +11994,7 @@ var $author$project$Backend$Scoreboard$Decoder$sanitizeCriterionBySeverities = f
 			$elm$core$List$map,
 			function (date) {
 				return _Utils_Tuple2(
-					$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+					$author$project$Utils$NominalDate$calendarMonth(date),
 					date);
 			},
 			data.severe));
@@ -12003,7 +12003,7 @@ var $author$project$Backend$Scoreboard$Decoder$sanitizeCriterionBySeverities = f
 			$elm$core$List$map,
 			function (date) {
 				return _Utils_Tuple2(
-					$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+					$author$project$Utils$NominalDate$calendarMonth(date),
 					date);
 			},
 			data.normal));
@@ -12012,7 +12012,7 @@ var $author$project$Backend$Scoreboard$Decoder$sanitizeCriterionBySeverities = f
 			$elm$core$List$map,
 			function (date) {
 				return _Utils_Tuple2(
-					$author$project$Backend$Scoreboard$Decoder$calendarMonth(date),
+					$author$project$Utils$NominalDate$calendarMonth(date),
 					date);
 			},
 			data.moderate));
@@ -44074,10 +44074,8 @@ var $author$project$Pages$Scoreboard$Model$RegularCheckups = {$: 'RegularCheckup
 var $author$project$Utils$NominalDate$equalByYearAndMonth = F2(
 	function (first, second) {
 		return _Utils_eq(
-			$justinmimbs$date$Date$year(first),
-			$justinmimbs$date$Date$year(second)) && _Utils_eq(
-			$justinmimbs$date$Date$month(first),
-			$justinmimbs$date$Date$month(second));
+			$author$project$Utils$NominalDate$calendarMonth(first),
+			$author$project$Utils$NominalDate$calendarMonth(second));
 	});
 var $author$project$Pages$Scoreboard$Utils$viewPercentage = F2(
 	function (nominator, denominator) {


### PR DESCRIPTION
Fixes #2044

The decoder's stated rule is one value per calendar month. It kept one value per *months-before-today* instead, so the boundary fell on the day of the month rather than the 1st — and the rule broke in both directions at once.

## What changes

The four keying sites move to the month the measurement was taken in:

```elm
List.map (\date -> ( calendarMonth date, date ))
```

Simulated against the real semantics of `Date.diff Months` and `AssocList.fromList`, with `currentDate = 2026-08-06`:

| Input | Kept before | Kept after |
|---|---|---|
| Jul 20, Aug 1 | **Aug 1 only** | both |
| Jul 2, Jul 25 | **both** | Jul 25 |
| May 28, Jun 3, Jul 20, Aug 1 | **Jun 3, Aug 1** | all four |

The third row is the everyday case: a child measured once a month loses half of those measurements, because each pair where the earlier date sits late in its month and the later one early in the next collapses into one bucket. The view matches by calendar month, so what is dropped is simply missing from its column.

The second row is the other half — two readings in one July surviving as separate values. In the severities case the cross-severity filters compare on the same key, so a child with a severe reading on July 2 and a normal one on July 25 was counted as **both severe and normal for July**, which is precisely what the rule exists to prevent. The simulation confirms that stops.

## Why the diff reaches further than four lines

`currentDate` existed in these functions only to compute the broken key. With the key gone the parameter is unused, and `NoUnused.Parameters` follows it up the chain: `decodeMonthlyValues` → the five pane decoders → `decodeNCDAData` → `decodePatientData` → `decodeSyncResponse` → `Backend.Scoreboard.Update.update` → `updateBackend`.

I removed it rather than silencing it with `_`, because the end state is the one that reads correctly: `Backend.Reports.Decoder.decodeSyncResponse` and `Backend.Completion.Decoder.decodeSyncResponse` never took a date, and neither did their `update` functions. The scoreboard was the outlier, and only because of this bug. The rest of the diff is mechanical and the compiler plus `elm-review` confirm it is complete.

## Deployment

**No recalculation needed.** This is decode-time arithmetic over the stored data, so it takes effect as soon as the rebuilt bundle is deployed — unlike #2035, which changes what is stored.

## Verification

* `elm make src/Main.elm` — Success, 84 modules
* `elm-format --validate` — clean
* `elm-review`, cold — I found no errors! (it drove the parameter removal)
* Simulation of old versus new bucketing, ported from `Date.diff Months` and `AssocList.fromList` semantics — the table above

**No test.** `server/elm` has no test suite at all: no test dependencies in `elm.json`, no `Test` modules, and CI runs only `elm-review` on it (`ci-scripts/test_elm_review.sh:27`). Stated rather than implied.

The regenerated `elm-main.js` is the second commit. Since #2034 and #2038 have merged, this bundle carries only this change plus the compiler-version churn already in develop's copy.
