### PR TITLE
Vaccination: schedule vaccines the way the client does

### DIFF
--- a/server/elm/src/Pages/Scoreboard/Utils.elm
+++ b/server/elm/src/Pages/Scoreboard/Utils.elm
@@ -30,7 +30,7 @@ generateFutureVaccinationsData site birthDate vaccinationProgress =
                 nextVaccinationData =
                     case latestVaccinationDataForVaccine vaccinationProgress vaccineType of
                         Just ( lastDoseAdministered, lastDoseDate ) ->
-                            nextVaccinationDataForVaccine site vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered
+                            nextVaccinationDataForVaccine site birthDate vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered
 
                         Nothing ->
                             let
@@ -71,9 +71,9 @@ latestVaccinationDataForVaccine vaccinationsData vaccineType =
             )
 
 
-nextVaccinationDataForVaccine : Site -> VaccineType -> Bool -> NominalDate -> VaccineDose -> Maybe ( VaccineDose, NominalDate )
-nextVaccinationDataForVaccine site vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered =
-    if getLastDoseForVaccine initialOpvAdministered vaccineType == lastDoseAdministered then
+nextVaccinationDataForVaccine : Site -> NominalDate -> VaccineType -> Bool -> NominalDate -> VaccineDose -> Maybe ( VaccineDose, NominalDate )
+nextVaccinationDataForVaccine site birthDate vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered =
+    if getLastDoseForVaccine site initialOpvAdministered vaccineType == lastDoseAdministered then
         Nothing
 
     else
@@ -83,13 +83,39 @@ nextVaccinationDataForVaccine site vaccineType initialOpvAdministered lastDoseDa
                     let
                         ( interval, unit ) =
                             getIntervalForVaccine site vaccineType
+
+                        byInterval =
+                            Date.add unit interval lastDoseDate
                     in
-                    ( dose, Date.add unit interval lastDoseDate )
+                    if vaccineType == VaccineOPV && initialOpvAdministered && dose == VaccineDoseSecond then
+                        -- The initial OPV dose is given before the child is two
+                        -- weeks old, and the second at six weeks, so the interval
+                        -- alone does not say when it is due.
+                        ( dose, laterOf byInterval (Date.add Weeks 6 birthDate) )
+
+                    else if site == SiteRwanda && vaccineType == VaccineIPV && dose == VaccineDoseSecond then
+                        -- The interval for IPV is zero, since for most sites
+                        -- there is only one dose. Rwanda's second dose is due on
+                        -- the later of 36 weeks of age and 28 days after the
+                        -- first, which is what says when it is due here.
+                        ( dose, laterOf (Date.add Days 28 lastDoseDate) (Date.add Weeks 36 birthDate) )
+
+                    else
+                        ( dose, byInterval )
                 )
 
 
-getLastDoseForVaccine : Bool -> VaccineType -> VaccineDose
-getLastDoseForVaccine initialOpvAdministered vaccineType =
+laterOf : NominalDate -> NominalDate -> NominalDate
+laterOf first second =
+    if Date.compare first second == GT then
+        first
+
+    else
+        second
+
+
+getLastDoseForVaccine : Site -> Bool -> VaccineType -> VaccineDose
+getLastDoseForVaccine site initialOpvAdministered vaccineType =
     case vaccineType of
         VaccineBCG ->
             VaccineDoseFirst
@@ -114,7 +140,12 @@ getLastDoseForVaccine initialOpvAdministered vaccineType =
             VaccineDoseSecond
 
         VaccineIPV ->
-            VaccineDoseFirst
+            case site of
+                SiteRwanda ->
+                    VaccineDoseSecond
+
+                _ ->
+                    VaccineDoseFirst
 
         VaccineMR ->
             VaccineDoseSecond
@@ -163,6 +194,12 @@ getIntervalForVaccine site vaccineType =
         VaccineRotarix ->
             ( 4, Weeks )
 
+        -- So far, there was only single IPV dose.
+        -- Since https://github.com/TIP-Global-Health/eheza-app/issues/1426,
+        -- at Rwanda site, we got second dose scheduled on the latter
+        -- between age of 36 weeks, and 4 weeks after first dose was administered.
+        -- This requirement is not reflected here. Instead, it's defined as
+        -- special case at appropriate spots in code (which use getIntervalForVaccine).
         VaccineIPV ->
             ( 0, Days )
 
@@ -245,8 +282,19 @@ initialVaccinationDateByBirthDate site birthDate initialOpvAdministered vaccinat
                 |> Date.add unit (dosesInterval * interval)
 
         VaccineIPV ->
-            Date.add Weeks 14 birthDate
-                |> Date.add unit (dosesInterval * interval)
+            case ( site, vaccineDose ) of
+                ( SiteRwanda, VaccineDoseSecond ) ->
+                    -- The later of 36 weeks of age and 28 days after the first
+                    -- dose. Where the first dose is not known, 36 weeks is the
+                    -- earliest the second is allowed.
+                    Dict.get VaccineIPV vaccinationProgress
+                        |> Maybe.andThen (Dict.get VaccineDoseFirst)
+                        |> Maybe.map (\firstDoseDate -> laterOf (Date.add Days 28 firstDoseDate) (Date.add Weeks 36 birthDate))
+                        |> Maybe.withDefault (Date.add Weeks 36 birthDate)
+
+                _ ->
+                    Date.add Weeks 14 birthDate
+                        |> Date.add unit (dosesInterval * interval)
 
         VaccineMR ->
             Date.add Weeks 36 birthDate
@@ -258,19 +306,36 @@ initialVaccinationDateByBirthDate site birthDate initialOpvAdministered vaccinat
 
 
 {-| We don't include VaccineHPV, since it's given only at
-age of 12 years.
+age of 12 years, and this report is for children up to 24 months.
+That is what makes this list different from the one in
+Pages.Reports.Utils, which covers all ages and does include it - they
+are not two copies of the same list, and should not be made one.
+
+Only Burundi schedules VaccineDTPStandalone. Listing it for a site that
+does not schedule it leaves a dose that is never administered, and the
+caller takes the earliest outstanding dose, so the child reads as off
+track from the day it falls due.
+
 -}
-allVaccineTypes : List VaccineType
-allVaccineTypes =
-    [ VaccineBCG
-    , VaccineOPV
-    , VaccineDTP
-    , VaccineDTPStandalone
-    , VaccinePCV13
-    , VaccineRotarix
-    , VaccineIPV
-    , VaccineMR
-    ]
+allVaccineTypes : Site -> List VaccineType
+allVaccineTypes site =
+    let
+        common =
+            [ VaccineBCG
+            , VaccineOPV
+            , VaccineDTP
+            , VaccinePCV13
+            , VaccineRotarix
+            , VaccineIPV
+            , VaccineMR
+            ]
+    in
+    case site of
+        SiteBurundi ->
+            common ++ [ VaccineDTPStandalone ]
+
+        _ ->
+            common
 
 
 valuesByViewMode : ViewMode -> List Int -> List Int -> List String

--- a/server/elm/src/Pages/Scoreboard/Utils.elm
+++ b/server/elm/src/Pages/Scoreboard/Utils.elm
@@ -282,12 +282,14 @@ initialVaccinationDateByBirthDate site birthDate initialOpvAdministered vaccinat
                 |> Date.add unit (dosesInterval * interval)
 
         VaccineIPV ->
-            -- Only the first dose is asked for here today: the one caller
-            -- resolves a date for a child who has had none. The second dose is
-            -- kept because the client asks this same question for any dose, and
-            -- because leaving it out would answer the second dose with 14 weeks
-            -- and an interval of none, which is the wrong date rather than no
-            -- date. Whoever asks for it next gets the right answer.
+            -- Nothing here asks for the second dose today: the one caller
+            -- resolves a date for a child who has had none, and so asks only
+            -- for the first. It is answered anyway, for symmetry with the
+            -- client's own copy of this function, which is reached with any
+            -- dose - and because leaving it out would answer the second dose
+            -- with 14 weeks and an interval of none, which is the wrong date
+            -- rather than no date. Whoever asks for it next gets the right
+            -- answer.
             case ( site, vaccineDose ) of
                 ( SiteRwanda, VaccineDoseSecond ) ->
                     -- The later of 36 weeks of age and 28 days after the first

--- a/server/elm/src/Pages/Scoreboard/Utils.elm
+++ b/server/elm/src/Pages/Scoreboard/Utils.elm
@@ -282,6 +282,12 @@ initialVaccinationDateByBirthDate site birthDate initialOpvAdministered vaccinat
                 |> Date.add unit (dosesInterval * interval)
 
         VaccineIPV ->
+            -- Only the first dose is asked for here today: the one caller
+            -- resolves a date for a child who has had none. The second dose is
+            -- kept because the client asks this same question for any dose, and
+            -- because leaving it out would answer the second dose with 14 weeks
+            -- and an interval of none, which is the wrong date rather than no
+            -- date. Whoever asks for it next gets the right answer.
             case ( site, vaccineDose ) of
                 ( SiteRwanda, VaccineDoseSecond ) ->
                     -- The later of 36 weeks of age and 28 days after the first

--- a/server/elm/src/Pages/Scoreboard/View.elm
+++ b/server/elm/src/Pages/Scoreboard/View.elm
@@ -619,7 +619,7 @@ viewUniversalInterventionPane language currentDate site yearSelectorGap monthsGa
                                                             generateFutureVaccinationsData site
                                                                 record.birthDate
                                                                 vaccinationProgressOnReferrenceDate
-                                                                allVaccineTypes
+                                                                (allVaccineTypes site)
 
                                                         closestDateForVaccination =
                                                             List.filterMap (Tuple.second >> Maybe.map Tuple.second) futureVaccinations

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -21111,6 +21111,12 @@ var $author$project$Pages$Scoreboard$Utils$getIntervalForVaccine = F2(
 				return _Utils_Tuple2(6, $justinmimbs$date$Date$Months);
 		}
 	});
+var $author$project$Pages$Scoreboard$Utils$laterOf = F2(
+	function (first, second) {
+		return _Utils_eq(
+			A2($justinmimbs$date$Date$compare, first, second),
+			$elm$core$Basics$GT) ? first : second;
+	});
 var $author$project$Backend$Scoreboard$Utils$vaccineDoseToComparable = function (dose) {
 	switch (dose.$) {
 		case 'VaccineDoseFirst':
@@ -21186,11 +21192,32 @@ var $author$project$Pages$Scoreboard$Utils$initialVaccinationDateByBirthDate = F
 					dosesInterval * interval,
 					A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 6, birthDate));
 			case 'VaccineIPV':
-				return A3(
-					$justinmimbs$date$Date$add,
-					unit,
-					dosesInterval * interval,
-					A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 14, birthDate));
+				var _v4 = _Utils_Tuple2(site, vaccineDose);
+				if ((_v4.a.$ === 'SiteRwanda') && (_v4.b.$ === 'VaccineDoseSecond')) {
+					var _v5 = _v4.a;
+					var _v6 = _v4.b;
+					return A2(
+						$elm$core$Maybe$withDefault,
+						A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 36, birthDate),
+						A2(
+							$elm$core$Maybe$map,
+							function (firstDoseDate) {
+								return A2(
+									$author$project$Pages$Scoreboard$Utils$laterOf,
+									A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Days, 28, firstDoseDate),
+									A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 36, birthDate));
+							},
+							A2(
+								$elm$core$Maybe$andThen,
+								$pzp1997$assoc_list$AssocList$get($author$project$Backend$Scoreboard$Model$VaccineDoseFirst),
+								A2($pzp1997$assoc_list$AssocList$get, $author$project$Backend$Scoreboard$Model$VaccineIPV, vaccinationProgress))));
+				} else {
+					return A3(
+						$justinmimbs$date$Date$add,
+						unit,
+						dosesInterval * interval,
+						A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 14, birthDate));
+				}
 			case 'VaccineMR':
 				return A3(
 					$justinmimbs$date$Date$add,
@@ -21219,8 +21246,8 @@ var $author$project$Pages$Scoreboard$Utils$latestVaccinationDataForVaccine = F2(
 					A2($elm$core$Basics$composeR, $elm$core$List$reverse, $elm$core$List$head))),
 			A2($pzp1997$assoc_list$AssocList$get, vaccineType, vaccinationsData));
 	});
-var $author$project$Pages$Scoreboard$Utils$getLastDoseForVaccine = F2(
-	function (initialOpvAdministered, vaccineType) {
+var $author$project$Pages$Scoreboard$Utils$getLastDoseForVaccine = F3(
+	function (site, initialOpvAdministered, vaccineType) {
 		switch (vaccineType.$) {
 			case 'VaccineBCG':
 				return $author$project$Backend$Scoreboard$Model$VaccineDoseFirst;
@@ -21235,7 +21262,11 @@ var $author$project$Pages$Scoreboard$Utils$getLastDoseForVaccine = F2(
 			case 'VaccineRotarix':
 				return $author$project$Backend$Scoreboard$Model$VaccineDoseSecond;
 			case 'VaccineIPV':
-				return $author$project$Backend$Scoreboard$Model$VaccineDoseFirst;
+				if (site.$ === 'SiteRwanda') {
+					return $author$project$Backend$Scoreboard$Model$VaccineDoseSecond;
+				} else {
+					return $author$project$Backend$Scoreboard$Model$VaccineDoseFirst;
+				}
 			case 'VaccineMR':
 				return $author$project$Backend$Scoreboard$Model$VaccineDoseSecond;
 			default:
@@ -21256,19 +21287,28 @@ var $author$project$Pages$Scoreboard$Utils$getNextVaccineDose = function (dose) 
 			return $elm$core$Maybe$Nothing;
 	}
 };
-var $author$project$Pages$Scoreboard$Utils$nextVaccinationDataForVaccine = F5(
-	function (site, vaccineType, initialOpvAdministered, lastDoseDate, lastDoseAdministered) {
+var $author$project$Pages$Scoreboard$Utils$nextVaccinationDataForVaccine = F6(
+	function (site, birthDate, vaccineType, initialOpvAdministered, lastDoseDate, lastDoseAdministered) {
 		return _Utils_eq(
-			A2($author$project$Pages$Scoreboard$Utils$getLastDoseForVaccine, initialOpvAdministered, vaccineType),
+			A3($author$project$Pages$Scoreboard$Utils$getLastDoseForVaccine, site, initialOpvAdministered, vaccineType),
 			lastDoseAdministered) ? $elm$core$Maybe$Nothing : A2(
 			$elm$core$Maybe$map,
 			function (dose) {
 				var _v0 = A2($author$project$Pages$Scoreboard$Utils$getIntervalForVaccine, site, vaccineType);
 				var interval = _v0.a;
 				var unit = _v0.b;
-				return _Utils_Tuple2(
+				var byInterval = A3($justinmimbs$date$Date$add, unit, interval, lastDoseDate);
+				return (_Utils_eq(vaccineType, $author$project$Backend$Scoreboard$Model$VaccineOPV) && (initialOpvAdministered && _Utils_eq(dose, $author$project$Backend$Scoreboard$Model$VaccineDoseSecond))) ? _Utils_Tuple2(
 					dose,
-					A3($justinmimbs$date$Date$add, unit, interval, lastDoseDate));
+					A2(
+						$author$project$Pages$Scoreboard$Utils$laterOf,
+						byInterval,
+						A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 6, birthDate))) : ((_Utils_eq(site, $author$project$App$Types$SiteRwanda) && (_Utils_eq(vaccineType, $author$project$Backend$Scoreboard$Model$VaccineIPV) && _Utils_eq(dose, $author$project$Backend$Scoreboard$Model$VaccineDoseSecond))) ? _Utils_Tuple2(
+					dose,
+					A2(
+						$author$project$Pages$Scoreboard$Utils$laterOf,
+						A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Days, 28, lastDoseDate),
+						A3($justinmimbs$date$Date$add, $justinmimbs$date$Date$Weeks, 36, birthDate))) : _Utils_Tuple2(dose, byInterval));
 			},
 			$author$project$Pages$Scoreboard$Utils$getNextVaccineDose(lastDoseAdministered));
 	});
@@ -21298,7 +21338,7 @@ var $author$project$Pages$Scoreboard$Utils$generateFutureVaccinationsData = F3(
 						var _v1 = _v0.a;
 						var lastDoseAdministered = _v1.a;
 						var lastDoseDate = _v1.b;
-						return A5($author$project$Pages$Scoreboard$Utils$nextVaccinationDataForVaccine, site, vaccineType, initialOpvAdministered, lastDoseDate, lastDoseAdministered);
+						return A6($author$project$Pages$Scoreboard$Utils$nextVaccinationDataForVaccine, site, birthDate, vaccineType, initialOpvAdministered, lastDoseDate, lastDoseAdministered);
 					} else {
 						var vaccinationDate = A5(
 							$author$project$Pages$Scoreboard$Utils$initialVaccinationDateByBirthDate,
@@ -45178,8 +45218,18 @@ var $author$project$Translate$NCDAUniversalInterventionItemLabel = function (a) 
 var $author$project$Pages$Scoreboard$Model$OngeraMNP = {$: 'OngeraMNP'};
 var $author$project$Translate$UniversalIntervention = {$: 'UniversalIntervention'};
 var $author$project$Pages$Scoreboard$Model$VitaminA = {$: 'VitaminA'};
-var $author$project$Pages$Scoreboard$Utils$allVaccineTypes = _List_fromArray(
-	[$author$project$Backend$Scoreboard$Model$VaccineBCG, $author$project$Backend$Scoreboard$Model$VaccineOPV, $author$project$Backend$Scoreboard$Model$VaccineDTP, $author$project$Backend$Scoreboard$Model$VaccineDTPStandalone, $author$project$Backend$Scoreboard$Model$VaccinePCV13, $author$project$Backend$Scoreboard$Model$VaccineRotarix, $author$project$Backend$Scoreboard$Model$VaccineIPV, $author$project$Backend$Scoreboard$Model$VaccineMR]);
+var $author$project$Pages$Scoreboard$Utils$allVaccineTypes = function (site) {
+	var common = _List_fromArray(
+		[$author$project$Backend$Scoreboard$Model$VaccineBCG, $author$project$Backend$Scoreboard$Model$VaccineOPV, $author$project$Backend$Scoreboard$Model$VaccineDTP, $author$project$Backend$Scoreboard$Model$VaccinePCV13, $author$project$Backend$Scoreboard$Model$VaccineRotarix, $author$project$Backend$Scoreboard$Model$VaccineIPV, $author$project$Backend$Scoreboard$Model$VaccineMR]);
+	if (site.$ === 'SiteBurundi') {
+		return _Utils_ap(
+			common,
+			_List_fromArray(
+				[$author$project$Backend$Scoreboard$Model$VaccineDTPStandalone]));
+	} else {
+		return common;
+	}
+};
 var $author$project$Pages$Scoreboard$View$viewUniversalInterventionPane = F8(
 	function (language, currentDate, site, yearSelectorGap, monthsGap, childrenUnder2, viewMode, data) {
 		var resolveLastDayForMonthX = F2(
@@ -45268,7 +45318,12 @@ var $author$project$Pages$Scoreboard$View$viewUniversalInterventionPane = F8(
 																	dosesDict);
 															}),
 														record.ncda.universalIntervention.row1);
-													var futureVaccinations = A4($author$project$Pages$Scoreboard$Utils$generateFutureVaccinationsData, site, record.birthDate, vaccinationProgressOnReferrenceDate, $author$project$Pages$Scoreboard$Utils$allVaccineTypes);
+													var futureVaccinations = A4(
+														$author$project$Pages$Scoreboard$Utils$generateFutureVaccinationsData,
+														site,
+														record.birthDate,
+														vaccinationProgressOnReferrenceDate,
+														$author$project$Pages$Scoreboard$Utils$allVaccineTypes(site));
 													var closestDateForVaccination = $elm$core$List$head(
 														A2(
 															$elm$core$List$sortWith,


### PR DESCRIPTION
Fixes #2046

The scoreboard runs its own copy of the client's vaccination engine, and it has drifted in three ways that pull the immunisation row in **both directions at once** — which is why the number looks plausible while being wrong per child.

## What was wrong

**DTP-standalone was scheduled for every site.** The consumer (`Pages/Scoreboard/View.elm:617-641`) takes the *earliest outstanding dose* and marks the child off track unless it falls after the reference month. DTP-standalone is due at the later of 28 days after OPV-3 and 18 months of age — inside the 24-month window — and Rwanda never gives it. So **every Rwandan child aged 18 to 24 months with an OPV-3 record read as off track**, whatever they had actually received. Children without OPV-3 were unaffected; their fallback is 999 years out.

**Rwanda's second IPV dose was missing**, so a child who had IPV-1 was treated as finished — the opposite error.

**OPV-2 used a flat four-week interval**, where the client waits for the later of six weeks of age and four weeks after the birth dose, so children read behind about two weeks early.

## ⚠️ Why the order of these changes matters

`getIntervalForVaccine` returns `( 0, Days )` for IPV **in both copies**. On the client that is a placeholder, and it says so:

> This requirement is not reflected here. Instead, it's defined as special case at appropriate spots in code.

The server had copied the placeholder without the comment and without the special cases. So the obvious one-line fix — give `getLastDoseForVaccine` a site so Rwanda expects a second dose — would have scheduled IPV-2 at `lastDoseDate + 0 days`, **due the day the first dose was given**, putting every Rwandan child with an IPV-1 record off track. Strictly worse than the bug it fixes.

The dose count is therefore turned on **last**, after the special cases and the initial date exist. The client's comment is carried across so the placeholder is labelled in both copies.

## The two vaccine lists stay separate

`Pages/Reports/Utils.allVaccineTypes` includes `VaccineHPV`; this one does not, because this report covers children to 24 months and HPV is given at 12 years — the docblock said so already. They are not two copies of one list, and unifying them would put a 12-year vaccine into an under-2 report. The scoreboard's copy gains only the site gate, and the docblock now says why they differ.

## Verification

Simulated old against new for a child born 2025-01-01:

**Rwanda IPV dose 2**, showing what the naive fix would have done:

| IPV-1 given | Naive port | This PR |
|---|---|---|
| 2025-04-09 (14w) | **2025-04-09** — same day | 2025-09-10 |
| 2025-07-30 (30w) | **2025-07-30** — same day | 2025-09-10 |
| 2025-10-08 (40w) | **2025-10-08** — same day | 2025-11-05 |

**OPV dose 2 with a birth dose:**

| OPV-1 given | Before | After |
|---|---|---|
| 2025-01-02 | 2025-01-30 | 2025-02-12 |
| 2025-01-11 | 2025-02-08 | 2025-02-12 |

**`allVaccineTypes`:** Rwanda loses `dtp_sa`, Burundi keeps it, neither gains HPV.

Also: `elm make` Success · `elm-format --validate` clean · `elm-review` cold — I found no errors! · and the regenerated bundle **byte-compared against a fresh build of the committed source — identical**.

**No test.** `server/elm` has no test suite: no test dependencies, no `Test` modules, and CI runs only `elm-review` on it.

## Not included, and related

The DTP-standalone gate reads OPV-3 rather than DTP-3, in this copy and the client's alike, though the comment beside it says "All 3 doses of DTP" and the PHP engine checks `dtp dose-3`. It has no GitHub issue — it is carried in the improvement backlog as B-055 — and it needs a clinical decision rather than a port, since it changes when a dose is considered due. Fixing it here alone would put this copy out of step with the client again.

**The PHP completion engine has the same missing IPV dose, and the same trap** (`hedley_reports.module`, `'+0 days'` for ipv, an OPV special case, no IPV one). It is a separate PR, and it should follow this one so it can cite the rule rather than re-derive it. Its own wrinkle: the next-dose block is duplicated at two call sites there, so the rule has to be extracted before it is added, or it lands twice.

