### PR TITLE
Child scoreboard: stop one undated ANC visit from blanking a district's scoreboard

### DIFF
--- a/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
+++ b/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
@@ -699,7 +699,14 @@ function hedley_ncda_calculate_aggregated_data_for_person($person, $birth_date_f
     if (!empty($encounters_ids)) {
       $encounters = node_load_multiple($encounters_ids);
       foreach ($encounters as $encounter) {
-        $encounter_type = $encounter->field_prenatal_encounter_type[LANGUAGE_NONE][0]['value'];
+        // Encounters recorded before the type field was populated have no
+        // type. They count as ANC visits, which is how the client reads them
+        // too.
+        $encounter_type = NULL;
+        if (!empty($encounter->field_prenatal_encounter_type[LANGUAGE_NONE][0]['value'])) {
+          $encounter_type = $encounter->field_prenatal_encounter_type[LANGUAGE_NONE][0]['value'];
+        }
+
         if (in_array($encounter_type, ['nurse-postpartum', 'chw-postpartum'])) {
           continue;
         }

--- a/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
+++ b/server/hedley/modules/custom/hedley_ncda/hedley_ncda.module
@@ -704,7 +704,12 @@ function hedley_ncda_calculate_aggregated_data_for_person($person, $birth_date_f
           continue;
         }
 
-        $data['ncda']['pane1']['row1'][] = hedley_ncda_get_date_filed_value($encounter, 'field_scheduled_date');
+        $scheduled_date = hedley_ncda_get_date_filed_value($encounter, 'field_scheduled_date');
+        if (!$scheduled_date) {
+          continue;
+        }
+
+        $data['ncda']['pane1']['row1'][] = $scheduled_date;
       }
     }
   }


### PR DESCRIPTION
Fixes #2087

An ANC encounter with no scheduled date is skipped rather than contributing `false` to the person's stored list of visit dates, so the list holds only dates and the district's aggregated scoreboard decodes.

An encounter with no type is read without raising a notice. It still counts as an ANC visit, which is how the client reads it too: the encounter syncs with a null type, and the client's decoder falls back to a nurse encounter.

Both skips follow the form the other dates collected in this file already use.

No repair accompanies this change: no stored record holds a `false` today, on any site. A record written before this change would keep it until that person's data is recalculated, which happens only when a measurement save, a new village, or a person edit triggers it — not on a schedule.