### PR TITLE
Reports: expect Rwanda's second IPV dose in the completion reports

### DIFF
--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -5982,12 +5982,15 @@ function hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_o
  */
 function hedley_reports_get_interval_for_vaccine($immunisation_type, $site) {
   switch ($immunisation_type) {
-    // The interval for IPV says nothing, since for most sites there is only
+    // The interval says nothing about IPV, since for most sites there is only
     // one dose. Rwanda's second dose is due on the later of 36 weeks of age
     // and 28 days after the first, which is applied where the next dose is
     // resolved rather than here.
-    case 'bcg':
     case 'ipv':
+      return '+0 days';
+
+    // One dose each, so there is no interval to give.
+    case 'bcg':
     case 'dtp_sa':
       return '+0 days';
 

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -5795,9 +5795,38 @@ function hedley_reports_well_child_get_expected_immunisation_activities(array $e
     }
   }
 
+  return hedley_reports_resolve_expected_immunisations($possible_immunisations, $vaccination_history, $initial_opv_administered, $site, $birth_date_obj, $start_date_obj, 'well_child_%s_immunisation');
+}
+
+/**
+ * Resolves which immunisations a child is expected to have had by now.
+ *
+ * A vaccine is expected when none of it was given, or when the dose that
+ * follows the last one given was due before the encounter started.
+ *
+ * @param array $possible_immunisations
+ *   The vaccines that apply to this child at this age.
+ * @param array $vaccination_history
+ *   The doses administered, keyed by vaccine and then by dose.
+ * @param bool $initial_opv_administered
+ *   Whether the OPV birth dose was given within 14 days of birth.
+ * @param string $site
+ *   The site, which decides how many doses some vaccines have and how far
+ *   apart they are.
+ * @param DateTime $birth_date_obj
+ *   The child's date of birth.
+ * @param DateTime $start_date_obj
+ *   The date the encounter started.
+ * @param string $name_pattern
+ *   The activity name for a vaccine, with the vaccine where the %s goes.
+ *
+ * @return array
+ *   The names of the immunisation activities that are expected.
+ */
+function hedley_reports_resolve_expected_immunisations(array $possible_immunisations, array $vaccination_history, $initial_opv_administered, $site, DateTime $birth_date_obj, DateTime $start_date_obj, $name_pattern) {
   $expected = [];
   foreach ($possible_immunisations as $immunisation_type) {
-    $immunisation_full_name = "well_child_{$immunisation_type}_immunisation";
+    $immunisation_full_name = sprintf($name_pattern, $immunisation_type);
     if (empty($vaccination_history)) {
       $expected[] = $immunisation_full_name;
       continue;
@@ -5812,7 +5841,7 @@ function hedley_reports_well_child_get_expected_immunisation_activities(array $e
     $doses = array_keys($performed);
     sort($doses);
     $last_dose = array_reverse($doses)[0];
-    $last_dose_for_immunisation = hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered);
+    $last_dose_for_immunisation = hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered, $site);
     // If all doses we administered, skipping to next immunisation type.
     if ($last_dose == $last_dose_for_immunisation) {
       continue;
@@ -5832,6 +5861,20 @@ function hedley_reports_well_child_get_expected_immunisation_activities(array $e
 
       if ($six_weeks_old_date_obj > $next_dose_date_obj) {
         $next_dose_date_obj = $six_weeks_old_date_obj;
+      }
+    }
+
+    if ($immunisation_type == 'ipv' && $next_dose_as_number == 2 && $site == 'rwanda') {
+      // The interval for IPV is none, since for most sites there is only one
+      // dose. Rwanda's second dose is due on the later of 36 weeks of age and
+      // 28 days after the first, which is what says when it is due here.
+      $next_dose_date_obj = clone $last_dose_date_obj;
+      $next_dose_date_obj->modify('+28 days');
+      $thirty_six_weeks_old_date_obj = clone $birth_date_obj;
+      $thirty_six_weeks_old_date_obj->modify('+36 weeks');
+
+      if ($thirty_six_weeks_old_date_obj > $next_dose_date_obj) {
+        $next_dose_date_obj = $thirty_six_weeks_old_date_obj;
       }
     }
 
@@ -5892,10 +5935,14 @@ function hedley_reports_initial_opv_administered(array $encounter_data, DateTime
  *   The last expected dose for the vaccine (e.g., 'dose-1', 'dose-3'),
  *   or FALSE, if the immunisation type is not recognized.
  */
-function hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered) {
+function hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered, $site) {
   switch ($immunisation_type) {
-    case 'bcg':
     case 'ipv':
+      // Since https://github.com/TIP-Global-Health/eheza-app/issues/1426,
+      // Rwanda gives a second dose. Other sites give one.
+      return $site == 'rwanda' ? 'dose-2' : 'dose-1';
+
+    case 'bcg':
     case 'dtp_sa':
       return 'dose-1';
 
@@ -5933,6 +5980,10 @@ function hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_o
  */
 function hedley_reports_get_interval_for_vaccine($immunisation_type, $site) {
   switch ($immunisation_type) {
+    // The interval for IPV says nothing, since for most sites there is only
+    // one dose. Rwanda's second dose is due on the later of 36 weeks of age
+    // and 28 days after the first, which is applied where the next dose is
+    // resolved rather than here.
     case 'bcg':
     case 'ipv':
     case 'dtp_sa':
@@ -6443,54 +6494,7 @@ function hedley_reports_child_scoreboard_get_expected_immunisation_activities(ar
     }
   }
 
-  $expected = [];
-  foreach ($possible_immunisations as $immunisation_type) {
-    $immunisation_full_name = "child_scoreboard_{$immunisation_type}_iz";
-    if (empty($vaccination_history)) {
-      $expected[] = $immunisation_full_name;
-      continue;
-    }
-
-    $performed = $vaccination_history[$immunisation_type];
-    if (empty($performed)) {
-      $expected[] = $immunisation_full_name;
-      continue;
-    }
-
-    $doses = array_keys($performed);
-    sort($doses);
-    $last_dose = array_reverse($doses)[0];
-    $last_dose_for_immunisation = hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered);
-    // If all doses we administered, skipping to next immunisation type.
-    if ($last_dose == $last_dose_for_immunisation) {
-      continue;
-    }
-
-    // Calculating when next dose is supposed to be administered.
-    $last_dose_as_number = (int) explode('-', $last_dose)[1];
-    $next_dose_as_number = $last_dose_as_number + 1;
-    $last_dose_date = $performed[$last_dose];
-    $interval_between_dosed = hedley_reports_get_interval_for_vaccine($immunisation_type, $site);
-    $last_dose_date_obj = new DateTime($last_dose_date);
-    $next_dose_date_obj = clone $last_dose_date_obj;
-    $next_dose_date_obj->modify($interval_between_dosed);
-    if ($immunisation_type == 'opv' && $next_dose_as_number == 2 && $initial_opv_administered) {
-      $six_weeks_old_date_obj = clone $birth_date_obj;
-      $six_weeks_old_date_obj->modify('+6 weeks');
-
-      if ($six_weeks_old_date_obj > $next_dose_date_obj) {
-        $next_dose_date_obj = $six_weeks_old_date_obj;
-      }
-    }
-
-    // If encounter started after the date when immunisation was supposed
-    // to be administered, adding it as expected.
-    if ($start_date_obj >= $next_dose_date_obj) {
-      $expected[] = $immunisation_full_name;
-    }
-  }
-
-  return $expected;
+  return hedley_reports_resolve_expected_immunisations($possible_immunisations, $vaccination_history, $initial_opv_administered, $site, $birth_date_obj, $start_date_obj, 'child_scoreboard_%s_iz');
 }
 
 /**

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -5758,6 +5758,7 @@ function hedley_reports_well_child_get_expected_immunisation_activities(array $e
   $age_in_days = $interval->days;
 
   $possible_immunisations = ['bcg', 'opv'];
+  $site = variable_get('hedley_general_site_name', '');
   if ($encounter_type != 'newborn-exam') {
     if ($age_in_days >= (6 * 7)) {
       $possible_immunisations = array_merge(
@@ -5772,7 +5773,6 @@ function hedley_reports_well_child_get_expected_immunisation_activities(array $e
       $possible_immunisations[] = 'mr';
     }
 
-    $site = variable_get('hedley_general_site_name', '');
     if ($site == 'burundi') {
       // All 3 doses of DTP were given, it has passed at least 28 days since
       // third dose, and, child is at last 18 months old.
@@ -5930,6 +5930,8 @@ function hedley_reports_initial_opv_administered(array $encounter_data, DateTime
  * @param bool $initial_opv_administered
  *   Indicates whether the initial OPV dose was administered within 14 days
  *   of birth.
+ * @param string $site
+ *   The site, since IPV has a second dose at Rwanda and one elsewhere.
  *
  * @return string|bool
  *   The last expected dose for the vaccine (e.g., 'dose-1', 'dose-3'),


### PR DESCRIPTION
Fixes #2048

Stacked on #2047 — **base is `b131-server-vaccination-engine-drift`, retarget to develop once that merges.** Same rule, third copy; that PR states it in Elm and this one follows it in PHP rather than re-deriving it.

`hedley_reports_get_last_dose_for_vaccine()` capped IPV at one dose and took no site, so once a Rwandan child had dose 1 the loop treated the vaccine as finished (`:5817`) and never expected it again. **Completion has been overstated for every Rwandan child from 36 weeks who is missing the second dose**, in both the well-child and the child-scoreboard reports.

## ⚠️ Why the dose count could not be corrected on its own

`hedley_reports_get_interval_for_vaccine()` returns `'+0 days'` for IPV, and the special case beside it covered only OPV. Correcting the count alone would have put the second dose at `last_dose_date + 0 days`.

Run against the real functions, extracted into a standalone harness — a Rwandan child given IPV-1 at 14 weeks:

| Encounter at | Dose count fixed alone | This PR |
|---|---|---|
| 15 weeks | **expected** | not expected |
| 20 weeks | **expected** | not expected |
| 30 weeks | **expected** | not expected |
| 40 weeks | expected | expected |

Today's bug overstates completion; that fix would have understated it for every child with an IPV-1 record — a larger population, in the other direction. Also checked: Burundi is unaffected at 15 and 40 weeks (one dose, already complete), and a Rwandan child with both doses is not expected at 50 weeks.

## The rule could not be added once, either

`hedley_reports_get_last_dose_for_vaccine()` was called from `:5815` and `:6463`, each followed by its **own byte-identical 37-line copy** of the interval, OPV special case and expected-activity logic. Adding the IPV rule as things stood would have produced two more copies of it — six implementations of one rule across the codebase.

So the block is extracted into `hedley_reports_resolve_expected_immunisations()` first, with the activity-name pattern (`well_child_%s_immunisation` versus `child_scoreboard_%s_iz`) as the only difference between the two call sites, and the rule added to the one that remains. Net 56 insertions, 52 deletions.

The interval function now also says why it says nothing — the comment the client has carried all along and that neither copy of this engine took with it.

## Verification

`php -l` clean; `phpcs` Drupal and DrupalPractice clean.

The discrimination table above comes from running the **real** `hedley_reports_resolve_expected_immunisations`, `hedley_reports_get_last_dose_for_vaccine` and `hedley_reports_get_interval_for_vaccine` in a standalone harness, against a reconstruction of what the naive fix would have done — not from reasoning about them.

**No test.** Nothing in the repo covers this engine, and standing one up means a SimpleTest class with a full install to protect a schedule constant. Stated rather than implied.

## Not included

The DTP-standalone gate here reads `dtp dose-3`, which matches the comment's intent and disagrees with the Elm copies, which read OPV-3. That is not a drift to fix in this direction — this copy is the evidence for what the Elm ones should say, and changing them needs a clinical decision. Carried in the backlog as B-055, and noted on #2047.
