### PR TITLE
Patient search: stop the search losing what was typed

### DIFF
--- a/client/src/elm/Components/PatientsSearchForm/Update.elm
+++ b/client/src/elm/Components/PatientsSearchForm/Update.elm
@@ -57,11 +57,14 @@ update msg model =
                         |> sequence update [ MsgDebouncer <| provideInput <| SetSearch input ]
 
                 ModeSearchByNationalId ->
-                    let
-                        asNumber =
-                            String.toInt input
-                    in
-                    if isJust asNumber then
+                    if String.isEmpty input then
+                        -- An emptied field searches for nothing, so the results
+                        -- of what it held go with it.
+                        ( { model | input = "", search = Nothing }
+                        , Cmd.none
+                        )
+
+                    else if isJust (String.toInt input) then
                         ( { model | input = input }
                         , Cmd.none
                         )

--- a/client/src/elm/Components/PatientsSearchForm/Update.elm
+++ b/client/src/elm/Components/PatientsSearchForm/Update.elm
@@ -59,10 +59,14 @@ update msg model =
                 ModeSearchByNationalId ->
                     if String.isEmpty input then
                         -- An emptied field searches for nothing, so the results
-                        -- of what it held go with it.
+                        -- of what it held go with it. The empty input goes to
+                        -- the debouncer too: it holds the last input it was
+                        -- given, and a number given a moment earlier would
+                        -- otherwise arrive half a second later and search again.
                         ( { model | input = "", search = Nothing }
                         , Cmd.none
                         )
+                            |> sequence update [ MsgDebouncer <| provideInput <| SetSearch "" ]
 
                     else if isJust (String.toInt input) then
                         ( { model | input = input }

--- a/client/src/elm/Components/PatientsSearchForm/Update.elm
+++ b/client/src/elm/Components/PatientsSearchForm/Update.elm
@@ -28,9 +28,19 @@ update msg model =
                     else
                         ModeSearchByNationalId
             in
-            ( { model | mode = mode, input = "", search = Nothing }
-            , Cmd.none
-            )
+            if mode == model.mode then
+                -- The mode asked for is the one already in use, so what has
+                -- been typed stays where it is.
+                ( model, Cmd.none )
+
+            else
+                ( { model | mode = mode, input = "", search = Nothing }
+                , Cmd.none
+                )
+                    -- The debouncer holds the last input it was given, so a
+                    -- search typed a moment ago would otherwise arrive after
+                    -- the switch and be run in the mode it was not typed for.
+                    |> sequence update [ MsgDebouncer <| provideInput <| SetSearch "" ]
 
         SetSearch search ->
             let

--- a/client/src/elm/Components/PatientsSearchForm/Update.elm
+++ b/client/src/elm/Components/PatientsSearchForm/Update.elm
@@ -61,19 +61,27 @@ update msg model =
         SetInput input ->
             case model.mode of
                 ModeSearchByName ->
-                    ( { model | input = input }
+                    ( { model
+                        | input = input
+                        , search =
+                            if String.isEmpty (String.trim input) then
+                                Nothing
+
+                            else
+                                model.search
+                      }
                     , Cmd.none
                     )
                         |> sequence update [ MsgDebouncer <| provideInput <| SetSearch input ]
 
                 ModeSearchByNationalId ->
-                    if String.isEmpty input then
+                    if String.isEmpty (String.trim input) then
                         -- An emptied field searches for nothing, so the results
                         -- of what it held go with it. The empty input goes to
                         -- the debouncer too: it holds the last input it was
                         -- given, and a number given a moment earlier would
                         -- otherwise arrive half a second later and search again.
-                        ( { model | input = "", search = Nothing }
+                        ( { model | input = input, search = Nothing }
                         , Cmd.none
                         )
                             |> sequence update [ MsgDebouncer <| provideInput <| SetSearch "" ]


### PR DESCRIPTION
Fixes #2080
Fixes #2082

Three changes to the shared patient-search widget.

**An emptied National ID field searches for nothing**, so `search` is cleared with it and the results of the previous search leave the screen.

**Tapping the label of the mode already in use** asks for that mode again, and what has been typed stays where it is.

**Switching mode gives the debouncer the empty input.** It holds the last input it was given, so a query typed a moment before a switch would otherwise arrive after it and be searched for in the mode it was not typed for. The emptied-field case does the same, so a number typed just before the field was cleared cannot bring its results back half a second later. This is what the search by name already does for every input.

## Not in this PR

A rejected non-digit stays visible in the National ID field: returning the model unchanged leaves the view identical, so nothing is patched and the character the model refused remains on screen.