### PR TITLE
Sync: stop losing an incident report when its entity is not on the device

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1372,7 +1372,12 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         }
 
         return sendIndexedDbFetchResult(queryType, JSON.stringify(entities));
-      })().catch((e) => sendIndexedDbFetchResult(queryType, JSON.stringify({ error: String(e) })));
+      })().catch((e) => {
+        // The backend reads this reply as a list of entities, so the reply
+        // stays a list whatever went wrong, and the reason goes to the log.
+        console.error('IndexDbQueryGetShardsEntityByUuid: ' + String(e));
+        return sendIndexedDbFetchResult(queryType, JSON.stringify([]));
+      });
         break;
 
     default:

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1190,6 +1190,13 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
             .limit(1)
             .toArray();
 
+        if (!result.length) {
+          // The uuid is not among the shards this device holds, so there is
+          // nothing to describe. The reply still goes back, because the
+          // report that asked is waiting for one.
+          return sendIndexedDbFetchResult(queryType, JSON.stringify([]));
+        }
+
         let entities = [result[0]];
 
         // In case we got entity of type "session", it's only reference is
@@ -1364,10 +1371,8 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
           }
         }
 
-        if (entities) {
-          return sendIndexedDbFetchResult(queryType, JSON.stringify(entities));
-        }
-      })();
+        return sendIndexedDbFetchResult(queryType, JSON.stringify(entities));
+      })().catch((e) => sendIndexedDbFetchResult(queryType, JSON.stringify({ error: String(e) })));
         break;
 
     default:

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -1374,8 +1374,8 @@ elmApp.ports.askFromIndexDb.subscribe(function(info) {
         return sendIndexedDbFetchResult(queryType, JSON.stringify(entities));
       })().catch((e) => {
         // The backend reads this reply as a list of entities, so the reply
-        // stays a list whatever went wrong, and the reason goes to the log.
-        console.error('IndexDbQueryGetShardsEntityByUuid: ' + String(e));
+        // stays a list whatever went wrong, and the reason is reported.
+        rollbar.log('IndexDbQueryGetShardsEntityByUuid: ' + String(e));
         return sendIndexedDbFetchResult(queryType, JSON.stringify([]));
       });
         break;

--- a/client/src/js/nodes.js
+++ b/client/src/js/nodes.js
@@ -928,9 +928,8 @@
                     if (nameContains) {
                         // For the case when there's more than one word as an input,
                         // we generate an array of lowercase words.
-                        var words = nameContains.split(' ');
-                        words.forEach(function (word, index) {
-                          words[index] = word.toLowerCase();
+                        var words = nameContains.split(/\s+/).flatMap(function (word) {
+                            return word ? [word.toLowerCase()] : [];
                         });
 
                         modifyQuery = modifyQuery.then(function () {
@@ -1272,7 +1271,7 @@
                   return Promise.reject('Clinic had no health_center: ' + clinic.uuid);
               }
           } else {
-              return Promise.reject('Could not find clinic: ' + session.clinic);
+              return Promise.reject('Could not find clinic: ' + clinicId);
           }
       });
     }

--- a/client/src/js/nodes.js
+++ b/client/src/js/nodes.js
@@ -926,11 +926,9 @@
                     // No need ot wory about combinations of several params.
                     var nameContains = params.get('name_contains');
                     if (nameContains) {
-                        // For the case when there's more than one word as an input,
-                        // we generate an array of lowercase words.
-                        var words = nameContains.split(/\s+/).flatMap(function (word) {
-                            return word ? [word.toLowerCase()] : [];
-                        });
+                        // Tokenized by the function that builds name_search, so
+                        // what is searched for and what was indexed cannot differ.
+                        var words = gatherWords(nameContains);
 
                         modifyQuery = modifyQuery.then(function () {
                             // We search for resulting persons that start with any of the input words (apply 'OR' condition).


### PR DESCRIPTION
Fixes #2076

Three independent changes to the client's JavaScript glue.

**`IndexDbQueryGetShardsEntityByUuid` answers a uuid it does not hold.** An empty Dexie result returns an empty reply instead of reading a row that is not there, and the handler carries a `.catch` like the upload lanes beside it, so the incident report that asked always receives an answer. The reply stays a string, since that is what the decoder for this query reads.

**`resolveShardByClinicId` names the clinic it was given** in its rejection, rather than a variable that is not in scope and throws while the message is built.

**A name search tokenizes the way the index does.** `gatherWords` splits on `/\s+/` and drops blanks; the query now does the same, so a name typed with two spaces between words searches for the words rather than scanning the whole `name_search` index.