### PR TITLE
Sync: stop two nodes created microseconds apart from sharing a UUID

### DIFF
--- a/client/src/js/nodes.js
+++ b/client/src/js/nodes.js
@@ -1296,41 +1296,21 @@
         return Promise.reject(response);
     }
 
-    // For things created on the backend, we use a v5 UUID which is a
-    // combination of a v4 device UUID and a high-res timestamp. So, we'll do
-    // the same thing here.  That is, we'll generate a v4 device UUID, and
-    // we'll use it with a high-res timestamp to create a v5 UUID. That ought
-    // to provide a sufficient guarantee of no UUID collisions.
+    // A random UUID, because a derived one collided.
+    //
+    // This used to hash a high-res timestamp against a per-device UUID, to
+    // mirror what the backend does. The backend hashes uniqid(), which
+    // carries its own entropy; this hashed a browser clock, which carries
+    // none - and browsers clamp that clock to roughly 100 microseconds as a
+    // Spectre mitigation, so two nodes created in the same bucket on one
+    // device hashed to the same UUID. It happened on live: a relationship
+    // and its pmtct participant, created in one update cycle, each collided
+    // with their sibling.
+    //
+    // Nothing derives these UUIDs from anything, so there is nothing to
+    // reproduce and no reason to hash. Random has no such bucket to share.
     function makeUuid () {
-        var timestamp = String(performance.timeOrigin + performance.now());
-
-        return caches.open(configCache).then(function (cache) {
-            return cache.match(deviceUuidUrl).then(function (response) {
-                if (response) {
-                    return response.text();
-                } else {
-                    var uuid = kelektivUuid.v4();
-
-                    var cachedResponse = new Response(uuid, {
-                        status: 200,
-                        statusTest: 'OK',
-                        headers: {
-                            'Content-Type': 'application/text'
-                        }
-                    });
-
-                    var cachedRequest = new Request (deviceUuidUrl, {
-                        method: 'GET'
-                    });
-
-                    return cache.put(cachedRequest, cachedResponse).then(function () {
-                        return Promise.resolve(uuid);
-                    });
-                }
-            });
-        }).then(function (deviceUuid) {
-            return Promise.resolve(kelektivUuid.v5(timestamp, deviceUuid));
-        });
+        return Promise.resolve(kelektivUuid.v4());
     }
 
     /**

--- a/client/src/js/sw.js
+++ b/client/src/js/sw.js
@@ -13,8 +13,6 @@ var configUrlRegex = /\/sw\/config/;
 var credentialsUrlRegex = /\/sw\/config\/device$/;
 var credentialsUrl = '/sw/config/device';
 
-var deviceUuidUrl = '/sw/config/device-uuid';
-
 var photosDownloadCache = "photos";
 var photosUploadCache = "photos-upload";
 var screenshotsUploadCache = "screenshots-upload";


### PR DESCRIPTION
Fixes #2060

Every node the client creates took its UUID from `v5(browser timestamp, device uuid)`. v5 is a hash, so identical input gives an identical UUID — and browsers clamp high-resolution clocks to roughly 100µs as a Spectre mitigation. Two nodes created in the same bucket on one device came out with the same UUID.

The timestamp was captured at function entry, before the async device-UUID lookup, so none of that async work provided spacing. What mattered was the gap between two `postNode` calls *starting* — and `PostRelationship` dispatches `PostPmtctParticipant` within a single update cycle.

## It reached production

`ihangane.live` holds two duplicate `field_uuid` values, both v5, each mapping to two distinct node ids:

| UUID | nodes | bundle |
| --- | --- | --- |
| `19206623-f8ac-5164-…` | 2684365, 2684434 | pmtct_participant |
| `b18519ff-2509-50f3-…` | 2684368, 2684437 | relationship |

Both survivors were created in the same second — 2023-02-24 06:44:26 — a relationship and its pmtct participant, exactly the predicted pair. Nodes 2684434 and 2684437 no longer exist; their `field_uuid` rows are orphaned. `vhw` has none.

Two is a floor, not a count. When the collision fires, the second `put` into the Dexie `shards` table overwrites the first client-side, before upload, so cases can leave no server trace.

## Why v4 rather than a salt

Both were one-line fixes. A counter salt keeps the v5 shape but resets when the service worker is killed, leaving a narrow residual case; `v4` removes the failure mode outright. Nothing derives these UUIDs, nothing inspects their version, and the per-device UUID that served as the namespace has no other consumer — `deviceUuidUrl` was referenced only by the two lines inside `makeUuid` that wrote and read it. So it goes too, and with it two Cache Storage operations on the path of every node creation.

The backend keeps its v5 (`hedley_device_assign_uuid`) and should: it hashes `uniqid('', TRUE)`, which carries its own entropy. The client copied the shape of that scheme and dropped the salt.

## Verified by measuring

Against the repo's own vendored `uuid.js`, 200k iterations each: `v4` **1,517 ns**, `v5` **2,304 ns**. So the replacement is also the cheaper primitive — and both are dwarfed by the Cache Storage round-trip this removes.

Emulating the 100µs clamp, 20k simulated same-cycle pairs per row, collision rate against the gap between the two creates:

```
      1 us     99.2%
      4 us     96.9%
     10 us     90.3%
     25 us     75.0%
     50 us     51.2%
    100 us      0.0%
   1000 us      0.0%
```

Which is the geometry you'd expect — `1 - gap/clamp` below the clamp, zero above it. The old scheme's safety rested entirely on two creates being 100µs apart, which nothing guaranteed. The same harness under `v4` produced 0 collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)