### PR TITLE
Sync: report dropped participant updates instead of discarding them silently

### DIFF
--- a/client/src/elm/Backend/IndividualEncounterParticipant/Update.elm
+++ b/client/src/elm/Backend/IndividualEncounterParticipant/Update.elm
@@ -6,25 +6,28 @@ import Backend.Endpoints exposing (individualEncounterParticipantEndpoint)
 import Backend.Entities exposing (IndividualEncounterParticipantId)
 import Backend.IndividualEncounterParticipant.Model exposing (IndividualEncounterParticipant, IndividualEncounterParticipantOutcome(..), Model, Msg(..))
 import Backend.Utils exposing (sw)
+import Error.Model exposing (ErrorType(..))
 import Gizra.NominalDate exposing (NominalDate)
 import Maybe.Extra exposing (unwrap)
-import RemoteData exposing (RemoteData(..))
-import Restful.Endpoint exposing (toCmd, withoutDecoder)
+import RemoteData exposing (RemoteData(..), WebData)
+import Restful.Endpoint exposing (fromEntityUuid, toCmd, withoutDecoder)
+import Utils.WebData exposing (viewErrorForRollbar)
 
 
 update :
     NominalDate
     -> IndividualEncounterParticipantId
-    -> Maybe IndividualEncounterParticipant
+    -> Maybe (WebData IndividualEncounterParticipant)
     -> Msg
     -> Model
     -> ( Model, Cmd Msg, List App.Model.Msg )
-update currentDate participantId maybeParticipant msg model =
+update currentDate participantId participantState msg model =
     case msg of
         ClosePrenatalSession concludedDate outcome deliveryLocation ->
             updateIndividualEncounterParticipant
                 participantId
-                maybeParticipant
+                participantState
+                "close-prenatal-session"
                 (\participant ->
                     { participant
                         | endDate = Just currentDate
@@ -38,14 +41,16 @@ update currentDate participantId maybeParticipant msg model =
         CloseAcuteIllnessSession outcome ->
             updateIndividualEncounterParticipant
                 participantId
-                maybeParticipant
+                participantState
+                "close-acute-illness-session"
                 (\participant -> { participant | endDate = Just currentDate, outcome = Just (AcuteIllness outcome) })
                 model
 
         CloseTuberculosisSession outcome ->
             updateIndividualEncounterParticipant
                 participantId
-                maybeParticipant
+                participantState
+                "close-tuberculosis-session"
                 (\participant ->
                     { participant
                         | endDate = Just currentDate
@@ -58,7 +63,8 @@ update currentDate participantId maybeParticipant msg model =
         CloseHIVSession outcome ->
             updateIndividualEncounterParticipant
                 participantId
-                maybeParticipant
+                participantState
+                "close-hiv-session"
                 (\participant ->
                     { participant
                         | endDate = Just currentDate
@@ -71,14 +77,16 @@ update currentDate participantId maybeParticipant msg model =
         SetEddDate eddDate ->
             updateIndividualEncounterParticipant
                 participantId
-                maybeParticipant
+                participantState
+                "set-edd-date"
                 (\participant -> { participant | eddDate = Just eddDate })
                 model
 
         SetNewborn personId ->
             updateIndividualEncounterParticipant
                 participantId
-                maybeParticipant
+                participantState
+                "set-newborn"
                 (\participant -> { participant | newborn = Just personId })
                 model
 
@@ -91,13 +99,34 @@ update currentDate participantId maybeParticipant msg model =
 
 updateIndividualEncounterParticipant :
     IndividualEncounterParticipantId
-    -> Maybe IndividualEncounterParticipant
+    -> Maybe (WebData IndividualEncounterParticipant)
+    -> String
     -> (IndividualEncounterParticipant -> IndividualEncounterParticipant)
     -> Model
     -> ( Model, Cmd Msg, List App.Model.Msg )
-updateIndividualEncounterParticipant individualEncounterParticipantId maybeIndividualEncounterParticipant updateFunc model =
-    maybeIndividualEncounterParticipant
-        |> unwrap ( model, Cmd.none, [] )
+updateIndividualEncounterParticipant individualEncounterParticipantId participantState action updateFunc model =
+    participantState
+        |> Maybe.andThen RemoteData.toMaybe
+        |> unwrap
+            -- The participant is not loaded, so there is nothing to apply the
+            -- update to, and it is discarded. Discarding used to be silent,
+            -- which made field occurrences (pregnancies left without EDD)
+            -- undiagnosable - so report it, with the cache state that explains
+            -- why the participant was not available.
+            ( model
+            , Cmd.none
+            , [ ("Dropped '"
+                    ++ action
+                    ++ "' for individual participant "
+                    ++ fromEntityUuid individualEncounterParticipantId
+                    ++ ": participant not loaded (cache state: "
+                    ++ describeParticipantState participantState
+                    ++ ")"
+                )
+                    |> Plain
+                    |> App.Model.TriggerRollbar App.Model.IndexedDB
+              ]
+            )
             (\individualEncounterParticipant ->
                 ( { model | updateIndividualEncounterParticipant = Loading }
                 , updateFunc individualEncounterParticipant
@@ -107,3 +136,22 @@ updateIndividualEncounterParticipant individualEncounterParticipantId maybeIndiv
                 , []
                 )
             )
+
+
+describeParticipantState : Maybe (WebData IndividualEncounterParticipant) -> String
+describeParticipantState participantState =
+    case participantState of
+        Nothing ->
+            "missing"
+
+        Just NotAsked ->
+            "not-asked"
+
+        Just Loading ->
+            "loading"
+
+        Just (Failure error) ->
+            "failure - " ++ viewErrorForRollbar error
+
+        Just (Success _) ->
+            "success"

--- a/client/src/elm/Backend/Update.elm
+++ b/client/src/elm/Backend/Update.elm
@@ -4119,16 +4119,17 @@ updateIndexedDb language currentDate currentTime coordinates zscores site featur
 
         MsgIndividualEncounterParticipant participantId subMsg ->
             let
-                participant =
+                -- The full cache state is passed down, so that a dropped
+                -- update can report what stood in the way of applying it.
+                participantState =
                     Dict.get participantId model.individualParticipants
-                        |> Maybe.andThen RemoteData.toMaybe
 
                 requests =
                     Dict.get participantId model.individualEncounterParticipantRequests
                         |> Maybe.withDefault Backend.IndividualEncounterParticipant.Model.emptyModel
 
                 ( subModel, subCmd, appMsgs ) =
-                    Backend.IndividualEncounterParticipant.Update.update currentDate participantId participant subMsg requests
+                    Backend.IndividualEncounterParticipant.Update.update currentDate participantId participantState subMsg requests
             in
             ( { model | individualEncounterParticipantRequests = Dict.insert participantId subModel model.individualEncounterParticipantRequests }
             , Cmd.map (MsgIndividualEncounterParticipant participantId) subCmd


### PR DESCRIPTION
Fixes #2085

When a participant update (`SetEddDate`, `SetNewborn`, or any of the four encounter-close messages) arrives while the participant is not loaded in `individualParticipants`, `updateIndividualEncounterParticipant` used to discard it with no trace — the silent no-op behind the pregnancies that `populate-edd.php` keeps backfilling.

**What this changes**

- `Backend.Update` passes the participant's full cache state (`Maybe (WebData ...)`) down instead of collapsing it to a `Maybe` first, so the drop branch can see *why* the participant was unavailable.
- Each update message now carries an action label (`set-edd-date`, `close-prenatal-session`, ...).
- The drop branch reports through `TriggerRollbar IndexedDB` (the offline-safe lane: stored in the local dbErrors table, drained at the next sync) with the action, the participant uuid, and the cache state — `missing`, `not-asked`, `loading`, or `failure - <error>`.

Rollbar attaches the device (person.id), build version and the telemetry trail automatically, so the next field occurrence arrives self-diagnosed: the cache-state string alone splits the remaining hypothesis space (failure names the failing read; loading = lost reply; missing = eviction).

**No behavior change when the participant is loaded** — the patch path is byte-identical.

**Verification**: `elm make src/elm/Main.elm` — 548 modules · `elm-test` — 2,974 passed · `elm-format --validate` clean on both files · `elm-review` on the committed state via clone — no errors.

Diff: +66 / −17 across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)