### PR TITLE
Dashboard stats: stop stale month figures being read as this month's

### DIFF
--- a/client/src/elm/Backend/Dashboard/Decoder.elm
+++ b/client/src/elm/Backend/Dashboard/Decoder.elm
@@ -64,7 +64,7 @@ decodeDashboardStatsRaw =
         |> required "villages_with_residents" decodeVillagesWithResidents
         |> required "patients_details" decodePatientsDetails
         |> required "timestamp" string
-        |> optional "stats_generated_month" (nullable decodeInt) Nothing
+        |> optional "stats_generated_date" (nullable decodeYYYYMMDD) Nothing
         |> required "stats_cache_hash" string
 
 

--- a/client/src/elm/Backend/Dashboard/Decoder.elm
+++ b/client/src/elm/Backend/Dashboard/Decoder.elm
@@ -64,6 +64,7 @@ decodeDashboardStatsRaw =
         |> required "villages_with_residents" decodeVillagesWithResidents
         |> required "patients_details" decodePatientsDetails
         |> required "timestamp" string
+        |> optional "stats_generated_month" (nullable decodeInt) Nothing
         |> required "stats_cache_hash" string
 
 

--- a/client/src/elm/Backend/Dashboard/Encoder.elm
+++ b/client/src/elm/Backend/Dashboard/Encoder.elm
@@ -58,6 +58,7 @@ encodeDashboardStatsRaw stats =
     , encodeVillagesWithResidents stats.villagesWithResidents
     , encodePatientsDetails stats.patientsDetails
     , ( "timestamp", string stats.timestamp )
+    , ( "stats_generated_date", maybe encodeYYYYMMDD stats.statsGeneratedDate )
     , ( "stats_cache_hash", string stats.cacheHash )
     ]
 

--- a/client/src/elm/Backend/Dashboard/Model.elm
+++ b/client/src/elm/Backend/Dashboard/Model.elm
@@ -88,9 +88,9 @@ type alias DashboardStatsRaw =
     -- UTC Date and time on which statistics were generated.
     , timestamp : String
 
-    -- The month the statistics were generated in. Monthly figures are numbered
-    -- from it, so it is the month they are read against.
-    , statsGeneratedMonth : Maybe Int
+    -- The date the statistics were generated on. Monthly figures are numbered
+    -- from its month, so it is the date they are read against.
+    , statsGeneratedDate : Maybe NominalDate
 
     -- An md5 hash, using which we know if we have the most up to date data.
     , cacheHash : String
@@ -108,9 +108,9 @@ type alias DashboardStats =
     -- UTC Date and time on which statistics were generated.
     , timestamp : String
 
-    -- The month the statistics were generated in. Monthly figures are numbered
-    -- from it, so it is the month they are read against.
-    , statsGeneratedMonth : Maybe Int
+    -- The date the statistics were generated on. Monthly figures are numbered
+    -- from its month, so it is the date they are read against.
+    , statsGeneratedDate : Maybe NominalDate
     }
 
 

--- a/client/src/elm/Backend/Dashboard/Model.elm
+++ b/client/src/elm/Backend/Dashboard/Model.elm
@@ -61,8 +61,9 @@ type alias NutritionPageData =
     , newCasesGraphData : Dict Int TotalBeneficiaries
     , totalsGraphData : Dict Int TotalBeneficiaries
 
-    -- The month the figures above are numbered from.
-    , statsMonth : Int
+    -- The date the figures above are numbered from, when the statistics
+    -- carried one.
+    , statsGeneratedDate : Maybe NominalDate
     }
 
 

--- a/client/src/elm/Backend/Dashboard/Model.elm
+++ b/client/src/elm/Backend/Dashboard/Model.elm
@@ -60,6 +60,9 @@ type alias NutritionPageData =
     , totalEncounters : Periods
     , newCasesGraphData : Dict Int TotalBeneficiaries
     , totalsGraphData : Dict Int TotalBeneficiaries
+
+    -- The month the figures above are numbered from.
+    , statsMonth : Int
     }
 
 
@@ -85,6 +88,10 @@ type alias DashboardStatsRaw =
     -- UTC Date and time on which statistics were generated.
     , timestamp : String
 
+    -- The month the statistics were generated in. Monthly figures are numbered
+    -- from it, so it is the month they are read against.
+    , statsGeneratedMonth : Maybe Int
+
     -- An md5 hash, using which we know if we have the most up to date data.
     , cacheHash : String
     }
@@ -100,6 +107,10 @@ type alias DashboardStats =
 
     -- UTC Date and time on which statistics were generated.
     , timestamp : String
+
+    -- The month the statistics were generated in. Monthly figures are numbered
+    -- from it, so it is the month they are read against.
+    , statsGeneratedMonth : Maybe Int
     }
 
 

--- a/client/src/elm/Pages/Dashboard/Test.elm
+++ b/client/src/elm/Pages/Dashboard/Test.elm
@@ -1,10 +1,15 @@
 module Pages.Dashboard.Test exposing (all)
 
 import AssocList as Dict
-import Backend.Dashboard.Model exposing (CaseManagement, CaseNutrition, NutritionStatus(..), NutritionValue)
+import Backend.Dashboard.Decoder exposing (decodeDashboardStatsRaw)
+import Backend.Dashboard.Encoder exposing (encodeDashboardStatsRaw)
+import Backend.Dashboard.Model exposing (CaseManagement, CaseNutrition, DashboardStatsRaw, NutritionStatus(..), NutritionValue)
 import Backend.Measurement.Model exposing (Gender(..))
 import Date
 import Expect
+import Gizra.NominalDate exposing (NominalDate)
+import Json.Decode
+import Json.Encode
 import Pages.Dashboard.Utils exposing (caseManagementMergeDuplicates)
 import Test exposing (Test, describe, test)
 import Time
@@ -75,8 +80,56 @@ caseManagementMergeDuplicatesTest =
         ]
 
 
+generatedOn : NominalDate
+generatedOn =
+    Date.fromCalendarDate 2026 Time.Jul 15
+
+
+statsWithGenerationDate : DashboardStatsRaw
+statsWithGenerationDate =
+    { caseManagement = { thisYear = Dict.empty, lastYear = Dict.empty }
+    , childrenBeneficiaries = Dict.empty
+    , completedPrograms = []
+    , familyPlanning = []
+    , missedSessions = []
+    , totalEncounters = { global = Dict.empty, villages = Dict.empty }
+    , acuteIllnessData = []
+    , prenatalData = []
+    , ncdData = []
+    , pmtctData = []
+    , spvData = []
+    , childScoreboardData = []
+    , nutritionIndividualData = []
+    , nutritionGroupData = []
+    , groupEducationData = Dict.empty
+    , villagesWithResidents = Dict.empty
+    , patientsDetails = Dict.empty
+    , timestamp = "15-07-2026, 09:49"
+    , statsGeneratedDate = Just generatedOn
+    , cacheHash = "hash"
+    }
+
+
+statsStorageRoundTripTest : Test
+statsStorageRoundTripTest =
+    describe "encodeDashboardStatsRaw"
+        [ test "keeps the generation date, which the monthly figures are read against" <|
+            \_ ->
+                -- Downloaded statistics are re-encoded through this function
+                -- before being stored, and decoded again on the next start. A
+                -- field the encoder drops is gone from then on.
+                statsWithGenerationDate
+                    |> encodeDashboardStatsRaw
+                    |> Json.Encode.object
+                    |> Json.Decode.decodeValue decodeDashboardStatsRaw
+                    |> Result.map .statsGeneratedDate
+                    |> Expect.equal (Ok (Just generatedOn))
+        ]
+
+
 all : Test
 all =
     describe "Pages.Dashboard.Utils"
         [ caseManagementMergeDuplicatesTest
+        , statsStorageRoundTripTest
         ]

--- a/client/src/elm/Pages/Dashboard/Utils.elm
+++ b/client/src/elm/Pages/Dashboard/Utils.elm
@@ -1232,7 +1232,7 @@ generateNutritionPageData currentDate stats programTypeFilter selectedVillageFil
     , totalEncounters = generateTotalEncounters currentPeriodStats.totalEncounters programTypeFilter selectedVillageFilter
     , totalsGraphData = totalsGraphData
     , newCasesGraphData = newCasesGraphData
-    , statsMonth = statsMonth
+    , statsGeneratedDate = stats.statsGeneratedDate
     }
 
 

--- a/client/src/elm/Pages/Dashboard/Utils.elm
+++ b/client/src/elm/Pages/Dashboard/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.Dashboard.Utils exposing (applyGenderFilter, caseManagementMergeDuplicates, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeFromString, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generateAssembledData, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, resolveStatsMonth, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
+module Pages.Dashboard.Utils exposing (applyGenderFilter, caseManagementMergeDuplicates, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeFromString, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generateAssembledData, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, resolveStatsDate, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
 
 import AssocList as Dict exposing (Dict)
 import Backend.AcuteIllnessEncounter.Types exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterType(..))
@@ -188,7 +188,7 @@ generateFilteredDashboardStats stats programTypeFilter selectedVillageFilter =
     , missedSessions = stats.missedSessions
     , totalEncounters = stats.totalEncounters
     , timestamp = stats.timestamp
-    , statsGeneratedMonth = stats.statsGeneratedMonth
+    , statsGeneratedDate = stats.statsGeneratedDate
     }
 
 
@@ -1193,7 +1193,9 @@ generateNutritionPageData : NominalDate -> DashboardStats -> FilterProgramType -
 generateNutritionPageData currentDate stats programTypeFilter selectedVillageFilter =
     let
         statsMonth =
-            resolveStatsMonth currentDate stats.statsGeneratedMonth
+            resolveStatsDate currentDate stats.statsGeneratedDate
+                |> Date.month
+                |> Date.monthToNumber
 
         currentPeriodStats =
             filterStatsWithinPeriod currentDate OneYear stats
@@ -1234,15 +1236,13 @@ generateNutritionPageData currentDate stats programTypeFilter selectedVillageFil
     }
 
 
-{-| The month monthly figures are numbered from, which is the month the
-statistics were computed in rather than today. Statistics that do not carry it
-are read against the current month, as they were before it was sent.
+{-| The date monthly figures are counted and numbered from, which is the date
+the statistics were computed on rather than today. Statistics that do not carry
+it are read against today, as they were before it was sent.
 -}
-resolveStatsMonth : NominalDate -> Maybe Int -> Int
-resolveStatsMonth currentDate statsGeneratedMonth =
-    Maybe.withDefault
-        (Date.month currentDate |> Date.monthToNumber)
-        statsGeneratedMonth
+resolveStatsDate : NominalDate -> Maybe NominalDate -> NominalDate
+resolveStatsDate currentDate statsGeneratedDate =
+    Maybe.withDefault currentDate statsGeneratedDate
 
 
 generateTotalBeneficiariesMonthlyDuringPastYear :
@@ -1251,8 +1251,11 @@ generateTotalBeneficiariesMonthlyDuringPastYear :
     -> Dict Int Int
 generateTotalBeneficiariesMonthlyDuringPastYear currentDate stats =
     let
+        statsDate =
+            resolveStatsDate currentDate stats.statsGeneratedDate
+
         currentMonth =
-            resolveStatsMonth currentDate stats.statsGeneratedMonth
+            Date.month statsDate |> Date.monthToNumber
 
         ( thisYear, lastYear ) =
             List.repeat 12 0
@@ -1265,11 +1268,11 @@ generateTotalBeneficiariesMonthlyDuringPastYear currentDate stats =
             (\index month ->
                 let
                     maxJoinDate =
-                        Date.add Months (-1 * index) currentDate
+                        Date.add Months (-1 * index) statsDate
                             |> toLastDayOfMonth
 
                     minGraduationDate =
-                        Date.add Months (-1 * index) currentDate
+                        Date.add Months (-1 * index) statsDate
                             |> Date.floor Date.Month
 
                     totalBeneficiaries =

--- a/client/src/elm/Pages/Dashboard/Utils.elm
+++ b/client/src/elm/Pages/Dashboard/Utils.elm
@@ -1,4 +1,4 @@
-module Pages.Dashboard.Utils exposing (applyGenderFilter, caseManagementMergeDuplicates, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeFromString, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generateAssembledData, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
+module Pages.Dashboard.Utils exposing (applyGenderFilter, caseManagementMergeDuplicates, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeFromString, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generateAssembledData, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, resolveStatsMonth, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
 
 import AssocList as Dict exposing (Dict)
 import Backend.AcuteIllnessEncounter.Types exposing (AcuteIllnessDiagnosis(..), AcuteIllnessEncounterType(..))
@@ -188,6 +188,7 @@ generateFilteredDashboardStats stats programTypeFilter selectedVillageFilter =
     , missedSessions = stats.missedSessions
     , totalEncounters = stats.totalEncounters
     , timestamp = stats.timestamp
+    , statsGeneratedMonth = stats.statsGeneratedMonth
     }
 
 
@@ -1191,6 +1192,9 @@ getAcuteIllnessFollowUpsBreakdownByDiagnosis currentDate limitDate db villageId 
 generateNutritionPageData : NominalDate -> DashboardStats -> FilterProgramType -> Maybe VillageId -> NutritionPageData
 generateNutritionPageData currentDate stats programTypeFilter selectedVillageFilter =
     let
+        statsMonth =
+            resolveStatsMonth currentDate stats.statsGeneratedMonth
+
         currentPeriodStats =
             filterStatsWithinPeriod currentDate OneYear stats
 
@@ -1217,7 +1221,7 @@ generateNutritionPageData currentDate stats programTypeFilter selectedVillageFil
 
         newCasesGraphData =
             stats.caseManagement.thisYear
-                |> List.map (.nutrition >> generateCaseNutritionNewCases currentDate)
+                |> List.map (.nutrition >> generateCaseNutritionNewCases statsMonth)
                 |> List.foldl accumCaseNutritionTotals emptyTotalBeneficiariesDict
                 |> applyTotalBeneficiariesDenomination totalBeneficiariesMonthlyDuringPastYear
     in
@@ -1226,7 +1230,19 @@ generateNutritionPageData currentDate stats programTypeFilter selectedVillageFil
     , totalEncounters = generateTotalEncounters currentPeriodStats.totalEncounters programTypeFilter selectedVillageFilter
     , totalsGraphData = totalsGraphData
     , newCasesGraphData = newCasesGraphData
+    , statsMonth = statsMonth
     }
+
+
+{-| The month monthly figures are numbered from, which is the month the
+statistics were computed in rather than today. Statistics that do not carry it
+are read against the current month, as they were before it was sent.
+-}
+resolveStatsMonth : NominalDate -> Maybe Int -> Int
+resolveStatsMonth currentDate statsGeneratedMonth =
+    Maybe.withDefault
+        (Date.month currentDate |> Date.monthToNumber)
+        statsGeneratedMonth
 
 
 generateTotalBeneficiariesMonthlyDuringPastYear :
@@ -1236,8 +1252,7 @@ generateTotalBeneficiariesMonthlyDuringPastYear :
 generateTotalBeneficiariesMonthlyDuringPastYear currentDate stats =
     let
         currentMonth =
-            Date.month currentDate
-                |> Date.monthToNumber
+            resolveStatsMonth currentDate stats.statsGeneratedMonth
 
         ( thisYear, lastYear ) =
             List.repeat 12 0
@@ -1310,13 +1325,9 @@ generateCaseNutritionTotals caseNutrition =
     }
 
 
-generateCaseNutritionNewCases : NominalDate -> CaseNutrition -> CaseNutritionTotal
-generateCaseNutritionNewCases currentDate caseNutrition =
+generateCaseNutritionNewCases : Int -> CaseNutrition -> CaseNutritionTotal
+generateCaseNutritionNewCases currentMonth caseNutrition =
     let
-        currentMonth =
-            Date.month currentDate
-                |> Date.monthToNumber
-
         generateTotals nutrition =
             let
                 sorted =

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -51,7 +51,7 @@ import Maybe.Extra exposing (isJust, isNothing)
 import Measurement.Utils exposing (generateFutureVaccinationsData)
 import Pages.Dashboard.GraphUtils exposing (barChartHeight, barChartWidth, column, familyPlanningSignToColor, familyPlanningSignsColors, feverCauseToColor, feverCausesColors, gridXScale, gridYScale, padding, pieChartHeight, pieChartWidth, radius, xAxis, xGridLine, xScale, yAxis, yGridLine)
 import Pages.Dashboard.Model exposing (BeneficiariesTableLabels(..), CardValueSeverity(..), DashboardFilter(..), DashboardSubFilter(..), FamilyPlanningSignsCounter, FeverCause(..), FilterGender(..), FilterPeriod(..), FilterProgramType(..), FilterType(..), MalnorishedNutritionData, ModalState(..), Model, MonthlyChartType(..), Msg(..), StatsCard, caseManagementFilters, caseManagementSubFilters, filterGenders, filterPeriodsForStatsPage, maxMonthGap, monthlyChartFilters)
-import Pages.Dashboard.Utils exposing (applyGenderFilter, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, resolveStatsMonth, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
+import Pages.Dashboard.Utils exposing (applyGenderFilter, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, resolveStatsDate, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
 import Pages.Page
     exposing
         ( AcuteIllnessSubPage(..)
@@ -330,8 +330,11 @@ viewStatsPage language currentDate stats model =
 
     else
         let
+            statsDate =
+                resolveStatsDate currentDate stats.statsGeneratedDate
+
             currentMonth =
-                resolveStatsMonth currentDate stats.statsGeneratedMonth
+                Date.month statsDate |> Date.monthToNumber
 
             ( modelWithLastMonth, displayedMonth ) =
                 if model.period == ThisMonth then
@@ -341,10 +344,10 @@ viewStatsPage language currentDate stats model =
                     ( { model | period = ThreeMonthsAgo }, resolvePreviousMonth currentMonth )
 
             currentPeriodStats =
-                filterStatsWithinPeriod currentDate model.period stats
+                filterStatsWithinPeriod statsDate model.period stats
 
             monthBeforeStats =
-                filterStatsWithinPeriod currentDate modelWithLastMonth.period stats
+                filterStatsWithinPeriod statsDate modelWithLastMonth.period stats
 
             malnourishedCurrentMonth =
                 mapMalnorishedByMonth displayedMonth currentPeriodStats.caseManagement.thisYear
@@ -426,7 +429,9 @@ viewCaseManagementPage language currentDate stats patientsDetails model =
     else
         let
             currentMonth =
-                resolveStatsMonth currentDate stats.statsGeneratedMonth
+                resolveStatsDate currentDate stats.statsGeneratedDate
+                    |> Date.month
+                    |> Date.monthToNumber
 
             tableDataUnsorted =
                 case model.currentCaseManagementFilter of

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -330,16 +330,22 @@ viewStatsPage language currentDate stats model =
 
     else
         let
-            currentMonth =
-                Date.month currentDate
+            -- The monthly figures below are numbered by the month they were
+            -- computed in, so that is the month they are looked up by. The
+            -- records are filtered by their own dates, which are read against
+            -- today: filtering them from the month of computation would hide
+            -- the ones recorded after it.
+            statsMonth =
+                resolveStatsDate currentDate stats.statsGeneratedDate
+                    |> Date.month
                     |> Date.monthToNumber
 
             ( modelWithLastMonth, displayedMonth ) =
                 if model.period == ThisMonth then
-                    ( { model | period = LastMonth }, currentMonth )
+                    ( { model | period = LastMonth }, statsMonth )
 
                 else
-                    ( { model | period = ThreeMonthsAgo }, resolvePreviousMonth currentMonth )
+                    ( { model | period = ThreeMonthsAgo }, resolvePreviousMonth statsMonth )
 
             currentPeriodStats =
                 filterStatsWithinPeriod currentDate model.period stats

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -51,7 +51,7 @@ import Maybe.Extra exposing (isJust, isNothing)
 import Measurement.Utils exposing (generateFutureVaccinationsData)
 import Pages.Dashboard.GraphUtils exposing (barChartHeight, barChartWidth, column, familyPlanningSignToColor, familyPlanningSignsColors, feverCauseToColor, feverCausesColors, gridXScale, gridYScale, padding, pieChartHeight, pieChartWidth, radius, xAxis, xGridLine, xScale, yAxis, yGridLine)
 import Pages.Dashboard.Model exposing (BeneficiariesTableLabels(..), CardValueSeverity(..), DashboardFilter(..), DashboardSubFilter(..), FamilyPlanningSignsCounter, FeverCause(..), FilterGender(..), FilterPeriod(..), FilterProgramType(..), FilterType(..), MalnorishedNutritionData, ModalState(..), Model, MonthlyChartType(..), Msg(..), StatsCard, caseManagementFilters, caseManagementSubFilters, filterGenders, filterPeriodsForStatsPage, maxMonthGap, monthlyChartFilters)
-import Pages.Dashboard.Utils exposing (applyGenderFilter, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
+import Pages.Dashboard.Utils exposing (applyGenderFilter, countAcuteIllnessAssessments, countAcuteIllnessCasesByPossibleDiagnosises, countAcuteIllnessCasesByTreatmentApproach, countAcuteIllnessDiagnosedCases, countComplicatedGISentToHC, countComplicatedMalariaSentToHC, countCurrentlyPregnantForSelectedMonth, countCurrentlyPregnantWithDangerSignsForSelectedMonth, countDeliveriesAtLocationForSelectedMonth, countDiagnosedWithCovidCallsTo114, countDiagnosedWithCovidManagedAtHome, countDiagnosedWithCovidSentToHC, countDiagnosedWithGI, countDiagnosedWithMalaria, countHospitalReferralsForSelectedMonth, countNewbornForSelectedMonth, countNewlyIdentifieHypertensionCasesForSelectedMonth, countNewlyIdentifiedDiabetesCasesForSelectedMonth, countNewlyIdentifiedPregananciesForSelectedMonth, countPregnanciesDueWithin4MonthsForSelectedMonth, countPregnanciesWith4VisitsOrMoreForSelectedMonth, countResolvedGICasesForSelectedMonth, countResolvedMalariaCasesForSelectedMonth, countTotalNumberOfPatientsWithDiabetes, countTotalNumberOfPatientsWithGestationalDiabetes, countTotalNumberOfPatientsWithHypertension, countUncomplicatedGIManagedByChw, countUncomplicatedMalariaAndPregnantSentToHC, countUncomplicatedMalariaManagedByChw, countUncomplicatedMalariaSentToHC, filterNewlyDiagnosesCasesForSelectedMonth, filterNewlyDiagnosesMalnutritionForSelectedMonth, filterProgramTypeToString, filterStatsByGender, filterStatsWithinPeriod, generatePatientsWithHIV, generateVaccinationProgressDict, getAcuteIllnessFollowUpsBreakdownByDiagnosis, getEncountersForSelectedMonth, getFollowUpsTotals, isAcuteIllnessNurseEncounter, isNurseEncounter, resolveStatsMonth, withinOrAfterSelectedMonth, withinOrBeforeSelectedMonth, withinSelectedMonth)
 import Pages.Page
     exposing
         ( AcuteIllnessSubPage(..)
@@ -314,7 +314,7 @@ viewNutritionPage :
 viewNutritionPage language currentDate activePage stats patientsDetails data model =
     case activePage of
         PageCharts ->
-            viewNutritionChartsPage language currentDate data model
+            viewNutritionChartsPage language data model
 
         PageStats ->
             viewStatsPage language currentDate stats model
@@ -331,8 +331,7 @@ viewStatsPage language currentDate stats model =
     else
         let
             currentMonth =
-                Date.month currentDate
-                    |> Date.monthToNumber
+                resolveStatsMonth currentDate stats.statsGeneratedMonth
 
             ( modelWithLastMonth, displayedMonth ) =
                 if model.period == ThisMonth then
@@ -427,8 +426,7 @@ viewCaseManagementPage language currentDate stats patientsDetails model =
     else
         let
             currentMonth =
-                Date.month currentDate
-                    |> Date.monthToNumber
+                resolveStatsMonth currentDate stats.statsGeneratedMonth
 
             tableDataUnsorted =
                 case model.currentCaseManagementFilter of
@@ -1103,8 +1101,8 @@ viewGastroPage language isChw dateLastDayOfSelectedMonth acuteIllnessData encoun
         ]
 
 
-viewNutritionChartsPage : Language -> NominalDate -> NutritionPageData -> Model -> List (Html Msg)
-viewNutritionChartsPage language currentDate data model =
+viewNutritionChartsPage : Language -> NutritionPageData -> Model -> List (Html Msg)
+viewNutritionChartsPage language data model =
     let
         links =
             case model.programTypeFilter of
@@ -1124,10 +1122,10 @@ viewNutritionChartsPage language currentDate data model =
             [ viewTotalEncounters language data.totalEncounters
             ]
         , div [ class "sixteen wide column" ]
-            [ viewMonthlyChart language currentDate MonthlyChartTotals FilterBeneficiariesChart data.totalsGraphData model.currentBeneficiariesChartsFilter
+            [ viewMonthlyChart language data.statsMonth MonthlyChartTotals FilterBeneficiariesChart data.totalsGraphData model.currentBeneficiariesChartsFilter
             ]
         , div [ class "sixteen wide column" ]
-            [ viewMonthlyChart language currentDate MonthlyChartIncidence FilterBeneficiariesIncidenceChart data.newCasesGraphData model.currentBeneficiariesIncidenceChartsFilter
+            [ viewMonthlyChart language data.statsMonth MonthlyChartIncidence FilterBeneficiariesIncidenceChart data.newCasesGraphData model.currentBeneficiariesIncidenceChartsFilter
             ]
         , links
         ]
@@ -2017,13 +2015,9 @@ viewFamilyPlanning language stats =
         ]
 
 
-viewMonthlyChart : Language -> NominalDate -> MonthlyChartType -> FilterType -> Dict Int TotalBeneficiaries -> DashboardFilter -> Html Msg
-viewMonthlyChart language currentDate chartType filterType data currentFilter =
+viewMonthlyChart : Language -> Int -> MonthlyChartType -> FilterType -> Dict Int TotalBeneficiaries -> DashboardFilter -> Html Msg
+viewMonthlyChart language currentMonth chartType filterType data currentFilter =
     let
-        currentMonth =
-            Date.month currentDate
-                |> Date.monthToNumber
-
         ( thisYear, lastYear ) =
             data
                 |> Dict.toList

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -314,7 +314,7 @@ viewNutritionPage :
 viewNutritionPage language currentDate activePage stats patientsDetails data model =
     case activePage of
         PageCharts ->
-            viewNutritionChartsPage language data model
+            viewNutritionChartsPage language currentDate data model
 
         PageStats ->
             viewStatsPage language currentDate stats model
@@ -330,11 +330,9 @@ viewStatsPage language currentDate stats model =
 
     else
         let
-            statsDate =
-                resolveStatsDate currentDate stats.statsGeneratedDate
-
             currentMonth =
-                Date.month statsDate |> Date.monthToNumber
+                Date.month currentDate
+                    |> Date.monthToNumber
 
             ( modelWithLastMonth, displayedMonth ) =
                 if model.period == ThisMonth then
@@ -344,10 +342,10 @@ viewStatsPage language currentDate stats model =
                     ( { model | period = ThreeMonthsAgo }, resolvePreviousMonth currentMonth )
 
             currentPeriodStats =
-                filterStatsWithinPeriod statsDate model.period stats
+                filterStatsWithinPeriod currentDate model.period stats
 
             monthBeforeStats =
-                filterStatsWithinPeriod statsDate modelWithLastMonth.period stats
+                filterStatsWithinPeriod currentDate modelWithLastMonth.period stats
 
             malnourishedCurrentMonth =
                 mapMalnorishedByMonth displayedMonth currentPeriodStats.caseManagement.thisYear
@@ -1106,8 +1104,15 @@ viewGastroPage language isChw dateLastDayOfSelectedMonth acuteIllnessData encoun
         ]
 
 
-viewNutritionChartsPage : Language -> NutritionPageData -> Model -> List (Html Msg)
-viewNutritionChartsPage language data model =
+chartsMonth : NominalDate -> NutritionPageData -> Int
+chartsMonth currentDate data =
+    resolveStatsDate currentDate data.statsGeneratedDate
+        |> Date.month
+        |> Date.monthToNumber
+
+
+viewNutritionChartsPage : Language -> NominalDate -> NutritionPageData -> Model -> List (Html Msg)
+viewNutritionChartsPage language currentDate data model =
     let
         links =
             case model.programTypeFilter of
@@ -1127,10 +1132,10 @@ viewNutritionChartsPage language data model =
             [ viewTotalEncounters language data.totalEncounters
             ]
         , div [ class "sixteen wide column" ]
-            [ viewMonthlyChart language data.statsMonth MonthlyChartTotals FilterBeneficiariesChart data.totalsGraphData model.currentBeneficiariesChartsFilter
+            [ viewMonthlyChart language (chartsMonth currentDate data) MonthlyChartTotals FilterBeneficiariesChart data.totalsGraphData model.currentBeneficiariesChartsFilter
             ]
         , div [ class "sixteen wide column" ]
-            [ viewMonthlyChart language data.statsMonth MonthlyChartIncidence FilterBeneficiariesIncidenceChart data.newCasesGraphData model.currentBeneficiariesIncidenceChartsFilter
+            [ viewMonthlyChart language (chartsMonth currentDate data) MonthlyChartIncidence FilterBeneficiariesIncidenceChart data.newCasesGraphData model.currentBeneficiariesIncidenceChartsFilter
             ]
         , links
         ]

--- a/client/src/elm/Pages/Dashboard/View.elm
+++ b/client/src/elm/Pages/Dashboard/View.elm
@@ -1104,16 +1104,14 @@ viewGastroPage language isChw dateLastDayOfSelectedMonth acuteIllnessData encoun
         ]
 
 
-chartsMonth : NominalDate -> NutritionPageData -> Int
-chartsMonth currentDate data =
-    resolveStatsDate currentDate data.statsGeneratedDate
-        |> Date.month
-        |> Date.monthToNumber
-
-
 viewNutritionChartsPage : Language -> NominalDate -> NutritionPageData -> Model -> List (Html Msg)
 viewNutritionChartsPage language currentDate data model =
     let
+        chartsMonth =
+            resolveStatsDate currentDate data.statsGeneratedDate
+                |> Date.month
+                |> Date.monthToNumber
+
         links =
             case model.programTypeFilter of
                 FilterProgramFbf ->
@@ -1132,10 +1130,10 @@ viewNutritionChartsPage language currentDate data model =
             [ viewTotalEncounters language data.totalEncounters
             ]
         , div [ class "sixteen wide column" ]
-            [ viewMonthlyChart language (chartsMonth currentDate data) MonthlyChartTotals FilterBeneficiariesChart data.totalsGraphData model.currentBeneficiariesChartsFilter
+            [ viewMonthlyChart language chartsMonth MonthlyChartTotals FilterBeneficiariesChart data.totalsGraphData model.currentBeneficiariesChartsFilter
             ]
         , div [ class "sixteen wide column" ]
-            [ viewMonthlyChart language (chartsMonth currentDate data) MonthlyChartIncidence FilterBeneficiariesIncidenceChart data.newCasesGraphData model.currentBeneficiariesIncidenceChartsFilter
+            [ viewMonthlyChart language chartsMonth MonthlyChartIncidence FilterBeneficiariesIncidenceChart data.newCasesGraphData model.currentBeneficiariesIncidenceChartsFilter
             ]
         , links
         ]

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -3894,7 +3894,7 @@ function hedley_stats_handle_cache($method, $cache_name, $health_center_id, $per
 
     case HEDLEY_STATS_CACHE_GET_TIMESTAMP:
       $cached = cache_get($cache_id);
-      return !empty($cached) ? $cached->data['timestamp'] : NULL;
+      return isset($cached->data['timestamp']) ? $cached->data['timestamp'] : NULL;
 
     case HEDLEY_STATS_CACHE_SET:
       $cached = [

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -66,6 +66,7 @@ define('HEDLEY_STATS_SYNC_PATIENTS_DETAILS', 'patients_details');
 
 // Cache methods.
 define('HEDLEY_STATS_CACHE_GET', 'get');
+define('HEDLEY_STATS_CACHE_GET_TIMESTAMP', 'get_timestamp');
 define('HEDLEY_STATS_CACHE_SET', 'set');
 define('HEDLEY_STATS_CACHE_CLEAR', 'clear');
 
@@ -831,10 +832,19 @@ function hedley_stats_pull_stats_for_health_center($health_center_id, $health_ce
     'patients_details' => $patients_details,
   ];
 
-  $now = time();
+  // The sections above are read from cache, so the moment they were computed
+  // is the moment the cache entry was written, not now. The monthly figures
+  // are numbered by the month they were computed in, so the client needs that
+  // month to place them. Cached sections are written in one pass, so the case
+  // management entry dates all of them.
+  $generated = hedley_stats_handle_cache(HEDLEY_STATS_CACHE_GET_TIMESTAMP, HEDLEY_STATS_SYNC_CASE_MANAGEMENT, $health_center_id, HEDLEY_STATS_PERIOD_ONE_YEAR);
+  if (empty($generated)) {
+    $generated = time();
+  }
+  $generated_utc = $generated - date('Z');
   // UTC date and time on which statistics were generated.
-  $timestamp = date('d-m-Y, H:i', $now - date('Z'));
-  $stats['timestamp'] = $timestamp;
+  $stats['timestamp'] = date('d-m-Y, H:i', $generated_utc);
+  $stats['stats_generated_month'] = (int) date('n', $generated_utc);
   // Update client of current hash for health center statistics.
   $stats['stats_cache_hash'] = $health_center_cached_hash;
 
@@ -3883,6 +3893,10 @@ function hedley_stats_handle_cache($method, $cache_name, $health_center_id, $per
     case HEDLEY_STATS_CACHE_GET:
       $cached = cache_get($cache_id);
       return !empty($cached) ? $cached->data['value'] : NULL;
+
+    case HEDLEY_STATS_CACHE_GET_TIMESTAMP:
+      $cached = cache_get($cache_id);
+      return !empty($cached) ? $cached->data['timestamp'] : NULL;
 
     case HEDLEY_STATS_CACHE_SET:
       $cached = [

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -832,19 +832,17 @@ function hedley_stats_pull_stats_for_health_center($health_center_id, $health_ce
     'patients_details' => $patients_details,
   ];
 
-  // The sections above are read from cache, so the moment they were computed
-  // is the moment the cache entry was written, not now. The monthly figures
-  // are numbered by the month they were computed in, so the client needs that
-  // month to place them. Cached sections are written in one pass, so the case
-  // management entry dates all of them.
-  $generated = hedley_stats_handle_cache(HEDLEY_STATS_CACHE_GET_TIMESTAMP, HEDLEY_STATS_SYNC_CASE_MANAGEMENT, $health_center_id, HEDLEY_STATS_PERIOD_ONE_YEAR);
-  if (empty($generated)) {
-    $generated = time();
-  }
-  $generated_utc = $generated - date('Z');
+  $now = time();
   // UTC date and time on which statistics were generated.
-  $stats['timestamp'] = date('d-m-Y, H:i', $generated_utc);
-  $stats['stats_generated_month'] = (int) date('n', $generated_utc);
+  $timestamp = date('d-m-Y, H:i', $now - date('Z'));
+  $stats['timestamp'] = $timestamp;
+
+  // The monthly figures are numbered by the month they were computed in, so
+  // the client needs that date to place them. It is the date the case
+  // management entry was cached, and it is read in the same local time the
+  // months are numbered in.
+  $generated = hedley_stats_handle_cache(HEDLEY_STATS_CACHE_GET_TIMESTAMP, HEDLEY_STATS_SYNC_CASE_MANAGEMENT, $health_center_id, HEDLEY_STATS_PERIOD_ONE_YEAR);
+  $stats['stats_generated_date'] = date('Y-m-d', empty($generated) ? $now : $generated);
   // Update client of current hash for health center statistics.
   $stats['stats_cache_hash'] = $health_center_cached_hash;
 


### PR DESCRIPTION
Fixes #2089

Statistics carry the date they were computed on, and the figures that are numbered by month are looked up by its month: the beneficiary counts and their labels, the new-case ordering, the malnourished cards on the FBF statistics page, the case management table's three months, and the two nutrition charts. A health center whose statistics were computed in an earlier month reads those against that month, so a figure and its label describe the same month.

Records carrying their own dates keep being filtered by today. Filtering those from the date of computation would hide the records made after it, and the sections they come from have their own caches and can be newer.

The date is stored alongside the statistics, so it survives the app being restarted, and it is read in the same local time the month buckets are numbered in.

`HEDLEY_STATS_CACHE_GET_TIMESTAMP` reads the generation time that `HEDLEY_STATS_CACHE_SET` already records.

Statistics without the date are read against today, as they were before it was sent, so a client and a server on different versions behave as they do today. The month buckets keep their existing numbering, which clients parse into integers: renumbering them would silently collapse every month into one on any client that had not updated.

Where a page shows both — the FBF beneficiaries table divides bucketed figures by a count of dated records — the two describe different months while a cache is a month old, and no choice of month reconciles them.

"Last updated" is unchanged. It reports when the statistics were served, and the sections behind it are refreshed independently, so no single moment describes them all.