### PR TITLE
Vaccination: stop the date picker coming up empty when a vaccine becomes due today

### DIFF
--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -1558,12 +1558,22 @@ vaccinationFormDynamicContentAndTasks language currentDate site config vaccineTy
                                 -- expected due date of first dose.
                                 |> Maybe.withDefault config.firstDoseExpectedFrom
 
+                        -- A dose given previously was given before today, so the
+                        -- range ends yesterday. On the day a dose first becomes due
+                        -- its due date is later than that, and the range starts from
+                        -- the last day it can offer instead.
+                        dateTo =
+                            Date.add Days -1 currentDate
+
+                        rangeStart =
+                            Date.min dateFrom dateTo
+
                         dateSelectorConfig =
                             { select = config.setVaccinationUpdateDateMsg
                             , close = config.setVaccinationUpdateDateSelectorStateMsg Nothing
-                            , dateFrom = dateFrom
-                            , dateTo = Date.add Days -1 currentDate
-                            , dateDefault = Just dateFrom
+                            , dateFrom = rangeStart
+                            , dateTo = dateTo
+                            , dateDefault = Just rangeStart
                             }
                     in
                     ( [ viewLabel language Translate.SelectDate

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -1558,22 +1558,20 @@ vaccinationFormDynamicContentAndTasks language currentDate site config vaccineTy
                                 -- expected due date of first dose.
                                 |> Maybe.withDefault config.firstDoseExpectedFrom
 
-                        -- A dose given previously was given before today, so the
-                        -- range ends yesterday. On the day a dose first becomes due
-                        -- its due date is later than that, and the range starts from
-                        -- the last day it can offer instead.
+                        -- The range runs from the day the dose became due to
+                        -- yesterday. A dose that becomes due today was not due on any
+                        -- earlier day, so the range is that one day: earlier is before
+                        -- the dose could be given, and for a first dose of BCG or OPV
+                        -- it would be before the child was born.
                         dateTo =
-                            Date.add Days -1 currentDate
-
-                        rangeStart =
-                            Date.min dateFrom dateTo
+                            Date.max (Date.add Days -1 currentDate) dateFrom
 
                         dateSelectorConfig =
                             { select = config.setVaccinationUpdateDateMsg
                             , close = config.setVaccinationUpdateDateSelectorStateMsg Nothing
-                            , dateFrom = rangeStart
+                            , dateFrom = dateFrom
                             , dateTo = dateTo
-                            , dateDefault = Just rangeStart
+                            , dateDefault = Just dateFrom
                             }
                     in
                     ( [ viewLabel language Translate.SelectDate


### PR DESCRIPTION
Fixes #2074

The date picker for a dose administered previously runs from the day the dose became due to yesterday. A dose that becomes due today was not due on any earlier day, so the range is that one day:

```elm
dateTo =
    Date.max (Date.add Days -1 currentDate) dateFrom
```

The calendar has a day to show, and the date the form takes when the picker opens is the day the dose became due.

Ending the range at yesterday would offer a day the dose could not have been given on — and for a first dose of BCG or OPV, whose due date is the birth date, a day before the child was born.

Ranges that already made sense are unchanged: a dose due last month still offers from that date to yesterday, and one due yesterday still offers that single day.

All three immunisation programs — WellChild, ChildScoreboard and Prenatal — build this picker through the same function.

## Not in this PR

Opening the picker writes its default into the form before the nurse chooses anything. That applies to every vaccine rather than to this case, and changing it would alter the interaction well beyond the defect.