### PR TITLE
Vaccination: wait for three doses of DTP, not three of polio

### DIFF
--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -9536,7 +9536,10 @@ initialVaccinationDateByBirthDate site birthDate initialOpvAdministered vaccinat
             -- All 3 dosed of DTP were given, it has passed
             -- at least 28 days since third dose, and, child
             -- is at last 18 months old.
-            Dict.get VaccineOPV vaccinationProgress
+            -- Burundi calls the DTP combo Pentavalent, and issue #926 asks for
+            -- this dose after three of them - not after three doses of polio,
+            -- which is a different vaccine with a fourth dose of its own.
+            Dict.get VaccineDTP vaccinationProgress
                 |> Maybe.andThen (Dict.get VaccineDoseThird)
                 |> Maybe.map
                     (\thirdDoseDate ->

--- a/server/elm/src/Pages/Scoreboard/Utils.elm
+++ b/server/elm/src/Pages/Scoreboard/Utils.elm
@@ -252,7 +252,10 @@ initialVaccinationDateByBirthDate site birthDate initialOpvAdministered vaccinat
             -- All 3 dosed of DTP were given, it has passed
             -- at least 28 days since third dose, and, child
             -- is at last 18 months old.
-            Dict.get VaccineOPV vaccinationProgress
+            -- Burundi calls the DTP combo Pentavalent, and issue #926 asks for
+            -- this dose after three of them - not after three doses of polio,
+            -- which is a different vaccine with a fourth dose of its own.
+            Dict.get VaccineDTP vaccinationProgress
                 |> Maybe.andThen (Dict.get VaccineDoseThird)
                 |> Maybe.map
                     (\thirdDoseDate ->

--- a/server/hedley/modules/custom/hedley_general/js/elm-main.js
+++ b/server/hedley/modules/custom/hedley_general/js/elm-main.js
@@ -21178,7 +21178,7 @@ var $author$project$Pages$Scoreboard$Utils$initialVaccinationDateByBirthDate = F
 						A2(
 							$elm$core$Maybe$andThen,
 							$pzp1997$assoc_list$AssocList$get($author$project$Backend$Scoreboard$Model$VaccineDoseThird),
-							A2($pzp1997$assoc_list$AssocList$get, $author$project$Backend$Scoreboard$Model$VaccineOPV, vaccinationProgress))));
+							A2($pzp1997$assoc_list$AssocList$get, $author$project$Backend$Scoreboard$Model$VaccineDTP, vaccinationProgress))));
 			case 'VaccinePCV13':
 				return A3(
 					$justinmimbs$date$Date$add,


### PR DESCRIPTION
Fixes #2050

Stacked on #2047 — **base is `b131-server-vaccination-engine-drift`, retarget to develop once that merges.** It touches the same function, and this is the correction that PR's review surfaced for the third time.

The DTP standalone booster is due after three doses of DTP. The code waited for three doses of **polio** — a different vaccine, which in Burundi has four doses of its own.

## This was gated on a clinician, and should not have been

It sat in the improvement backlog from Round 1 as needing clinical sign-off, on the grounds that reading polio might be a deliberate proxy. It is not a judgement call: the requirement is written down.

`29a578fde` ("Logic for suggesting DTP (standalone vaccine)") came from PR #927, for issue **#926**:

> **Add new vaccine called DTP for one dose at 18 months. It should only appear after 3 doses of Pentavalent and with a minimum 28 day interval from the last Pentavalent dose.**

**#920** gives the naming — Burundi calls the DTP-HepB-Hib combo **Pentavalent**, which is `VaccineDTP` — and its schedule table gives Pentavalent 3 doses against Oral Polio's 4. They are not interchangeable, and @anvmn's comment on #926 confirms the mapping at the time.

Four sources agree; the code was alone:

| Source | Says |
|---|---|
| Requirement #926 | after 3 doses of Pentavalent |
| The comment above the code | "All 3 doses of DTP were given" |
| The variable it binds | `fourWeeksAfterThirdDTPDose` |
| The PHP engine (`hedley_reports.module:5779`) | `$vaccination_progress['dtp']['dose-3']` |
| The Elm code | `VaccineOPV`, dose 3 |

## Who it affects

Burundi only, and only children catching up. On schedule, 18 months of age decides the date and the lookup makes no difference.

* **Three DTP doses, polio incomplete** → the lookup finds nothing, the fallback is "never", the booster is never due. The child reads on track for a dose nobody will offer.
* **Polio dose 3 earlier than DTP dose 3** → the booster is offered inside the 28-day window the requirement asks to wait out.

## Both copies, together

`client/src/elm/Measurement/Utils.elm` and `server/elm/src/Pages/Scoreboard/Utils.elm`. Moving one alone would re-create the client/scoreboard drift #2046 has just finished repairing. The PHP already reads `dtp` and does not change.

## Verification

`elm make src/elm/Main.elm` — Success, 548 modules · `elm-test` — 2974 passed · `elm make src/Main.elm` (server) — Success, 84 · `elm-format --validate` both files — clean · `elm-review` cold, both apps — I found no errors! · regenerated bundle **byte-compared against a fresh build of the committed source — identical**.

No new test: the change is a one-word lookup with the intent stated in the comment beside it, and `server/elm` has no test suite at all.


## Which reports move

Both consumers of `generateFutureVaccinationsData`, not only the scoreboard:

* **Aggregated scoreboard**, Universal Intervention row 1 (`Pages/Scoreboard/View.elm:619`).
* **Reports, "up to date with immunization"** (`Pages/Reports/View.elm:3127`), whose buckets run to 24 months — so its `19To24Months` row moves for Burundi with this change, and its `15WeeksTo10Months`, `10To19Months` and `19To24Months` rows move for Rwanda with #2047's IPV change.

Worth comparing both reports before and after, rather than the scoreboard alone.
