### PR TITLE
Build: make gulp publish fail when the build fails

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -14,6 +14,11 @@ var $ = require("gulp-load-plugins")();
 // "del" is used to clean out directories and such
 var del = require("del");
 
+// Publishing must fail when the build does. The watch loop must not: it keeps
+// running so that the next save can fix the error, and shows the error in the
+// browser meanwhile. The same tasks serve both, so they ask which they are in.
+var isPublishing = false;
+
 var rename = require("gulp-rename");
 // BrowserSync isn't a gulp package, and needs to be loaded manually
 var browserSync = require("browser-sync");
@@ -272,6 +277,11 @@ gulp.task("minify", gulp.series(
         mangle: false
       }))).on('error', function(err) {
         console.error(err);
+
+        if (isPublishing) {
+          // A partially minified dist is not something to ship quietly.
+          this.destroy(err);
+        }
       })
 
     // Minify CSS
@@ -309,6 +319,18 @@ gulp.task("deploy", function() {
 });
 
 gulp.task('elm', gulp.series('version', function elmCompile() {
+  if (isPublishing) {
+    // No plumber and no error handler, so a compile error ends the task and
+    // with it the publish. Swallowing it here would leave the error page that
+    // the watch loop writes to be packaged into dist and shipped as the app.
+    return gulp.src('src/elm/Main.elm')
+      .pipe(elm({
+        'debug': false,
+        'warn': false
+      }))
+      .pipe(gulp.dest('serve'));
+  }
+
   return gulp.src('src/elm/Main.elm')
     .pipe(plumber())
     .pipe(elm({
@@ -489,7 +511,13 @@ gulp.task("deploy:revert", function(cb) {
 
 // Builds your site with the "build" command and then runs all the optimizations on
 // it and outputs it to "./dist"
+gulp.task("publish:mark", function markPublishing(cb) {
+  isPublishing = true;
+  cb();
+});
+
 gulp.task("publish", gulp.series(
+  "publish:mark",
   "deploy:config",
   gulp.parallel("build", "clean:prod"),
   gulp.parallel("minify", "cname", "images"),

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -61,12 +61,20 @@ gulp.task("clean:prod", function() {
 });
 
 // Compiles the SASS files and moves them into the "assets/stylesheets" directory
-gulp.task("styles", function() {
+gulp.task("styles", function styleCompile() {
   // Looks at the style.scss file for what to include and creates a style.css file
-  return gulp.src("src/assets/scss/style.scss")
-    .pipe(plumber())
-    .pipe(sass({silenceDeprecations: ['legacy-js-api', 'import']}))
-    .on('error', function(err) {
+  var stream = gulp.src("src/assets/scss/style.scss");
+
+  // Publishing attaches neither plumber nor the handler below, so a SASS error
+  // travels down the stream and fails the task.
+  if (!isPublishing) {
+    stream = stream.pipe(plumber());
+  }
+
+  stream = stream.pipe(sass({silenceDeprecations: ['legacy-js-api', 'import']}));
+
+  if (!isPublishing) {
+    stream = stream.on('error', function(err) {
       browserSync.notify("SASS error");
 
       console.error(err.message);
@@ -79,7 +87,10 @@ gulp.task("styles", function() {
 
       // No need to continue processing.
       this.emit('end');
-    })
+    });
+  }
+
+  return stream
     // AutoPrefix your CSS so it works between browsers
     .pipe($.autoprefixer("last 1 version", {
       cascade: true
@@ -277,11 +288,6 @@ gulp.task("minify", gulp.series(
         mangle: false
       }))).on('error', function(err) {
         console.error(err);
-
-        if (isPublishing) {
-          // A partially minified dist is not something to ship quietly.
-          this.destroy(err);
-        }
       })
 
     // Minify CSS
@@ -319,25 +325,22 @@ gulp.task("deploy", function() {
 });
 
 gulp.task('elm', gulp.series('version', function elmCompile() {
-  if (isPublishing) {
-    // No plumber and no error handler, so a compile error ends the task and
-    // with it the publish. Swallowing it here would leave the error page that
-    // the watch loop writes to be packaged into dist and shipped as the app.
-    return gulp.src('src/elm/Main.elm')
-      .pipe(elm({
-        'debug': false,
-        'warn': false
-      }))
-      .pipe(gulp.dest('serve'));
+  var stream = gulp.src('src/elm/Main.elm');
+
+  // Publishing attaches neither plumber nor the handler below, so a compile
+  // error travels down the stream and fails the task. Swallowing it would
+  // package the error page written below into dist and ship it as the app.
+  if (!isPublishing) {
+    stream = stream.pipe(plumber());
   }
 
-  return gulp.src('src/elm/Main.elm')
-    .pipe(plumber())
-    .pipe(elm({
-      'debug': false,
-      'warn': false
-    }))
-    .on('error', function(err) {
+  stream = stream.pipe(elm({
+    'debug': false,
+    'warn': false
+  }));
+
+  if (!isPublishing) {
+    stream = stream.on('error', function(err) {
       console.error(err.message);
 
       browserSync.notify("Elm compile error", 5000);
@@ -347,8 +350,10 @@ gulp.task('elm', gulp.series('version', function elmCompile() {
       fs.writeFileSync('serve/index.html',
         "<!DOCTYPE HTML><html><body><pre>" + err.message +
         "</pre></body></html>");
-    })
-    .pipe(gulp.dest('serve'));
+    });
+  }
+
+  return stream.pipe(gulp.dest('serve'));
 }));
 
 // BrowserSync will serve our site on a local server for us and other devices to use
@@ -516,10 +521,18 @@ gulp.task("publish:mark", function markPublishing(cb) {
   cb();
 });
 
+// Cleared so that a task graph running publish before a serving task in the
+// same process (say "gulp publish watch") leaves the watch loop its plumber.
+gulp.task("publish:unmark", function unmarkPublishing(cb) {
+  isPublishing = false;
+  cb();
+});
+
 gulp.task("publish", gulp.series(
   "publish:mark",
   "deploy:config",
   gulp.parallel("build", "clean:prod"),
   gulp.parallel("minify", "cname", "images"),
-  "deploy:revert"
+  "deploy:revert",
+  "publish:unmark"
 ));


### PR DESCRIPTION
Fixes #2056

`gulp publish` exits 0 when the build fails, and writes the compiler error page to `dist/index.html` as the app.

The cause is tasks shared by two callers with opposite needs. `elm` and `styles` both pipe through `plumber()` and both catch their compiler's error, write it into `serve/index.html` and continue — that is what the watch loop needs, so a typo does not kill the watcher and the error shows up in the browser. `publish` runs the same tasks and inherits the swallowing.

Both tasks now attach `plumber` and their error handler only when not publishing. `publish` sets the flag as its first step and clears it as its last, so a graph that runs publish before a serving task in one process leaves the watch loop intact.

## Verified by running it

Deliberate type error in `client/src/elm/Pages/Device/View.elm`, `gulp publish`, on `develop`:

```
gulp exit=0
dist/index.html: 440 bytes
<!DOCTYPE HTML><html><body><pre>-- TYPE MISMATCH ---------- src/elm/Pages/Device/View.elm
```

On this branch, four runs:

| run | expected | got |
|---|---|---|
| broken Elm + `publish` | fail | exit 1, no dist |
| broken SCSS + `publish` | fail | exit 1, no dist |
| broken Elm + `build` (watch path) | still writes the error page | exit 0, error page intact |
| clean + `publish` | succeed | exit 0, real 1380-byte dist |

The third row is the discrimination test: the dev loop keeps the behaviour the comments say it must.

## Review history

The first commit fixed only the Elm path and also changed the uglify error handler. Review found the SCSS path unfixed — the same failure, reached through SASS — and that the uglify change was inert, since `this.destroy()` there acts on a mid-pipeline stream rather than the one the task returns. A parse error in a minified file ends identically with or without it, on this branch and on develop. That hunk is gone; the SCSS path is fixed.

## Not in this PR

A failing `publish` stops before `deploy:revert`, leaving the tracked `client/src/elm/Config.elm` holding deployment config. This change is what makes that path reachable for Elm errors. It belongs with the deploy-safety work (B-146) rather than here, and is recorded as an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)