### PR TITLE
CI: stop passing when the tests never ran

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,9 @@ jobs:
           no_output_timeout: 15m
       - store_artifacts:
           path: client/test-results
+          # Screenshots are captured only on failure, so the default
+          # on_success would drop them exactly when they are needed.
+          when: always
           destination: playwright-results
   e2e_playwright_2:
     machine:
@@ -199,6 +202,9 @@ jobs:
           no_output_timeout: 15m
       - store_artifacts:
           path: client/test-results
+          # Screenshots are captured only on failure, so the default
+          # on_success would drop them exactly when they are needed.
+          when: always
           destination: playwright-results
   e2e_reporting:
     machine:
@@ -253,4 +259,7 @@ jobs:
           no_output_timeout: 15m
       - store_artifacts:
           path: client/test-results
+          # Screenshots are captured only on failure, so the default
+          # on_success would drop them exactly when they are needed.
+          when: always
           destination: playwright-results

--- a/.ddev/commands/web/simpletest
+++ b/.ddev/commands/web/simpletest
@@ -4,11 +4,37 @@
 ## Usage: simpletest
 ## Example: "ddev simpletest"
 #
-drush en simpletest -y
+
+# The runner's exit code reaches us through the pipe into tee, and every step
+# below is checked. Without this the job reported success for a runner that
+# never started - a broken site build left the only server-side test job green
+# on every pull request, with nothing to distinguish no failures from no tests.
+set -o pipefail
+
+if ! drush en simpletest -y; then
+  echo "Could not enable the simpletest module, so no tests were run."
+  exit 1
+fi
+
 cd ..
 php ./www/scripts/run-tests.sh --php "$(which php)" --concurrency 4 --verbose --color --url http://eheza-app.ddev.site:8081 Hedley 2>&1 | tee /tmp/simpletest-result.txt
+runner_status=$?
 
+if [ "$runner_status" -ne 0 ]; then
+  echo "The test runner exited with status $runner_status."
+  exit 1
+fi
+
+# Reports a failure, a fatal, or an exception. The trailing-zero alternatives
+# catch counts like 10 and 20, which the leading [1-9] would otherwise miss.
 grep -E -i "([1-9]+ fail)|(Fatal error)|([1-9]+ exception)|([0-9]+0 fail)|([0-9]+0 exception)" /tmp/simpletest-result.txt && exit 1
+
+# Says nothing failed, which is also what it says when nothing ran. A suite
+# that passed has passes to show for it.
+if ! grep -E -q "[1-9][0-9]* passes" /tmp/simpletest-result.txt; then
+  echo "No passing tests were reported, so the suite did not run."
+  exit 1
+fi
 
 drush pm-disable simpletest -y
 

--- a/.ddev/commands/web/simpletest
+++ b/.ddev/commands/web/simpletest
@@ -16,6 +16,10 @@ if ! drush en simpletest -y; then
   exit 1
 fi
 
+# Every path below can exit, and leaving the module enabled changes the state
+# of the developer's site.
+trap 'drush pm-disable simpletest -y' EXIT
+
 cd ..
 php ./www/scripts/run-tests.sh --php "$(which php)" --concurrency 4 --verbose --color --url http://eheza-app.ddev.site:8081 Hedley 2>&1 | tee /tmp/simpletest-result.txt
 runner_status=$?
@@ -30,12 +34,12 @@ fi
 grep -E -i "([1-9]+ fail)|(Fatal error)|([1-9]+ exception)|([0-9]+0 fail)|([0-9]+0 exception)" /tmp/simpletest-result.txt && exit 1
 
 # Says nothing failed, which is also what it says when nothing ran. A suite
-# that passed has passes to show for it.
-if ! grep -E -q "[1-9][0-9]* passes" /tmp/simpletest-result.txt; then
+# that passed has passes to show for it. The singular is spelled differently -
+# simpletest formats the count with format_plural, so exactly one reads
+# "1 pass" - and a run of a single narrow class must not look like no run.
+if ! grep -E -q "[1-9][0-9]* pass(es)?" /tmp/simpletest-result.txt; then
   echo "No passing tests were reported, so the suite did not run."
   exit 1
 fi
-
-drush pm-disable simpletest -y
 
 exit 0

--- a/ci-scripts/install_ddev.sh
+++ b/ci-scripts/install_ddev.sh
@@ -18,7 +18,7 @@ curl -s -L https://raw.githubusercontent.com/drud/ddev/master/scripts/install_dd
 echo "Configuring ddev."
 mkdir ~/.ddev
 cp "ci-scripts/global_config.yaml" ~/.ddev/
-docker network create ddev_default || ddev logs
+docker network create ddev_default || { ddev logs; exit 1; }
 
 if [[ "$MAC" == 1 ]];
 then

--- a/ci-scripts/install_ddev.sh
+++ b/ci-scripts/install_ddev.sh
@@ -18,7 +18,7 @@ curl -s -L https://raw.githubusercontent.com/drud/ddev/master/scripts/install_dd
 echo "Configuring ddev."
 mkdir ~/.ddev
 cp "ci-scripts/global_config.yaml" ~/.ddev/
-docker network create ddev_default || { ddev logs; exit 1; }
+docker network create ddev_default || ddev logs
 
 if [[ "$MAC" == 1 ]];
 then

--- a/ci-scripts/install_drupal.sh
+++ b/ci-scripts/install_drupal.sh
@@ -8,4 +8,4 @@ echo "Install Drupal."
 
 echo composer_version: "2" > .ddev/config.local.yaml
 cat .ddev/config.local.yaml.example >> .ddev/config.local.yaml
-ddev restart || ddev logs
+ddev restart || { ddev logs; exit 1; }

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: recording ? './e2e/global-teardown.ts' : undefined,
   testDir: './e2e',
+  // A committed test.only would otherwise shrink a shard to one test and
+  // leave the job green, and e2e is the only functional gate on a release.
+  forbidOnly: !!process.env.CI,
   timeout: 120000,
   retries: 0,
   workers: 1,


### PR DESCRIPTION
Fixes #2066

The simpletest wrapper fails when the suite does not run. `set -o pipefail` carries the runner's exit code out of the pipe to `tee`, that status is checked, `drush en simpletest -y` is checked, and a run reports at least one pass before the script exits 0. The failure grep is unchanged — it was already correct for runs that complete — and the module is disabled from a trap, so a failing run leaves the site as it found it.

A failed `ddev restart` fails `ci-scripts/install_drupal.sh` rather than passing through the `ddev logs` fallback.

`forbidOnly: !!process.env.CI` stops a committed `test.only` from shrinking an e2e shard while the job stays green.

The three `store_artifacts` steps carry `when: always`, so failure screenshots survive the run that produced them. Note that `trace: 'on-first-retry'` with `retries: 0` means traces are never captured, so this covers screenshots only.

## Not in this PR

Three of the issue's smaller gates, each of which can turn CI red for pre-existing reasons and wants its own diff:

- `lint_elm_review` installs registry-latest `elm-review` at run time instead of the pinned version.
- `test_shell.sh` checks neither the extensionless install and deploy chain nor any `.ddev/commands/*`, including the wrapper this PR fixes.
- Nothing rebuilds the committed `server/elm` bundle and compares it against source.