### PR TITLE
Child scoreboard: let the report cancel, and refer on diarrhea

### DIFF
--- a/client/e2e/child-scoreboard-encounter-chw.spec.ts
+++ b/client/e2e/child-scoreboard-encounter-chw.spec.ts
@@ -11,7 +11,11 @@ import {
   completeVaccinationHistory,
   endChildScoreboardEncounter,
   queryChildScoreboardNodes,
+  openScorecardReport,
+  endEncounterDialog,
+  diarrheaReferralPopup,
 } from './helpers/child-scoreboard';
+import { click } from './helpers/auth';
 
 // =========================================================================
 // Test 1: CHW First Child Scoreboard Encounter — NCDA + Vaccination History
@@ -141,5 +145,72 @@ test.describe('CHW: Child Scoreboard Encounter — child under six months', () =
     const nodes = queryChildScoreboardNodes(fullName, ['child_scoreboard_ncda']);
     expect(nodes['child_scoreboard_ncda'], 'child_scoreboard_ncda should exist').toBe(true);
     expect(queryNCDAWeight(fullName), 'the weight entered should be saved').toBe(8.5);
+  });
+});
+
+// =========================================================================
+// Test 3: Ending the encounter from the progress report
+// =========================================================================
+
+test.describe('CHW: Child Scoreboard Encounter — ending it from the progress report', () => {
+  test.describe.configure({ timeout: 600000 });
+
+  if (process.env.RECORD) {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(installCursorScript());
+    });
+  }
+
+  test.beforeEach(async ({ page }) => {
+    resetDevice();
+    await setupDevice(page, '2345', 'Akanduga');
+  });
+
+  // Scenario: the encounter is ended from the progress report rather than from
+  // the encounter page, with diarrhea recorded on the NCDA questionnaire.
+  //
+  // Covers issue #2062, both halves, in one encounter:
+  //   1. Cancel on the confirmation dialog leaves the report open. Before the
+  //      fix the report passed "always ShowAIEncounterPopup" for that dialog,
+  //      so Cancel set the flag the dialog's own visibility reads and re-opened
+  //      it - confirming was the only way out.
+  //   2. Confirming refers the child on. Before the fix the report never asked
+  //      whether diarrhea was recorded, so the same child was referred or not
+  //      depending on which screen the encounter was ended from; and the
+  //      referral itself navigated to the PIN code page, because the message
+  //      that closed the encounter appended a navigation of its own after it.
+  test('cancel keeps the report open, and confirming refers a child with diarrhea', async ({
+    page,
+  }) => {
+    // 1. A child with diarrhea recorded, so ending the encounter should refer.
+    await createChildAndStartEncounter(page, { ageMonths: 10 });
+    await completeNCDA(page, { expectMuacAsked: true, diarrhea: 'Yes' });
+    await completeVaccinationHistory(page);
+
+    // 2. End the encounter from the report, not from the encounter page.
+    await openScorecardReport(page);
+    await click(page.locator('button', { hasText: 'End Encounter' }).first(), page);
+
+    const dialog = endEncounterDialog(page);
+    await expect(dialog).toBeVisible();
+
+    // 3. Cancel means cancel: the dialog closes and the report is still here.
+    await click(dialog.locator('button', { hasText: 'Cancel' }), page);
+    await expect(dialog).toBeHidden();
+    await expect(page.locator('h1', { hasText: 'PROGRESS REPORT' })).toBeVisible();
+
+    // 4. Confirming this time brings up the referral warning.
+    await click(page.locator('button', { hasText: 'End Encounter' }).first(), page);
+    await expect(dialog).toBeVisible();
+    await click(dialog.locator('button.primary', { hasText: 'Continue' }), page);
+
+    const popup = diarrheaReferralPopup(page);
+    await expect(popup).toBeVisible();
+
+    // 5. Continue arrives at the acute illness encounter, not the PIN screen.
+    await click(popup.locator('button'), page);
+    await expect(page.locator('div.page-participant.acute-illness')).toBeVisible({
+      timeout: 30000,
+    });
   });
 });

--- a/client/e2e/helpers/child-scoreboard.ts
+++ b/client/e2e/helpers/child-scoreboard.ts
@@ -153,7 +153,10 @@ export async function createChildAndStartEncounter(
  *
  * Creates: child_scoreboard_ncda
  */
-export async function completeNCDA(page: Page, options?: { expectMuacAsked?: boolean }) {
+export async function completeNCDA(
+  page: Page,
+  options?: { expectMuacAsked?: boolean; diarrhea?: 'Yes' | 'No' },
+) {
   await openActivity(page, 'child-scoreboard', 'history');
 
   // --- Step 1: Antenatal Care ---
@@ -357,10 +360,11 @@ export async function completeNCDA(page: Page, options?: { expectMuacAsked?: boo
   await answerNCDAYesNo(page, 'receive support', 'Yes');
   await page.waitForTimeout(WAIT.formInteraction);
 
-  // ChildGotDiarrhea → No (does not contribute to any scoreboard pane —
-  // pane4.row3 requires ORS/Zinc medication, not this sign. Answering Yes
-  // triggers a popup on end-encounter that breaks the standalone test).
-  await answerNCDAYesNo(page, 'have diarrhea', 'No');
+  // ChildGotDiarrhea → No by default (it contributes to no scoreboard pane —
+  // pane4.row3 requires ORS/Zinc medication, not this sign). Yes is what sends
+  // the child on to an acute illness encounter when this one ends, so tests
+  // that want that path ask for it.
+  await answerNCDAYesNo(page, 'have diarrhea', options?.diarrhea ?? 'No');
   await page.waitForTimeout(WAIT.formInteraction);
 
   await clickSave(page);
@@ -627,4 +631,30 @@ export function queryNCDAWeight(personName: string): number | null {
     throw new Error(`queryNCDAWeight: ${parsed.error}`);
   }
   return parsed.weight === null || parsed.weight === undefined ? null : Number(parsed.weight);
+}
+
+
+/**
+ * Open the progress report (the "scorecard" tab of the encounter).
+ */
+export async function openScorecardReport(page: Page) {
+  await click(page.locator('#scorecard-tab'), page);
+  await page.locator('h1', { hasText: 'PROGRESS REPORT' }).waitFor({ timeout: 30000 });
+  await page.waitForTimeout(WAIT.elmRerender);
+}
+
+/**
+ * The confirmation dialog the report shows before ending an encounter.
+ * Distinct from the diarrhea warning, which is a .danger-signs-popup - both
+ * carry a Continue button, so tests have to say which one they mean.
+ */
+export function endEncounterDialog(page: Page) {
+  return page.locator('div.ui.tiny.active.modal');
+}
+
+/**
+ * The warning shown when a child recorded with diarrhea is referred on.
+ */
+export function diarrheaReferralPopup(page: Page) {
+  return page.locator('div.ui.active.modal.danger-signs-popup');
 }

--- a/client/src/elm/Pages/ChildScoreboard/Encounter/Model.elm
+++ b/client/src/elm/Pages/ChildScoreboard/Encounter/Model.elm
@@ -47,5 +47,5 @@ type Msg
     = CloseEncounter ChildScoreboardEncounterId
     | SetActivePage Page
     | SetSelectedTab Tab
-    | ShowAIEncounterPopup
+    | ShowAIEncounterPopup ChildScoreboardEncounterId
     | TriggerAcuteIllnessEncounter AssembledData

--- a/client/src/elm/Pages/ChildScoreboard/Encounter/Update.elm
+++ b/client/src/elm/Pages/ChildScoreboard/Encounter/Update.elm
@@ -2,9 +2,9 @@ module Pages.ChildScoreboard.Encounter.Update exposing (update)
 
 import App.Model
 import Backend.ChildScoreboardEncounter.Model
+import Backend.Entities exposing (..)
 import Backend.IndividualEncounterParticipant.Model exposing (IndividualParticipantInitiator(..))
 import Backend.Model
-import Gizra.Update exposing (sequenceExtra)
 import Pages.ChildScoreboard.Encounter.Model exposing (Model, Msg(..))
 import Pages.Page exposing (Page(..), UserPage(..))
 
@@ -15,11 +15,7 @@ update msg model =
         CloseEncounter id ->
             ( model
             , Cmd.none
-            , [ Backend.ChildScoreboardEncounter.Model.CloseChildScoreboardEncounter
-                    |> Backend.Model.MsgChildScoreboardEncounter id
-                    |> App.Model.MsgIndexedDb
-              , App.Model.SetActivePage PinCodePage
-              ]
+            , closeEncounterMsgs id ++ [ App.Model.SetActivePage PinCodePage ]
             )
 
         SetActivePage page ->
@@ -31,15 +27,32 @@ update msg model =
         SetSelectedTab tab ->
             ( { model | selectedTab = tab }, Cmd.none, [] )
 
-        ShowAIEncounterPopup ->
+        ShowAIEncounterPopup id ->
+            -- Ending the encounter is what the button asked for, so it
+            -- happens now. The popup that follows is the referral, not a
+            -- second chance to decide.
             ( { model | showAIEncounterPopup = True }
             , Cmd.none
-            , []
+            , closeEncounterMsgs id
             )
 
         TriggerAcuteIllnessEncounter assembled ->
+            -- The encounter was closed when the popup opened, so this only
+            -- navigates. Going through CloseEncounter would append its own
+            -- SetActivePage PinCodePage after this one, and the last one wins.
             ( { model | showAIEncounterPopup = False }
             , Cmd.none
             , [ App.Model.SetActivePage <| UserPage (AcuteIllnessParticipantPage InitiatorParticipantsPage assembled.participant.person) ]
             )
-                |> sequenceExtra update [ CloseEncounter assembled.id ]
+
+
+{-| Closing the encounter, without saying where to go next. The two callers
+disagree about that: ending normally returns to the PIN code page, while a
+referral carries on to the acute illness encounter.
+-}
+closeEncounterMsgs : ChildScoreboardEncounterId -> List App.Model.Msg
+closeEncounterMsgs id =
+    [ Backend.ChildScoreboardEncounter.Model.CloseChildScoreboardEncounter
+        |> Backend.Model.MsgChildScoreboardEncounter id
+        |> App.Model.MsgIndexedDb
+    ]

--- a/client/src/elm/Pages/ChildScoreboard/Encounter/Utils.elm
+++ b/client/src/elm/Pages/ChildScoreboard/Encounter/Utils.elm
@@ -1,11 +1,26 @@
-module Pages.ChildScoreboard.Encounter.Utils exposing (generateAssembledData)
+module Pages.ChildScoreboard.Encounter.Utils exposing (childGotDiarrhea, generateAssembledData)
 
 import Backend.Entities exposing (..)
+import Backend.Measurement.Model exposing (NCDASign(..))
+import Backend.Measurement.Utils exposing (getMeasurementValueFunc)
 import Backend.Model exposing (ModelIndexedDb)
+import EverySet
 import Measurement.Utils
 import Pages.ChildScoreboard.Encounter.Model exposing (AssembledData)
 import RemoteData exposing (WebData)
 import SyncManager.Model exposing (Site)
+
+
+{-| Diarrhea recorded on the NCDA questionnaire sends the child to an acute
+illness encounter. Both places an encounter can be ended ask this, so that
+ending one from the progress report refers the child as ending it from the
+encounter page does.
+-}
+childGotDiarrhea : AssembledData -> Bool
+childGotDiarrhea assembled =
+    getMeasurementValueFunc assembled.measurements.ncda
+        |> Maybe.map (.signs >> EverySet.member ChildGotDiarrhea)
+        |> Maybe.withDefault False
 
 
 generateAssembledData : Site -> ChildScoreboardEncounterId -> ModelIndexedDb -> WebData AssembledData

--- a/client/src/elm/Pages/ChildScoreboard/Encounter/View.elm
+++ b/client/src/elm/Pages/ChildScoreboard/Encounter/View.elm
@@ -1,19 +1,16 @@
-module Pages.ChildScoreboard.Encounter.View exposing (view)
+module Pages.ChildScoreboard.Encounter.View exposing (acuteIllnessEncounterPopup, view)
 
 import Backend.ChildScoreboardActivity.Utils exposing (allActivities, getActivityIcon)
 import Backend.Entities exposing (..)
 import Backend.IndividualEncounterParticipant.Model
-import Backend.Measurement.Model exposing (NCDASign(..))
-import Backend.Measurement.Utils exposing (getMeasurementValueFunc)
 import Backend.Model exposing (ModelIndexedDb)
-import EverySet
 import Gizra.NominalDate exposing (NominalDate)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Pages.ChildScoreboard.Activity.Utils exposing (activityCompleted, expectActivity)
 import Pages.ChildScoreboard.Encounter.Model exposing (AssembledData, Model, Msg(..), Tab(..))
-import Pages.ChildScoreboard.Encounter.Utils exposing (generateAssembledData)
+import Pages.ChildScoreboard.Encounter.Utils exposing (childGotDiarrhea, generateAssembledData)
 import Pages.Page exposing (Page(..), UserPage(..))
 import Pages.Utils exposing (viewCustomAction, viewEncounterActionButton, viewPersonDetailsExtended)
 import SyncManager.Model exposing (Site)
@@ -154,13 +151,7 @@ viewEndEncounterButton : Language -> AssembledData -> Bool -> msg -> (ChildScore
 viewEndEncounterButton language assembled allowEndEncounter showAIEncounterPopupMsg closeEncounterMsg =
     let
         endEncounterMsg =
-            let
-                childGotDiarrhea =
-                    getMeasurementValueFunc assembled.measurements.ncda
-                        |> Maybe.map (.signs >> EverySet.member ChildGotDiarrhea)
-                        |> Maybe.withDefault False
-            in
-            if childGotDiarrhea then
+            if childGotDiarrhea assembled then
                 showAIEncounterPopupMsg
 
             else

--- a/client/src/elm/Pages/ChildScoreboard/Encounter/View.elm
+++ b/client/src/elm/Pages/ChildScoreboard/Encounter/View.elm
@@ -139,7 +139,7 @@ viewMainPageContent language currentDate site assembled model =
         content =
             div [ class "ui full segment" ]
                 [ innerContent
-                , viewEndEncounterButton language assembled allowEndEncounter ShowAIEncounterPopup CloseEncounter
+                , viewEndEncounterButton language assembled allowEndEncounter (ShowAIEncounterPopup assembled.id) CloseEncounter
                 ]
     in
     [ tabs

--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/Model.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/Model.elm
@@ -33,7 +33,7 @@ type Msg
     = NoOp
     | CloseEncounter ChildScoreboardEncounterId
     | SetActivePage Page
-    | ShowAIEncounterPopup
+    | ShowAIEncounterPopup ChildScoreboardEncounterId
     | TriggerAcuteIllnessEncounter AssembledData
     | SetDiagnosisMode DiagnosisMode
     | SetEndEncounterDialogState Bool

--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/Model.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/Model.elm
@@ -11,6 +11,7 @@ import Pages.Report.Model exposing (DiagnosisMode(..), ReportTab(..))
 type alias Model =
     { diagnosisMode : DiagnosisMode
     , showAIEncounterPopup : Bool
+    , showEndEncounterDialog : Bool
     , reportToWhatsAppDialog : Components.ReportToWhatsAppDialog.Model.Model
     , components : Maybe (EverySet Components.ReportToWhatsAppDialog.Model.ReportComponentWellChild)
     , reportTab : ReportTab
@@ -21,6 +22,7 @@ emptyModel : Model
 emptyModel =
     { diagnosisMode = ModeActiveDiagnosis
     , showAIEncounterPopup = False
+    , showEndEncounterDialog = False
     , reportToWhatsAppDialog = Components.ReportToWhatsAppDialog.Model.emptyModel
     , components = Nothing
     , reportTab = TabSPVReport
@@ -34,6 +36,7 @@ type Msg
     | ShowAIEncounterPopup
     | TriggerAcuteIllnessEncounter AssembledData
     | SetDiagnosisMode DiagnosisMode
+    | SetEndEncounterDialogState Bool
     | MsgReportToWhatsAppDialog (Components.ReportToWhatsAppDialog.Model.Msg Msg)
     | SetReportComponents (Maybe Components.ReportToWhatsAppDialog.Model.ReportComponentsList)
     | SetReportTab ReportTab

--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/Update.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/Update.elm
@@ -37,7 +37,9 @@ update msg model =
             )
 
         ShowAIEncounterPopup ->
-            ( { model | showAIEncounterPopup = True }
+            -- The confirmation dialog has done its job by the time we get
+            -- here, and two stacked modals would be one too many.
+            ( { model | showAIEncounterPopup = True, showEndEncounterDialog = False }
             , Cmd.none
             , []
             )
@@ -51,6 +53,9 @@ update msg model =
 
         SetDiagnosisMode mode ->
             ( { model | diagnosisMode = mode }, Cmd.none, [] )
+
+        SetEndEncounterDialogState isOpen ->
+            ( { model | showEndEncounterDialog = isOpen }, Cmd.none, [] )
 
         MsgReportToWhatsAppDialog subMsg ->
             let

--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/Update.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/Update.elm
@@ -2,6 +2,7 @@ module Pages.ChildScoreboard.ProgressReport.Update exposing (update)
 
 import App.Model
 import Backend.ChildScoreboardEncounter.Model
+import Backend.Entities exposing (..)
 import Backend.IndividualEncounterParticipant.Model exposing (IndividualParticipantInitiator(..))
 import Backend.Model
 import Components.ReportToWhatsAppDialog.Model
@@ -21,13 +22,12 @@ update msg model =
             )
 
         CloseEncounter id ->
-            ( model
+            -- The dialog is cleared as well: this page model is kept per
+            -- encounter and outlives the encounter, so a flag left set here
+            -- greets whoever opens the report next.
+            ( { model | showEndEncounterDialog = False }
             , Cmd.none
-            , [ Backend.ChildScoreboardEncounter.Model.CloseChildScoreboardEncounter
-                    |> Backend.Model.MsgChildScoreboardEncounter id
-                    |> App.Model.MsgIndexedDb
-              , App.Model.SetActivePage PinCodePage
-              ]
+            , closeEncounterMsgs id ++ [ App.Model.SetActivePage PinCodePage ]
             )
 
         SetActivePage page ->
@@ -36,20 +36,23 @@ update msg model =
             , [ App.Model.SetActivePage page ]
             )
 
-        ShowAIEncounterPopup ->
-            -- The confirmation dialog has done its job by the time we get
-            -- here, and two stacked modals would be one too many.
+        ShowAIEncounterPopup id ->
+            -- The encounter is closed here, because that is what was just
+            -- confirmed. The popup that follows is the referral, not a second
+            -- chance to decide, and the dialog goes so the two do not stack.
             ( { model | showAIEncounterPopup = True, showEndEncounterDialog = False }
             , Cmd.none
-            , []
+            , closeEncounterMsgs id
             )
 
         TriggerAcuteIllnessEncounter assembled ->
+            -- The encounter was closed when the popup opened, so this only
+            -- navigates. Going through CloseEncounter would append its own
+            -- SetActivePage PinCodePage after this one, and the last one wins.
             ( { model | showAIEncounterPopup = False }
             , Cmd.none
             , [ App.Model.SetActivePage <| UserPage (AcuteIllnessParticipantPage InitiatorParticipantsPage assembled.participant.person) ]
             )
-                |> sequenceExtra update [ CloseEncounter assembled.id ]
 
         SetDiagnosisMode mode ->
             ( { model | diagnosisMode = mode }, Cmd.none, [] )
@@ -85,3 +88,15 @@ update msg model =
 
         SetReportTab tab ->
             ( { model | reportTab = tab }, Cmd.none, [] )
+
+
+{-| Closing the encounter, without saying where to go next. The two callers
+disagree about that: ending normally returns to the PIN code page, while a
+referral carries on to the acute illness encounter.
+-}
+closeEncounterMsgs : ChildScoreboardEncounterId -> List App.Model.Msg
+closeEncounterMsgs id =
+    [ Backend.ChildScoreboardEncounter.Model.CloseChildScoreboardEncounter
+        |> Backend.Model.MsgChildScoreboardEncounter id
+        |> App.Model.MsgIndexedDb
+    ]

--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/View.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/View.elm
@@ -8,13 +8,15 @@ import EverySet exposing (EverySet)
 import Gizra.NominalDate exposing (NominalDate)
 import Html exposing (..)
 import Pages.ChildScoreboard.Activity.Utils exposing (activityCompleted, expectActivity)
-import Pages.ChildScoreboard.Encounter.Utils exposing (generateAssembledData)
+import Pages.ChildScoreboard.Encounter.Utils exposing (childGotDiarrhea, generateAssembledData)
+import Pages.ChildScoreboard.Encounter.View exposing (acuteIllnessEncounterPopup)
 import Pages.ChildScoreboard.ProgressReport.Model exposing (Model, Msg(..))
 import Pages.WellChild.ProgressReport.Model exposing (WellChildProgressReportInitiator(..))
 import Pages.WellChild.ProgressReport.View exposing (viewProgressReport)
 import RemoteData exposing (RemoteData(..))
 import SyncManager.Model exposing (Site, SiteFeature)
 import Translate.Model exposing (Language)
+import Utils.Html exposing (viewModal)
 import Utils.WebData exposing (viewWebData)
 import ZScore.Model
 
@@ -65,10 +67,18 @@ view language currentDate zscores site features id db model =
                                 |> List.partition (activityCompleted currentDate site assembled)
                     in
                     ( Just
-                        { showEndEncounterDialog = model.showAIEncounterPopup
+                        { showEndEncounterDialog = model.showEndEncounterDialog
                         , allowEndEncounter = List.isEmpty pendingActivities
-                        , closeEncounterMsg = CloseEncounter id
-                        , setEndEncounterDialogStateMsg = always ShowAIEncounterPopup
+                        , closeEncounterMsg =
+                            -- Same rule the encounter page applies, so that
+                            -- where the encounter was ended from does not
+                            -- decide whether the child is referred.
+                            if childGotDiarrhea assembled then
+                                ShowAIEncounterPopup
+
+                            else
+                                CloseEncounter id
+                        , setEndEncounterDialogStateMsg = SetEndEncounterDialogState
                         , startEncounterMsg = NoOp
                         }
                     , True
@@ -83,26 +93,41 @@ view language currentDate zscores site features id db model =
 
         componentsConfig =
             Just { setReportComponentsMsg = SetReportComponents }
+
+        -- The same warning the encounter page shows, so a child recorded
+        -- with diarrhea is told why the acute illness encounter follows.
+        aiEncounterPopup =
+            Maybe.andThen
+                (\assembled ->
+                    acuteIllnessEncounterPopup language
+                        assembled
+                        model.showAIEncounterPopup
+                        TriggerAcuteIllnessEncounter
+                )
+                assembledData
     in
-    viewWebData language
-        (viewProgressReport language
-            currentDate
-            zscores
-            site
-            features
-            initiator
-            mandatoryNutritionAssessmentMeasurementsTaken
-            db
-            model.diagnosisMode
-            model.reportToWhatsAppDialog
-            model.reportTab
-            SetActivePage
-            SetReportTab
-            SetDiagnosisMode
-            MsgReportToWhatsAppDialog
-            componentsConfig
-            model.components
-            bottomActionData
-        )
-        identity
-        childData
+    div []
+        [ viewWebData language
+            (viewProgressReport language
+                currentDate
+                zscores
+                site
+                features
+                initiator
+                mandatoryNutritionAssessmentMeasurementsTaken
+                db
+                model.diagnosisMode
+                model.reportToWhatsAppDialog
+                model.reportTab
+                SetActivePage
+                SetReportTab
+                SetDiagnosisMode
+                MsgReportToWhatsAppDialog
+                componentsConfig
+                model.components
+                bottomActionData
+            )
+            identity
+            childData
+        , viewModal aiEncounterPopup
+        ]

--- a/client/src/elm/Pages/ChildScoreboard/ProgressReport/View.elm
+++ b/client/src/elm/Pages/ChildScoreboard/ProgressReport/View.elm
@@ -74,7 +74,7 @@ view language currentDate zscores site features id db model =
                             -- where the encounter was ended from does not
                             -- decide whether the child is referred.
                             if childGotDiarrhea assembled then
-                                ShowAIEncounterPopup
+                                ShowAIEncounterPopup id
 
                             else
                                 CloseEncounter id


### PR DESCRIPTION
Fixes #2062

Two defects on one screen, both from how the ChildScoreboard progress report fills in the shared progress-report config.

## The dialog could not be cancelled

It passed `setEndEncounterDialogStateMsg = always ShowAIEncounterPopup` while reading `showEndEncounterDialog = model.showAIEncounterPopup`. The shared dialog's Cancel sends `False`; `always` discarded it and set the flag the dialog's own visibility reads, so Cancel re-opened the dialog and confirming was the only way out.

The page now has a real `SetEndEncounterDialogState Bool` and its own `showEndEncounterDialog` flag, which also lets `showAIEncounterPopup` go back to meaning the popup.

## Diarrhea did not refer from the report

Ending an encounter from the encounter page asks whether diarrhea was recorded on the NCDA questionnaire, warns the worker, and starts an acute illness encounter. Ending it from the progress report never asked — its `TriggerAcuteIllnessEncounter` handler existed but no view referenced it, which is how an unused-constructor sweep found this.

So the same child, with the same data, was referred or not depending on which screen the encounter was ended from. Both paths now ask through one helper — `childGotDiarrhea` in `Pages/ChildScoreboard/Encounter/Utils.elm` — and the report shows the same warning before it refers.

## Scope check

I checked all five bindings of `setEndEncounterDialogStateMsg` before writing anything:

| site | msg | dialog flag | status |
| --- | --- | --- | --- |
| `Nutrition/ProgressReport:71` | `SetEndEncounterDialogState` | `model.showEndEncounterDialog` | correct |
| `WellChild/ProgressReport:172` | `SetEndEncounterDialogState` | `model.showEndEncounterDialog` | correct |
| `PatientRecord/View:175` | `always NoOp` | `False` | inert |
| `ProgressReport/View:54` | `always NoOp` | `False` | inert |
| `ChildScoreboard/ProgressReport:71` | `always ShowAIEncounterPopup` | `model.showAIEncounterPopup` | **broken** |

Three sites discard the `Bool`, but two pair it with a hardcoded `False`, so their dialog never opens and the message is never sent. Only ChildScoreboard combines `always` with a live flag. A one-off, not a family — the two inert sites are left alone rather than churned, though they are one edit away from the same trap.

## Verified

`elm make src/elm/Main.elm` compiles 548 modules. `elm-format --validate` clean. `elm-test` 2,974 passed — re-run after replacing the symlinked `elm-stuff` with a real directory, since a symlinked one silently compiles the main tree and makes the pass vacuous; the generated project's `source-directories` were confirmed to resolve into the worktree. `elm-review` reports 10 findings under `ChildScoreboard`, all the pre-existing `Backend.Entities` / `Backend.Measurement.Model` unused-import pattern that also affects files this branch never touches; each of the four touched files already carried that import on develop. Three imports in `Encounter/View.elm` became unused when the inline check moved to the helper, and were removed.

One structural note: the report's view now returns `div [] [ report, viewModal popup ]` rather than the bare report, because the popup needs a sibling. The report's own root keeps its `page-report` class, and no CSS selector depends on it being a direct child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)