### PR TITLE
Wellbeing: stop the notification reappearing when it is ignored

### DIFF
--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -1054,7 +1054,7 @@ update msg model =
                 (\configured ->
                     let
                         ( subModel, subCmd, outMsg ) =
-                            Pages.PinCode.Update.update subMsg configured.pinCodePage
+                            Pages.PinCode.Update.update model.currentTime subMsg configured.pinCodePage
 
                         ( extraMsgs, extraCmds ) =
                             Maybe.map

--- a/client/src/elm/Pages/PinCode/Update.elm
+++ b/client/src/elm/Pages/PinCode/Update.elm
@@ -6,8 +6,8 @@ import Time
 import Time.Extra
 
 
-update : Msg -> Model -> ( Model, Cmd Msg, Maybe OutMsg )
-update msg model =
+update : Time.Posix -> Msg -> Model -> ( Model, Cmd Msg, Maybe OutMsg )
+update currentTime msg model =
     case msg of
         HandleLoginClicked ->
             ( { model | code = "" }
@@ -41,9 +41,11 @@ update msg model =
 
         HandleNotificationResponse accept ->
             let
+                -- An hour from now. Adding to the time already stored would
+                -- land in the past whenever more than an hour has passed since
+                -- it was set, and the dialog shows again straight away.
                 nextNotification =
-                    Maybe.map (Time.Extra.add Time.Extra.Hour 1 Time.utc)
-                        model.nextNotification
+                    Just <| Time.Extra.add Time.Extra.Hour 1 Time.utc currentTime
 
                 outMsg =
                     if accept then


### PR DESCRIPTION
Fixes #2078

Ignoring the notification schedules the next one an hour from now:

```elm
nextNotification =
    Just <| Time.Extra.add Time.Extra.Hour 1 Time.utc currentTime
```

It previously added an hour to the time already stored, which was set at login — so once more than an hour had passed, the new time was still in the past and the dialog showed again immediately, taking one press per hour elapsed to clear.

`Pages.PinCode.Update.update` takes the current time for this, and `App.Update` passes `model.currentTime` when it calls it.