### PR TITLE
CI: let the code sniffer install again

### DIFF
--- a/ci-scripts/install_coder.sh
+++ b/ci-scripts/install_coder.sh
@@ -14,8 +14,18 @@ if [[ ! -f "$COMPOSER2" ]]; then
   curl -sS https://getcomposer.org/download/latest-stable/composer.phar -o "$COMPOSER2"
 fi
 
-COMPOSER_MEMORY_LIMIT=-1 php "$COMPOSER2" global require squizlabs/php_codesniffer:3.5.6
-COMPOSER_MEMORY_LIMIT=-1 php "$COMPOSER2" global require drupal/coder:8.3.9
+# Composer refuses to install a package under a security advisory, and one was
+# published on 2026-08-06 against every php_codesniffer below 3.13.6 - which
+# stopped this job installing anything at all, on every branch. The advisory is
+# an OS command injection, and this runs a linter over our own source in CI,
+# where that is not reachable, so it is allowed through here.
+#
+# Upgrading instead is a bigger piece of work than it looks: 3.13.6 needs a
+# newer coder, which enables sniffs that did not exist in 3.5.6 and reports
+# hundreds of findings across the custom modules. Worth doing on its own, not
+# while it is blocking every branch.
+COMPOSER_MEMORY_LIMIT=-1 php "$COMPOSER2" global require --no-security-blocking squizlabs/php_codesniffer:3.5.6
+COMPOSER_MEMORY_LIMIT=-1 php "$COMPOSER2" global require --no-security-blocking drupal/coder:8.3.9
 if [[ -f ~/.composer/vendor/bin/phpcs ]]
 then
   ~/.composer/vendor/bin/phpcs --config-set installed_paths "$HOME"/.composer/vendor/drupal/coder/coder_sniffer


### PR DESCRIPTION
Fixes #2052

`lint_phpcs` fails on **every branch, including develop**, and on nothing to do with any code. The job dies inside `ci-scripts/install_coder.sh` before linting a file:

```
Root composer.json requires squizlabs/php_codesniffer 3.5.6 … but these were not
loaded, because they are affected by security advisories ("PKSA-rdkp-vv9z-mjkg")
```

Composer refuses to install a package under advisory, and **PKSA-rdkp-vv9z-mjkg — OS command injection, covering everything below 3.13.6** — became visible to composer's install-time check this morning.

This passes `--no-security-blocking` on the two installs. The advisory is still reported in the log; it just no longer stops the install.

## That it is universal, not branch-specific

| Job | Ran | Result |
|---|---|---|
| #2049 | 08:29 UTC | pass |
| #2051 | 11:16 UTC | pass |
| #2047 | 11:36 UTC | **fail** |
| #2043 — empty commit, as a test | ~12:0x UTC | **fail** |

Composer is not the variable: `latest-stable` has been 2.10.2 since 1 July, so all four runs fetched the same binary. The advisory data went live on Packagist between 11:16 and 11:36.

The last row settles it — an empty commit on a branch that had passed two hours earlier, which then failed. **The PRs still showing a green `lint_phpcs` are stale; they will fail on any re-run.**

## Why this, and not the upgrade

I tried the upgrade first, and it is a larger piece of work than it appears:

* **phpcs 3.13.6 cannot load `drupal/coder:8.3.9` at all.** It rejects the `DrupalPractice\Sniffs\CodeAnalysis\ScopeInfo` helper as a malformed sniff and aborts for every module. Bumping phpcs alone leaves the job red.
* **The coder that does work with it (8.3.31) enables sniffs that did not exist in 3.5.6**, which report **349 findings under `Drupal` and 236 under `DrupalPractice`** across `server/hedley/modules/custom` — mostly "class short comment should describe what the class does" (283) and "Unused variable `$plugin`" (225). 13 files are auto-fixable.
* It also pulls in a composer plugin (`dealerdirect/phpcodesniffer-composer-installer`) that must be explicitly allowed, so the script needs a third change.

That is a worthwhile change and it should be made on its own, with the findings addressed as findings — not while six PRs and develop are red behind it.

## Verification

Ran the script's exact sequence in a scratch composer home:

* `composer global require --no-security-blocking squizlabs/php_codesniffer:3.5.6` — **exit 0**, 3.5.6 installed, advisory reported and not fatal
* `… drupal/coder:8.3.9` — **exit 0**
* `phpcs --config-set installed_paths …` — **exit 0**
* `phpcs --standard=DrupalPractice` over a module — **exit 0**, no sniff-loading errors

Checking the exit codes rather than the absence of output matters here: an earlier attempt of mine looked clean only because the standard had failed to install and phpcs was linting with nothing loaded.
