### PR TITLE
Deploy: let a failed deploy say so

### DIFF
--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -22,10 +22,10 @@ and `server/RoboFile.php`.
 2. **Aborts if the eheza-app working tree is dirty.**
 3. **Aborts if the Pantheon clone (`.pantheon-<name>`) is dirty.**
 4. **Aborts if `pantheon.upstream.yml` is missing or has no `php_version:`.**
-5. Checks out the target branch in the Pantheon clone (`master` for Dev, else the multidev branch name).
+5. Checks out the target branch in the Pantheon clone (`master` for Dev, else the multidev branch name), then pulls it. Checkout and pull fail with different messages, so a pull that fails for its own reasons — no network to the code server, no upstream, a conflict — does not read as a missing branch.
 6. rsyncs `www/.` (server) and `client/dist/.` (app) into the clone, excluding `.git`, `.ddev`, `client`, etc.
 7. Prints `git status`, then asks **"Commit changes and deploy?"** (interactive — needs a human).
-8. On confirm: `git pull && git add . && git commit -am 'Site update' && git push` to Pantheon.
+8. On confirm: `git add .`, commit if there is anything to commit, then `git push` to Pantheon. Nothing to commit is not a failure — re-running a deploy after fixing something on the Pantheon side finds no change to make, and the push still runs in case an earlier run committed without pushing.
 9. Calls `deployPantheonSync(<env>, FALSE)` → runs `cc all` (×2), `updb -y`, `fra -y`, `cc all`, `uli` on that env.
 
 `$branchName == 'master'` maps to the Pantheon **`dev`** environment.

--- a/.claude/skills/_deploy-common/deploy-reference.md
+++ b/.claude/skills/_deploy-common/deploy-reference.md
@@ -18,7 +18,7 @@ and `server/RoboFile.php`.
 ## What the robo commands actually do (`server/RoboFile.php`)
 
 ### `deployPantheon($branchName = 'master')` — `ddev robo deploy:pantheon [env]`
-1. Resolves `PANTHEON_NAME` from the env var (falls back to the `PANTHEON_NAME` const, `eheza-app`, if unset — which is why the env var must be set correctly).
+1. Resolves `PANTHEON_NAME` from the env var, and refuses to run without it. It used to fall back to a `PANTHEON_NAME` const of `eheza-app` — which is itself a real site, so an unset variable deployed to someone else's environment.
 2. **Aborts if the eheza-app working tree is dirty.**
 3. **Aborts if the Pantheon clone (`.pantheon-<name>`) is dirty.**
 4. **Aborts if `pantheon.upstream.yml` is missing or has no `php_version:`.**

--- a/.claude/skills/deploy-multidev/SKILL.md
+++ b/.claude/skills/deploy-multidev/SKILL.md
@@ -54,7 +54,7 @@ Report a ✅/❌ checklist. **Stop and surface any ❌.**
    git ls-remote --heads origin <source-branch>   # ...or on origin
    git status -s -uno                        # expect empty (no tracked changes)
    ```
-3. **Pantheon clone exists, clean, and has the target multidev branch.** The deploy runs `git checkout <env>` inside the clone and aborts with *"Specified branch `<env>` does not exist"* if that branch isn't there:
+3. **Pantheon clone exists, clean, and has the target multidev branch.** The deploy runs `git checkout <env>` inside the clone and aborts with *"Specified branch `<env>` does not exist"* if that branch isn't there. It then pulls, which aborts with *"Failed to pull `<env>`"* — a different message, because a pull fails for reasons of its own:
    ```bash
    git -C server/.pantheon-<PANTHEON_NAME> status -s -uno              # clean
    git -C server/.pantheon-<PANTHEON_NAME> fetch origin                # refresh

--- a/server/RoboFile.php
+++ b/server/RoboFile.php
@@ -56,12 +56,23 @@ class RoboFile extends Tasks {
     }
 
     $result = $this
-      ->taskExec("cd $pantheonDirectory && git checkout $branchName && git pull")
+      ->taskExec("cd $pantheonDirectory && git checkout $branchName")
       ->printOutput(FALSE)
       ->run();
 
     if (!$result->wasSuccessful()) {
       throw new Exception("Specified branch $branchName does not exist.");
+    }
+
+    // Before the rsync, so that the tree is clean when it runs. Its own check,
+    // because a pull fails for reasons that have nothing to do with the branch
+    // existing - no network to the code server, no upstream, a conflict.
+    $result = $this
+      ->taskExec("cd $pantheonDirectory && git pull")
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new Exception("Failed to pull $branchName in the Pantheon directory ($pantheonDirectory)");
     }
 
     $rsyncExclude = [
@@ -124,7 +135,11 @@ class RoboFile extends Tasks {
       return;
     }
 
-    $push_status = $this->_exec("cd $pantheonDirectory && git add . && git commit -am 'Site update' && git push")->getExitCode();
+    // `git commit` exits non-zero when there is nothing to commit, which is an
+    // ordinary case: re-running the deploy after fixing something on the
+    // Pantheon side finds the rsync has produced no change. Push regardless -
+    // an earlier run may have committed without getting as far as pushing.
+    $push_status = $this->_exec("cd $pantheonDirectory && git add . && { git diff --cached --quiet || git commit -m 'Site update'; } && git push")->getExitCode();
     if ($push_status != 0) {
       throw new Exception('Failed to push to Pantheon');
     }
@@ -142,12 +157,17 @@ class RoboFile extends Tasks {
    *   Determine if a deploy should be done by terminus. That is, for example
    *   should TEST environment be updated from DEV.
    *
+   * @return \Robo\Result
+   *   The result of the deploy steps.
+   *
+   * @throws \Exception
+   *   If PANTHEON_NAME is not set, or any of the deploy steps failed.
    * @throws \Robo\Exception\TaskException
    */
   public function deployPantheonSync(string $env = 'test', bool $doDeploy = TRUE) {
-    // Required, as deployPantheon() requires it. The constant below is another
-    // real site, so falling back to it would run these steps against someone
-    // else's environment.
+    // Required, as deployPantheon() requires it. This used to fall back to a
+    // constant naming another of our sites, so an unset variable deployed to
+    // someone else's environment rather than failing.
     $pantheonName = getenv('PANTHEON_NAME');
     if (!$pantheonName) {
       throw new Exception('Please specify PANTHEON_NAME in your DDEV local config, so it is clear which site is being deployed to.');

--- a/server/RoboFile.php
+++ b/server/RoboFile.php
@@ -9,14 +9,6 @@ use Symfony\Component\Yaml\Yaml;
 class RoboFile extends Tasks {
 
   /**
-   * The Pantheon name.
-   *
-   * You need to fill this information for Robo to know what's the name of your
-   * site.
-   */
-  const PANTHEON_NAME = 'eheza-app';
-
-  /**
    * Deploy to Pantheon.
    *
    * @param string $branchName
@@ -25,10 +17,6 @@ class RoboFile extends Tasks {
    * @throws \Exception
    */
   public function deployPantheon($branchName = 'master') {
-    if (empty(self::PANTHEON_NAME)) {
-      throw new Exception('You need to fill the "PANTHEON_NAME" const in the Robo file, so it will know what is the name of your site.');
-    }
-
     $site = getenv('PANTHEON_NAME');
     if (!$site) {
       throw new Exception('Please specify PANTHEON_NAME in your DDEV local config, so it will be possible to resolve pantheon directory.');
@@ -68,7 +56,7 @@ class RoboFile extends Tasks {
     }
 
     $result = $this
-      ->taskExec("cd $pantheonDirectory && git checkout $branchName")
+      ->taskExec("cd $pantheonDirectory && git checkout $branchName && git pull")
       ->printOutput(FALSE)
       ->run();
 
@@ -136,8 +124,8 @@ class RoboFile extends Tasks {
       return;
     }
 
-    $push_status = $this->_exec("cd $pantheonDirectory && git pull && git add . && git commit -am 'Site update' && git push")->getExitCode();
-    if ($client_sync_result != 0) {
+    $push_status = $this->_exec("cd $pantheonDirectory && git add . && git commit -am 'Site update' && git push")->getExitCode();
+    if ($push_status != 0) {
       throw new Exception('Failed to push to Pantheon');
     }
 
@@ -157,11 +145,12 @@ class RoboFile extends Tasks {
    * @throws \Robo\Exception\TaskException
    */
   public function deployPantheonSync(string $env = 'test', bool $doDeploy = TRUE) {
-    if (getenv('PANTHEON_NAME')) {
-      $pantheonName = getenv('PANTHEON_NAME');
-    }
-    else {
-      $pantheonName = self::PANTHEON_NAME;
+    // Required, as deployPantheon() requires it. The constant below is another
+    // real site, so falling back to it would run these steps against someone
+    // else's environment.
+    $pantheonName = getenv('PANTHEON_NAME');
+    if (!$pantheonName) {
+      throw new Exception('Please specify PANTHEON_NAME in your DDEV local config, so it is clear which site is being deployed to.');
     }
 
     $pantheonTerminusEnvironment = $pantheonName . '.' . $env;
@@ -182,8 +171,14 @@ class RoboFile extends Tasks {
       // clear caches again so the reverted config takes effect.
       ->exec("terminus remote:drush $pantheonTerminusEnvironment -- fra -y")
       ->exec("terminus remote:drush $pantheonTerminusEnvironment -- cc all")
-      ->exec("terminus remote:drush $pantheonTerminusEnvironment -- uli")
-      ->run();
+      ->exec("terminus remote:drush $pantheonTerminusEnvironment -- uli");
+
+    $result = $task->run();
+    if (!$result->wasSuccessful()) {
+      throw new Exception("Deploy steps failed on $pantheonTerminusEnvironment");
+    }
+
+    return $result;
   }
 
   /**


### PR DESCRIPTION
Fixes #2054

Three places in `server/RoboFile.php` where a deploy could fail and still report success. Each is small; together they mean the output you watch during a release does not reliably say that the code arrived, or where.

## What changes

**The push result is actually tested.** `$push_status` was assigned and never read — the throw beside it re-tested `$client_sync_result`, the rsync code from `:108` that `:109` had already checked and which is therefore zero by the time it is reached. A failed `git pull`, `commit` or `push` went straight on to `cc`, `updb` and `fra` against an environment that never received the code.

**The pull happens with the checkout, not after the rsync.** It ran at `:139` against an already-dirty tree, which is precisely where a two-machine deploy fails — and it failed inside the statement whose result was being ignored.

**The sync hands back what happened.** `deployPantheonSync` ended `->run();` with the Result discarded and returned void, so the command exited 0 even when terminus, `updb` or `fra` failed. It now raises on failure and returns the result.

**`PANTHEON_NAME` is required, and the constant is gone.** The sync fell back to `const PANTHEON_NAME = 'eheza-app'` when the variable was unset. **That is a real site of ours** — I confirmed it in the Pantheon site list — so the fallback did not fail against a nonexistent target, it ran `cc`, `updb`, `fra` and `uli` against a different live environment, with the errors hidden by the previous defect. The constant is deleted rather than left in place: it is the mechanism of this defect, and its only other use was `empty('eheza-app')`, a check that could never fire.

The deploy skill's reference doc documented the fallback, so it is updated too.

## Verification, and what it cannot cover

`php -l` clean; `phpcs` Drupal and DrupalPractice clean.

I cannot exercise a real deploy, and did not fake one. What I did run is the branching of all three defects with the shell stubbed:

```
                                          BEFORE                     AFTER
(a) git push fails, rsync succeeded       continues to cc/updb/fra   throws
(a) everything succeeds                   continues to cc/updb/fra   continues to cc/updb/fra
(b) updb fails during sync                caller sees success        throws
(b) all steps succeed                     caller sees success        returns success
(c) PANTHEON_NAME unset                   eheza-app (another site)   throws
(c) PANTHEON_NAME=vhw                     vhw                        vhw
```

Worth one reviewer's eye in particular: **removing the constant would fatal at runtime if any use were left behind**, since `self::PANTHEON_NAME` becomes an undefined class constant — and `php -l` does not catch that. I grepped the file and the repo; the only remaining references are to the environment variable, and the one dead `self::` use was removed with it.
