### PR TITLE
CI: stop switching itself off on 21 September

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
-version: 2
+version: 2.1
 
 workflows:
-  version: 2
   build:
     jobs:
       - lint_phpcs


### PR DESCRIPTION
Fixes #2083

The config declares `version: 2.1`, which CircleCI still compiles after 21 September 2026, so CI keeps running on every branch.

The `version` key nested under `workflows` has no meaning in 2.1 and is gone.

Nothing else changes: the config uses no feature whose behaviour differs between the two versions, and the ten jobs and their dependencies are untouched.