### PR TITLE
Person records: stop a person edit from erasing recorded GPS coordinates

### DIFF
--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4438,7 +4438,7 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
                     -- Adding GPS coordinates.
                     personWithCoordinates =
                         if gpsCoordinatesEnabled features && person.saveGPSLocation then
-                            updatePersonWithCooridnates person coordinates
+                            updatePersonWithCoordinates person coordinates
 
                         else
                             person
@@ -4648,7 +4648,7 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
                 -- fix this leaves what is stored alone.
                 personWithCoordinates =
                     if gpsCoordinatesEnabled features && person.saveGPSLocation then
-                        updatePersonWithCooridnates personWithStoredCoordinates coordinates
+                        updatePersonWithCoordinates personWithStoredCoordinates coordinates
 
                     else
                         personWithStoredCoordinates
@@ -10469,8 +10469,8 @@ generateTuberculosisEncounterCompletedMsgs currentDate after id =
         |> Maybe.withDefault []
 
 
-updatePersonWithCooridnates : Person -> Maybe App.Model.GPSCoordinates -> Person
-updatePersonWithCooridnates person =
+updatePersonWithCoordinates : Person -> Maybe App.Model.GPSCoordinates -> Person
+updatePersonWithCoordinates person =
     Maybe.map
         (\coordinates ->
             { person

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4627,26 +4627,31 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
 
         PatchPerson origin personId person ->
             let
-                -- Adding GPS coordinates.
+                -- The edit form has no coordinate inputs, so it always reports
+                -- Nothing for them. Patching that in would erase the location
+                -- recorded at registration, so the stored one is carried over.
+                personWithStoredCoordinates =
+                    Dict.get personId model.people
+                        |> Maybe.andThen RemoteData.toMaybe
+                        |> Maybe.map
+                            (\stored ->
+                                { person
+                                    | registrationLatitude = stored.registrationLatitude
+                                    , registrationLongitude = stored.registrationLongitude
+                                }
+                            )
+                        |> Maybe.withDefault person
+
+                -- Adding GPS coordinates. Laid over the stored ones, rather
+                -- than offered instead of them, because a reading that was
+                -- asked for is not always a reading that arrived: without a
+                -- fix this leaves what is stored alone.
                 personWithCoordinates =
                     if gpsCoordinatesEnabled features && person.saveGPSLocation then
-                        updatePersonWithCooridnates person coordinates
+                        updatePersonWithCooridnates personWithStoredCoordinates coordinates
 
                     else
-                        -- The edit form has no coordinate inputs, so it always
-                        -- reports Nothing for them. Patching that in would
-                        -- erase the location recorded at registration, so the
-                        -- stored one is carried over instead.
-                        Dict.get personId model.people
-                            |> Maybe.andThen RemoteData.toMaybe
-                            |> Maybe.map
-                                (\stored ->
-                                    { person
-                                        | registrationLatitude = stored.registrationLatitude
-                                        , registrationLongitude = stored.registrationLongitude
-                                    }
-                                )
-                            |> Maybe.withDefault person
+                        personWithStoredCoordinates
             in
             ( { model | postPerson = Loading }
             , sw.patchFull personEndpoint personId personWithCoordinates

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4633,7 +4633,20 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
                         updatePersonWithCooridnates person coordinates
 
                     else
-                        person
+                        -- The edit form has no coordinate inputs, so it always
+                        -- reports Nothing for them. Patching that in would
+                        -- erase the location recorded at registration, so the
+                        -- stored one is carried over instead.
+                        Dict.get personId model.people
+                            |> Maybe.andThen RemoteData.toMaybe
+                            |> Maybe.map
+                                (\stored ->
+                                    { person
+                                        | registrationLatitude = stored.registrationLatitude
+                                        , registrationLongitude = stored.registrationLongitude
+                                    }
+                                )
+                            |> Maybe.withDefault person
             in
             ( { model | postPerson = Loading }
             , sw.patchFull personEndpoint personId personWithCoordinates

--- a/server/hedley/modules/custom/hedley_person/scripts/restore-wiped-gps-coordinates.php
+++ b/server/hedley/modules/custom/hedley_person/scripts/restore-wiped-gps-coordinates.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * @file
+ * Restores GPS coordinates that editing a person erased.
+ *
+ * The person edit form has no coordinate inputs, so it reported Nothing for
+ * them, and the resulting patch wrote that over whatever the device recorded
+ * at registration. One ordinary edit - a corrected name - was enough. The
+ * fields have no other writer and no screen that can restore them.
+ *
+ * What the edit did not touch is the node's revisions, so the erased values
+ * are still there to be read back. This restores the most recent revision
+ * that held both coordinates, to persons that hold neither now.
+ *
+ * Restoring a person writes a new revision, which every device holding that
+ * person then downloads again.
+ *
+ * Execution: drush scr profiles/hedley/modules/custom/hedley_person/scripts/
+ *   restore-wiped-gps-coordinates.php [--dry_run] [--batch=50] [--nid=0].
+ */
+
+if (!drupal_is_cli()) {
+  // Prevent execution from browser.
+  return;
+}
+
+// Report what would be restored, without restoring it.
+$dry_run = (bool) drush_get_option('dry_run', FALSE);
+
+// Resume after this person, for a run that stopped on memory. A restored
+// person no longer matches, so a plain re-run resumes on its own; this is
+// here for a run that has to be repeated deliberately.
+$nid = drush_get_option('nid', 0);
+
+// Get the number of nodes to be processed at once.
+$batch = drush_get_option('batch', 50);
+
+// Get allowed memory limit.
+$memory_limit = drush_get_option('memory_limit', 800);
+
+// Persons whose revisions hold a latitude, and whose current data holds none.
+// Longitude is not named here: it is read per person below, since a person
+// missing only one of the two is a case to report rather than to guess at.
+$query = db_select('field_revision_field_latitude', 'r');
+$query->join('node', 'n', 'n.nid = r.entity_id');
+// Field tables keep the rows of deleted field instances and are keyed by
+// entity type as well, so both are named rather than left to the fact that
+// this field is only on nodes today.
+$query->leftJoin('field_data_field_latitude', 'd', 'd.entity_id = r.entity_id AND d.entity_type = r.entity_type AND d.deleted = r.deleted');
+hedley_general_apply_exclude_deleted($query, 'n');
+
+$query
+  ->fields('r', ['entity_id'])
+  ->condition('r.entity_type', 'node')
+  ->condition('r.deleted', 0)
+  ->isNotNull('r.field_latitude_value')
+  ->condition('n.type', 'person')
+  ->condition('n.status', NODE_PUBLISHED)
+  ->isNull('d.entity_id')
+  ->distinct();
+
+$affected = $query->execute()->fetchCol();
+sort($affected);
+
+if ($nid) {
+  $affected = array_values(array_filter($affected, function ($person_id) use ($nid) {
+    return $person_id > $nid;
+  }));
+}
+
+$count = count($affected);
+if ($count == 0) {
+  drush_print('No person is missing coordinates that a revision still holds.');
+  return;
+}
+
+drush_print("$count persons lost their coordinates.");
+
+$total = 0;
+$incomplete = 0;
+foreach (array_chunk($affected, $batch) as $chunk) {
+  foreach ($chunk as $person_id) {
+    // The newest revision that recorded a latitude. Longitude is taken from
+    // that same revision, so the pair that is restored is the pair that was
+    // read together from one device at one moment.
+    $revision = db_select('field_revision_field_latitude', 'r')
+      ->fields('r', ['revision_id', 'field_latitude_value'])
+      ->condition('entity_id', $person_id)
+      ->condition('entity_type', 'node')
+      ->condition('deleted', 0)
+      ->isNotNull('field_latitude_value')
+      ->orderBy('revision_id', 'DESC')
+      ->range(0, 1)
+      ->execute()
+      ->fetchAssoc();
+
+    $longitude = db_select('field_revision_field_longitude', 'r')
+      ->fields('r', ['field_longitude_value'])
+      ->condition('entity_id', $person_id)
+      ->condition('entity_type', 'node')
+      ->condition('deleted', 0)
+      ->condition('revision_id', $revision['revision_id'])
+      ->execute()
+      ->fetchField();
+
+    if ($longitude === FALSE || !isset($longitude)) {
+      // Half a coordinate places nobody, so it is left alone and reported.
+      drush_print("  Person $person_id has a latitude to restore but no longitude alongside it. Skipped.");
+      $incomplete++;
+      continue;
+    }
+
+    if ($dry_run) {
+      drush_print("  Person $person_id would be restored to {$revision['field_latitude_value']}, $longitude.");
+      $total++;
+      continue;
+    }
+
+    $person = node_load($person_id);
+    if (!$person) {
+      continue;
+    }
+
+    $person->field_latitude[LANGUAGE_NONE][0]['value'] = $revision['field_latitude_value'];
+    $person->field_longitude[LANGUAGE_NONE][0]['value'] = $longitude;
+    node_save($person);
+    $total++;
+  }
+
+  $memory = round(memory_get_usage() / 1048576);
+  if ($memory >= $memory_limit) {
+    drush_print(dt('Stopped before running out of memory, after @total of @count persons. Run again with --nid=@nid to continue.', [
+      '@total' => $total,
+      '@count' => $count,
+      '@nid' => end($chunk),
+    ]));
+    return;
+  }
+
+  // Free up memory.
+  drupal_static_reset();
+}
+
+if ($incomplete) {
+  drush_print("$incomplete of them had no longitude to go with the latitude, and were skipped.");
+}
+
+if ($dry_run) {
+  drush_print("Dry run. $total persons would be restored.");
+  return;
+}
+
+drush_print("Done! Restored coordinates for $total of $count persons.");

--- a/server/hedley/modules/custom/hedley_restful/plugins/restful/node/sync/HedleyRestfulSync.class.php
+++ b/server/hedley/modules/custom/hedley_restful/plugins/restful/node/sync/HedleyRestfulSync.class.php
@@ -446,6 +446,19 @@ class HedleyRestfulSync extends \RestfulBase implements \RestfulDataProviderInte
           $ignored[] = 'health_center';
         }
 
+        // The person edit form has no coordinate inputs, so the client sends
+        // NULL for them whenever a person is edited. Applying that erases the
+        // location recorded at registration, which no screen can restore. An
+        // edit that does carry a fresh reading still updates them, and
+        // registration is unaffected, as this applies to PATCH only.
+        if ($item['type'] == 'person' && $item['method'] == 'PATCH') {
+          foreach (['latitude', 'longitude'] as $coordinate) {
+            if (!isset($item['data'][$coordinate]) || $item['data'][$coordinate] === '') {
+              $ignored[] = $coordinate;
+            }
+          }
+        }
+
         $data = [];
         foreach (array_keys($item['data']) as $key) {
           $value = $item['data'][$key];


### PR DESCRIPTION
Fixes #2058

Any edit to a person erases the GPS coordinates recorded at registration. The edit form has no coordinate inputs, so `validatePerson` reports `Nothing` for both, `PatchPerson` re-attaches them only when a fresh reading was requested, and the encoder sends the `Nothing` as `null` regardless. The backend applies it. A corrected name destroys a household's location, and no screen can put it back.

On vhw.live it has already happened to **77 persons** — they appear in `field_revision_field_latitude` but have no current value, they are all still-existing person nodes, and 76 of the 77 were edited after creation. Another 10,599 carry coordinates today and are one edit away.

## Three parts

**1. Backend guard** (`HedleyRestfulSync`) — null coordinates are dropped from a person `PATCH`. This is the half that matters first: devices in the field run whatever build they last received, so a client-only fix leaves every un-updated device erasing coordinates for months, while this takes effect for all of them the moment it deploys. It sits in the existing per-type `$ignored` idiom, two lines below where `save_gps_location` is filtered for the same kind of reason. An edit that *does* carry a fresh reading still updates the fields, and `POST` is untouched, so registration still records them.

**2. Client** (`Backend/Update.elm`) — `PatchPerson` carries over the stored coordinates instead of the form's `Nothing`. It goes here rather than in the form because the validator reporting `Nothing` is defensible — the form genuinely has no coordinate inputs — while treating "the form knows nothing" as "clear the field" is not.

**3. Repair script** — the erased values are still in the node revisions, so `restore-wiped-gps-coordinates.php` restores the most recent revision holding both coordinates, to persons that hold neither now. Latitude and longitude are taken from the *same* revision, so the restored pair is one reading from one moment; a person with only one of the two is reported and skipped rather than guessed at.

```
drush scr profiles/hedley/modules/custom/hedley_person/scripts/restore-wiped-gps-coordinates.php --dry_run
```

Only vhw needs it. The flag is on at `vhw` and `tip-somalia`, unset at `ihangane`; tip-somalia has one coordinate record in total.

## Verified by running

**The repair script, end to end on a local copy** — recorded coordinates on a person, wiped them the way an edit does (`node_save` with the fields emptied), then:

| step | result |
|---|---|
| dry run | `Person 28590 would be restored to -1.9440000, 30.0619000`, current rows still 0 |
| real run | `Restored coordinates for 1 of 1 persons` |
| stored values afterwards | `-1.9440000` / `30.0619000` — the originals |
| second dry run | `No person is missing coordinates that a revision still holds` (idempotent) |

The test person was returned to having no coordinates afterwards.

**Its selection against real data** — the script's query, run against vhw.live, selects exactly the **77** persons independently identified as having lost coordinates. (The script also excludes soft-deleted persons, so it may restore slightly fewer.)

**Static checks** — `php -l` clean on both PHP files; phpcs `Drupal` and `DrupalPractice` with the full CI extension list both exit 0 with no output, and a deliberately bad file makes the same invocation exit 2 with 12 findings, so the standards really are loaded. `elm make src/elm/Main.elm` compiles 548 modules; `elm-format --validate` clean; `elm-review` reports one pre-existing unused import in the touched file, identical on develop, and nothing new.

## Not covered

The sibling defect recorded with this one: a stale GPS reading from a previous household can display as current and be saved onto the next person, because geolocation errors send no reply to Elm and `model.coordinates` is not cleared per request. Different bug, same feature — left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)