### PR TITLE
Dashboard stats: stop counting an absence as a session attended

### DIFF
--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -489,8 +489,17 @@ function hedley_activity_get_persons_sessions_with_measurements(array $sessions_
   // the record itself turned an absence into proof of attendance.
   //
   // The join is optional because only the attendance bundle carries the
-  // field; every other measurement passes on the first condition.
-  hedley_general_join_field_to_query($query, 'node', 'field_attended', FALSE);
+  // field; every other measurement passes on the first condition. It is made
+  // by hand rather than through the usual helper, which would also add the
+  // value to the SELECT list and so to the DISTINCT below - a person with
+  // both a measurement and an attendance record would come back as two rows
+  // where one will do, in the query that exists to be the cheap bulk path.
+  $query->leftJoin(
+    'field_data_field_attended',
+    'field_attended',
+    'node.nid = field_attended.entity_id AND field_attended.entity_type = :attended_entity_type',
+    [':attended_entity_type' => 'node']
+  );
   $query->condition(
     db_or()
       ->condition('node.type', HEDLEY_ACTIVITY_ATTENDANCE_CONTENT_TYPE, '<>')

--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -477,6 +477,15 @@ function hedley_activity_get_persons_sessions_with_measurements(array $sessions_
   $session_field_name = $session_field . '.' . $session_field . '_target_id';
   $query->condition($session_field_name, $sessions_ids, 'IN');
 
+  // A session counts for a person when something was measured there. The
+  // attendance record does not count: it carries a person and a session like
+  // any measurement does, but it says only whether the person was expected to
+  // come, and it exists either way - marking someone absent updates it to
+  // attended = FALSE rather than removing it. So counting it made a record of
+  // absence into proof of presence, and a tick with nothing behind it into a
+  // session that ran.
+  $query->condition('node.type', HEDLEY_ACTIVITY_ATTENDANCE_CONTENT_TYPE, '<>');
+
   $query->distinct();
 
   $result = $query->execute();

--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -452,8 +452,7 @@ function hedley_activity_node_by_peer_in_session(\EntityMetadataWrapper $wrapper
  *
  * Attending is evidenced either by a measurement taken during the session, or
  * by an attendance record that says they came. An attendance record saying
- * they did not is no evidence at all, which is what the name of this function
- * fails to convey - it predates the distinction.
+ * they did not is no evidence at all.
  *
  * Resolves attendance for many persons at once with a single query, rather
  * than a COUNT query per person, so callers can determine it in memory.
@@ -465,7 +464,7 @@ function hedley_activity_node_by_peer_in_session(\EntityMetadataWrapper $wrapper
  *   A map keyed by person node ID; each value is a set of session node IDs (as
  *   array keys) that person attended.
  */
-function hedley_activity_get_persons_sessions_with_measurements(array $sessions_ids) {
+function hedley_activity_get_persons_sessions_attended(array $sessions_ids) {
   $persons_sessions = [];
   if (empty($sessions_ids)) {
     return $persons_sessions;

--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -488,18 +488,13 @@ function hedley_activity_get_persons_sessions_with_measurements(array $sessions_
   // and its value, not its presence, is what answers the question. Counting
   // the record itself turned an absence into proof of attendance.
   //
-  // The join is optional because only the attendance bundle carries the
-  // field; every other measurement passes on the first condition. It is made
-  // by hand rather than through the usual helper, which would also add the
-  // value to the SELECT list and so to the DISTINCT below - a person with
-  // both a measurement and an attendance record would come back as two rows
-  // where one will do, in the query that exists to be the cheap bulk path.
-  $query->leftJoin(
-    'field_data_field_attended',
-    'field_attended',
-    'node.nid = field_attended.entity_id AND field_attended.entity_type = :attended_entity_type',
-    [':attended_entity_type' => 'node']
-  );
+  // The join is left, because only the attendance bundle carries the field;
+  // every other measurement passes on the first condition. It is made by hand
+  // rather than through the usual helper, which would also add the value to
+  // the SELECT list and so to the DISTINCT below - a person with both a
+  // measurement and an attendance record would come back as two rows where
+  // one will do, in the query that exists to be the cheap bulk path.
+  $query->leftJoin('field_data_field_attended', 'field_attended', 'node.nid = field_attended.entity_id');
   $query->condition(
     db_or()
       ->condition('node.type', HEDLEY_ACTIVITY_ATTENDANCE_CONTENT_TYPE, '<>')

--- a/server/hedley/modules/custom/hedley_activity/hedley_activity.module
+++ b/server/hedley/modules/custom/hedley_activity/hedley_activity.module
@@ -448,7 +448,12 @@ function hedley_activity_node_by_peer_in_session(\EntityMetadataWrapper $wrapper
 }
 
 /**
- * Loads, per person, the sessions during which they have measurements.
+ * Loads, per person, the sessions they attended.
+ *
+ * Attending is evidenced either by a measurement taken during the session, or
+ * by an attendance record that says they came. An attendance record saying
+ * they did not is no evidence at all, which is what the name of this function
+ * fails to convey - it predates the distinction.
  *
  * Resolves attendance for many persons at once with a single query, rather
  * than a COUNT query per person, so callers can determine it in memory.
@@ -458,7 +463,7 @@ function hedley_activity_node_by_peer_in_session(\EntityMetadataWrapper $wrapper
  *
  * @return array
  *   A map keyed by person node ID; each value is a set of session node IDs (as
- *   array keys) during which that person has at least one measurement.
+ *   array keys) that person attended.
  */
 function hedley_activity_get_persons_sessions_with_measurements(array $sessions_ids) {
   $persons_sessions = [];
@@ -477,14 +482,20 @@ function hedley_activity_get_persons_sessions_with_measurements(array $sessions_
   $session_field_name = $session_field . '.' . $session_field . '_target_id';
   $query->condition($session_field_name, $sessions_ids, 'IN');
 
-  // A session counts for a person when something was measured there. The
-  // attendance record does not count: it carries a person and a session like
-  // any measurement does, but it says only whether the person was expected to
-  // come, and it exists either way - marking someone absent updates it to
-  // attended = FALSE rather than removing it. So counting it made a record of
-  // absence into proof of presence, and a tick with nothing behind it into a
-  // session that ran.
-  $query->condition('node.type', HEDLEY_ACTIVITY_ATTENDANCE_CONTENT_TYPE, '<>');
+  // A measurement means the person was there, and so does the attendance
+  // record - but only when it says so. Marking someone absent updates it to
+  // attended = FALSE rather than removing it, so the record exists either way
+  // and its value, not its presence, is what answers the question. Counting
+  // the record itself turned an absence into proof of attendance.
+  //
+  // The join is optional because only the attendance bundle carries the
+  // field; every other measurement passes on the first condition.
+  hedley_general_join_field_to_query($query, 'node', 'field_attended', FALSE);
+  $query->condition(
+    db_or()
+      ->condition('node.type', HEDLEY_ACTIVITY_ATTENDANCE_CONTENT_TYPE, '<>')
+      ->condition('field_attended.field_attended_value', 1)
+  );
 
   $query->distinct();
 

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -2737,9 +2737,9 @@ function hedley_stats_get_session_attendance_stats_by_health_center($health_cent
 
     // Load, in a single query, the sessions during which each person has
     // measurements, so attendance can be determined in memory below instead of
-    // with a COUNT query per (participant, period). Attending is measured by
-    // what was recorded: a session where nothing was taken did not run for
-    // that person, whatever the attendance record says.
+    // with a COUNT query per (participant, period). A measurement means the
+    // person was there, and so does an attendance record that says they came;
+    // one saying they did not is no evidence of either.
     $all_sessions_ids = [];
     foreach ($sessions_by_period as $period_sessions_ids) {
       $all_sessions_ids = array_merge($all_sessions_ids, $period_sessions_ids);

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -2737,7 +2737,9 @@ function hedley_stats_get_session_attendance_stats_by_health_center($health_cent
 
     // Load, in a single query, the sessions during which each person has
     // measurements, so attendance can be determined in memory below instead of
-    // with a COUNT query per (participant, period).
+    // with a COUNT query per (participant, period). Attending is measured by
+    // what was recorded: a session where nothing was taken did not run for
+    // that person, whatever the attendance record says.
     $all_sessions_ids = [];
     foreach ($sessions_by_period as $period_sessions_ids) {
       $all_sessions_ids = array_merge($all_sessions_ids, $period_sessions_ids);

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -2744,7 +2744,7 @@ function hedley_stats_get_session_attendance_stats_by_health_center($health_cent
     foreach ($sessions_by_period as $period_sessions_ids) {
       $all_sessions_ids = array_merge($all_sessions_ids, $period_sessions_ids);
     }
-    $persons_sessions = hedley_activity_get_persons_sessions_with_measurements(array_unique($all_sessions_ids));
+    $persons_sessions = hedley_activity_get_persons_sessions_attended(array_unique($all_sessions_ids));
 
     // Get PMTCT participants by clinic.
     $participants_ids = hedley_stats_get_pmtct_participants_by_clinic($clinic_id, 5000);

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -80,7 +80,8 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
    *
    *   1. Total encounters by period (last_year / this_year split).
    *   2. Case management aggregation across moderate/severe branches.
-   *   3. Session attendance (smoke check that the function runs).
+   *   3. Session attendance (smoke check that the function runs), and what
+   *      counts as having attended one (B-152a).
    *   4. Stats-blob sync with cache-hash invalidation.
    *   5. Soft-deleted measurements are excluded from stats aggregates (B-032).
    *   6. Soft-deleted persons are excluded from group education stats (B-033).
@@ -165,6 +166,44 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
         $count_completed_programs++;
       }
     }
+
+    // 3b. What counts as attending a session.
+    //
+    // A session counts for a person when something was measured there. The
+    // attendance record itself does not count: it carries a person and a
+    // session like any measurement does, but marking someone absent updates
+    // it to attended = FALSE rather than removing it, so counting it turned a
+    // record of absence into proof of presence.
+    $this->resetHealthCenter();
+    $session_nid = $this->createSession($this->clinicId, strtotime('-1 week'));
+    $nurse = $this->createNurse($this->clinicId);
+
+    $mother_nid = $this->createMother($this->clinicId);
+    $measured_child = $this->createChild($mother_nid, $this->healthCenterId, strtotime('-23 months'), strtotime('-23 months'));
+    $attended_only_child = $this->createChild($mother_nid, $this->healthCenterId, strtotime('-23 months'), strtotime('-23 months'));
+    $absent_child = $this->createChild($mother_nid, $this->healthCenterId, strtotime('-23 months'), strtotime('-23 months'));
+
+    // One child was weighed, one was marked present and nothing was taken,
+    // one was marked absent.
+    $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $measured_child, TRUE, strtotime('-1 week'));
+    $this->createWeight('weight', $session_nid, $measured_child, 12, strtotime('-1 week'));
+    $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $attended_only_child, TRUE, strtotime('-1 week'));
+    $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $absent_child, FALSE, strtotime('-1 week'));
+
+    $persons_sessions = hedley_activity_get_persons_sessions_with_measurements([$session_nid]);
+
+    $this->assertTrue(
+      !empty($persons_sessions[$measured_child][$session_nid]),
+      'A child who was weighed in the session counts as having attended it.'
+    );
+    $this->assertTrue(
+      empty($persons_sessions[$attended_only_child][$session_nid]),
+      'A child marked present, with nothing measured, does not count: the session did not run for them.'
+    );
+    $this->assertTrue(
+      empty($persons_sessions[$absent_child][$session_nid]),
+      'A child marked absent does not count. The record of the absence is not evidence of presence.'
+    );
 
     // 4. Sync handler with cache-hash invalidation.
     $this->resetHealthCenter();

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -169,11 +169,10 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
 
     // 3b. What counts as attending a session.
     //
-    // A session counts for a person when something was measured there. The
-    // attendance record itself does not count: it carries a person and a
-    // session like any measurement does, but marking someone absent updates
-    // it to attended = FALSE rather than removing it, so counting it turned a
-    // record of absence into proof of presence.
+    // A measurement means the person was there, and so does the attendance
+    // record - but only when it says so. Marking someone absent updates it to
+    // attended = FALSE rather than removing it, so counting the record itself
+    // turned an absence into proof of attendance.
     $this->resetHealthCenter();
     $session_nid = $this->createSession($this->clinicId, strtotime('-1 week'));
     $nurse = $this->createNurse($this->clinicId);
@@ -184,7 +183,7 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $absent_child = $this->createChild($mother_nid, $this->healthCenterId, strtotime('-23 months'), strtotime('-23 months'));
 
     // One child was weighed, one was marked present and nothing was taken,
-    // one was marked absent.
+    // one was marked absent. Only the last is not evidence of attending.
     $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $measured_child, TRUE, strtotime('-1 week'));
     $this->createWeight('weight', $session_nid, $measured_child, 12, strtotime('-1 week'));
     $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $attended_only_child, TRUE, strtotime('-1 week'));
@@ -197,8 +196,8 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
       'A child who was weighed in the session counts as having attended it.'
     );
     $this->assertTrue(
-      empty($persons_sessions[$attended_only_child][$session_nid]),
-      'A child marked present, with nothing measured, does not count: the session did not run for them.'
+      !empty($persons_sessions[$attended_only_child][$session_nid]),
+      'A child marked present counts, even with nothing measured. The record says they came.'
     );
     $this->assertTrue(
       empty($persons_sessions[$absent_child][$session_nid]),

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -189,7 +189,7 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $attended_only_child, TRUE, strtotime('-1 week'));
     $this->createAttendance($this->healthCenterId, $session_nid, $nurse->uid, $absent_child, FALSE, strtotime('-1 week'));
 
-    $persons_sessions = hedley_activity_get_persons_sessions_with_measurements([$session_nid]);
+    $persons_sessions = hedley_activity_get_persons_sessions_attended([$session_nid]);
 
     $this->assertTrue(
       !empty($persons_sessions[$measured_child][$session_nid]),


### PR DESCRIPTION
Fixes #2064

The query behind the missed-session statistics selected any published node carrying both `field_person` and `field_session`, with no bundle condition. The `attendance` record carries both — and it exists whether or not the person came, because marking someone absent **updates** it to `attended = FALSE` rather than deleting it.

So the record stating that a child was absent was the thing proving they attended, and that session was never counted as missed. On ihangane.live, **6,748 of 187,676 attendance records say `attended = FALSE`**.

## What counts as attending

A measurement means the person was there — and so does the attendance record, but only when it says so. Its value, not its existence, answers the question:

| attended | measurements | before | after |
| --- | --- | --- | --- |
| yes | yes | counted | counted |
| no | yes | counted | counted — someone was clearly there |
| yes | no | counted | counted — the record says they came |
| no | no | **counted** (the bug) | not counted |

```php
hedley_general_join_field_to_query($query, 'node', 'field_attended', FALSE);
$query->condition(
  db_or()
    ->condition('node.type', HEDLEY_ACTIVITY_ATTENDANCE_CONTENT_TYPE, '<>')
    ->condition('field_attended.field_attended_value', 1)
);
```

The join is optional because only the `attendance` bundle carries that field, so every other measurement passes on the first condition.

## Why not exclude attendance altogether

The first pass did exactly that, on the reasoning that a session where nothing was measured did not really run. Review found it contradicts how the codebase already counts group attendance: `hedley_stats_get_total_encounters_by_patients_at_clinic()` (`hedley_stats.module:3004-3012`) counts attendance with `attended = TRUE`, commented *"Only participants who actually attended the sessions."* The same child would have been one FBF encounter there and a missed session here.

Measured on the 50 most recent sessions on ihangane.live: **141** attendance records say `attended = 1`, and **39 of them (28%)** have no measurement for that person in that session. The common case, not the corner one — so the two statistics now agree instead.

## Test

The existing coverage was a smoke check that computed `$count_missed_sessions` and `$count_completed_programs` and asserted on **neither** — the semantics were entirely uncovered, which is how this survived. Rather than add a test class (each costs a full install in CI), assertions are folded into `testStatsCalculations`: one session, three children — weighed, ticked with nothing taken, marked absent. The first two count, the third does not. The third assertion fails on develop.

## Verification status

`php -l` clean; phpcs `Drupal` and `DrupalPractice` with the full CI extension list both exit 0 with no output.

**The SimpleTest has not been run locally** — the DDEV router is unhealthy on this machine, so `ddev simpletest` cannot start. CI's `test_simpletest_linux` job is the first execution of these assertions.

## Known gap, not taken here

The new assertions exercise the helper, not `hedley_stats_get_session_attendance_stats_by_health_center()` where the defect actually surfaced, so a regression one level up would still pass. Writing that blind — without being able to run it — risks a red CI cycle on period arithmetic, so it is raised rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)