### PR TITLE
Dashboard stats: stop a second measurement at one encounter from breaking the figures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Avoid code duplication. Extract shared logic into common functions rather than c
 
 The same principle applies to issue and PR text: describe the current state, not how it came to be.
 
-- The title names the defect from the reader's side, not the mechanism chosen to fix it. Someone scanning the merge log should learn what was wrong. "Stop a person edit from erasing recorded GPS coordinates", not "Carry stored coordinates in PatchPerson".
+- The title starts with the feature area, then names the defect from the reader's side, not the mechanism chosen to fix it: `<Feature area>: <what was wrong>`. Someone scanning the merge log should learn both where the problem was and what it was. "Dashboard stats: stop stale month figures being read as this month's", not "Anchor the month split on stats.timestamp", and not "Stop stale month figures being read as this month's".
 - An issue describes what is wrong and how to see it. A PR describes what the change makes true.
 - **No verification sections.** Do not list how the change was tested, which commands were run, or what they printed. CI reports that, and it is noise in the permanent record.
 - No process narrative — no review rounds, no "the first attempt did X", no account of what was tried and abandoned.

--- a/server/hedley/HedleyWebTestBase.inc
+++ b/server/hedley/HedleyWebTestBase.inc
@@ -538,7 +538,7 @@ class HedleyWebTestBase extends DrupalWebTestCase {
   /**
    * Create an acute illness vitals entity.
    */
-  public function createAcuteIllnessVitals($encounter_id, $person_id, $timestamp = REQUEST_TIME) {
+  public function createAcuteIllnessVitals($encounter_id, $person_id, $timestamp = REQUEST_TIME, $temperature = 37.2) {
     $node = $this->drupalCreateNode(['type' => 'acute_illness_vitals']);
 
     $wrapper = entity_metadata_wrapper('node', $node);
@@ -549,7 +549,7 @@ class HedleyWebTestBase extends DrupalWebTestCase {
     $wrapper->field_dia->set(70);
     $wrapper->field_heart_rate->set(80);
     $wrapper->field_respiratory_rate->set(20);
-    $wrapper->field_body_temperature->set(37.2);
+    $wrapper->field_body_temperature->set($temperature);
     $wrapper->save();
 
     return $node->nid;

--- a/server/hedley/HedleyWebTestBase.inc
+++ b/server/hedley/HedleyWebTestBase.inc
@@ -497,7 +497,7 @@ class HedleyWebTestBase extends DrupalWebTestCase {
   /**
    * Create an acute illness symptom measurement entity of given type.
    */
-  public function createAcuteIllnessSymptoms($type, $encounter_id, $person_id, $timestamp = REQUEST_TIME) {
+  public function createAcuteIllnessSymptoms($type, $encounter_id, $person_id, $timestamp = REQUEST_TIME, $fever_period = NULL) {
     $node = $this->drupalCreateNode(['type' => $type]);
 
     $wrapper = entity_metadata_wrapper('node', $node);
@@ -513,6 +513,9 @@ class HedleyWebTestBase extends DrupalWebTestCase {
         break;
 
       case 'symptoms_general':
+        if (!is_null($fever_period)) {
+          $wrapper->field_fever_period->set($fever_period);
+        }
         $wrapper->field_night_sweats_period->set(2);
         $wrapper->field_headache_period->set(2);
         $wrapper->field_poor_suck_period->set(2);
@@ -550,6 +553,39 @@ class HedleyWebTestBase extends DrupalWebTestCase {
     $wrapper->field_heart_rate->set(80);
     $wrapper->field_respiratory_rate->set(20);
     $wrapper->field_body_temperature->set($temperature);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * Create a prenatal nutrition entity.
+   */
+  public function createPrenatalNutrition($encounter_id, $person_id, $muac, $timestamp = REQUEST_TIME) {
+    $node = $this->drupalCreateNode(['type' => 'prenatal_nutrition']);
+
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_person->set($person_id);
+    $wrapper->field_date_measured->set($timestamp);
+    $wrapper->field_prenatal_encounter->set($encounter_id);
+    $wrapper->field_muac->set($muac);
+    $wrapper->save();
+
+    return $node->nid;
+  }
+
+  /**
+   * Create an NCD HIV test entity.
+   */
+  public function createNcdHivTest($encounter_id, $person_id, $result, $execution_note, $timestamp = REQUEST_TIME) {
+    $node = $this->drupalCreateNode(['type' => 'ncd_hiv_test']);
+
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $wrapper->field_person->set($person_id);
+    $wrapper->field_date_measured->set($timestamp);
+    $wrapper->field_ncd_encounter->set($encounter_id);
+    $wrapper->field_test_result->set($result);
+    $wrapper->field_test_execution_note->set($execution_note);
     $wrapper->save();
 
     return $node->nid;

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -987,15 +987,16 @@ function hedley_stats_get_acute_illness_data($health_center_id) {
   $query->addField('send_to_hc', 'field_send_to_hc_value');
   $query->addExpression("GROUP_CONCAT(DISTINCT send_to_hc.field_send_to_hc_value)", 'send_to_hc');
 
-  // Pull data of recorded fever at symptoms.
+  // Pull the longest fever reported and the highest temperature recorded at
+  // the encounter, since an encounter can hold more than one of each and it
+  // is a fever if any of them says so.
   $query->leftJoin('field_data_field_fever_period', 'fever_period', 'fever_period.entity_id = ai_encounter.entity_id');
   $query->addField('fever_period', 'field_fever_period_value');
-  $query->addExpression("GROUP_CONCAT(fever_period.field_fever_period_value)", 'fever_period');
+  $query->addExpression("MAX(fever_period.field_fever_period_value)", 'fever_period');
 
-  // Pull data of recorded fever at vitals.
   $query->leftJoin('field_data_field_body_temperature', 'body_temperature', 'body_temperature.entity_id = ai_encounter.entity_id');
   $query->addField('body_temperature', 'field_body_temperature_value');
-  $query->addExpression("GROUP_CONCAT(body_temperature.field_body_temperature_value)", 'body_temperature');
+  $query->addExpression("MAX(body_temperature.field_body_temperature_value)", 'body_temperature');
 
   // Pull data of isolations - COVID suspect.
   $query->leftJoin('field_data_field_isolation', 'isolation', 'isolation.entity_id = ai_encounter.entity_id');
@@ -1209,7 +1210,7 @@ function hedley_stats_get_prenatal_data($health_center_id) {
     }
 
     if (!empty($row->muac)) {
-      $item['muac'] = $row->muac;
+      $item['muac'] = hedley_stats_extract_first_value($row->muac);
     }
 
     $items[$row->field_individual_participant]['encounters'][] = $item;

--- a/server/hedley/modules/custom/hedley_stats/hedley_stats.module
+++ b/server/hedley/modules/custom/hedley_stats/hedley_stats.module
@@ -1395,7 +1395,7 @@ function hedley_stats_get_ncd_data($health_center_id) {
       continue;
     }
 
-    $items[$row->field_individual_participant]['encounters'][$row->nid]['hiv_test_result'] = $row->test_result;
+    $items[$row->field_individual_participant]['encounters'][$row->nid]['hiv_test_result'] = hedley_stats_extract_first_value($row->test_result);
   }
 
   $query = clone $base_query;
@@ -1425,7 +1425,7 @@ function hedley_stats_get_ncd_data($health_center_id) {
       continue;
     }
 
-    $items[$row->field_individual_participant]['encounters'][$row->nid]['hiv_test_execution_note'] = $row->test_execution_note;
+    $items[$row->field_individual_participant]['encounters'][$row->nid]['hiv_test_execution_note'] = hedley_stats_extract_first_value($row->test_execution_note);
   }
 
   foreach ($items as &$item) {

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -258,10 +258,24 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->assertFalse(empty($stats['prenatal_data']));
     $this->assertFalse(empty($stats['acute_illness_data']));
 
-    // A temperature of 38.5 was recorded at the acute illness encounter,
-    // alongside a reading below the fever threshold.
+    // One encounter recorded a temperature of 38.5 alongside a reading below
+    // the fever threshold, the other five days of fever alongside a report of
+    // none. Both are a fever.
     $acute_illness_encounters = $stats['acute_illness_data'][0]['encounters'];
-    $this->assertTrue($acute_illness_encounters[0]['fever']);
+    $this->assertEqual(count($acute_illness_encounters), 2);
+    foreach ($acute_illness_encounters as $acute_illness_encounter) {
+      $this->assertTrue($acute_illness_encounter['fever']);
+    }
+
+    // Two MUAC readings were recorded at the prenatal encounter, and two HIV
+    // tests at the NCD encounter. Each is reported as one value, since a list
+    // of them fails the dashboard's decoder.
+    $prenatal_encounter = $stats['prenatal_data'][0]['encounters'][0];
+    $this->assertTrue(in_array($prenatal_encounter['muac'], ['23.5', '24.5']));
+
+    $ncd_encounter = reset($stats['ncd_data'][0]['encounters']);
+    $this->assertTrue(in_array($ncd_encounter['hiv_test_result'], ['positive', 'negative']));
+    $this->assertTrue(in_array($ncd_encounter['hiv_test_execution_note'], ['test-performed', 'test-performed-today']));
     $this->assertFalse(empty($stats['child_scoreboard_data']));
     $this->assertFalse(empty($stats['spv_data']));
 
@@ -685,6 +699,10 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->createCoreExam('ncd_core_exam', $encounter->nid, $mother_id, $date);
     $this->createNcdVitals($encounter->nid, $mother_id, $date);
     $this->createNcdFamilyPlanning($encounter->nid, $mother_id, $date);
+    // Two tests, differing, so that the statistics are asked for one result
+    // rather than the list of them.
+    $this->createNcdHivTest($encounter->nid, $mother_id, 'positive', 'test-performed', $date);
+    $this->createNcdHivTest($encounter->nid, $mother_id, 'negative', 'test-performed-today', $date);
   }
 
   /**
@@ -723,6 +741,32 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->createAcuteIllnessVitals($encounter->nid, $child_id, $date, 38.5);
     $this->createAcuteIllnessCoreExam($encounter->nid, $child_id, $date);
     $this->createAcuteFindings($encounter->nid, $child_id, $date);
+
+    // A second encounter where no temperature reaches the fever threshold, so
+    // that the fever periods are what decides. The first of them reports no
+    // fever and the second reports five days of it.
+    $second_encounter = (object) [
+      'type' => 'acute_illness_encounter',
+      'title' => 'Acute illness encounter with a reported fever',
+      'field_individual_participant' => [
+        LANGUAGE_NONE => [
+          ['target_id' => $participant->nid],
+        ],
+      ],
+      'field_scheduled_date' => [
+        LANGUAGE_NONE => [
+          [
+            'value' => date('Y-m-d', $date),
+            'value2' => date('Y-m-d', $date),
+          ],
+        ],
+      ],
+    ];
+    node_save($second_encounter);
+
+    $this->createAcuteIllnessSymptoms('symptoms_general', $second_encounter->nid, $child_id, $date, 0);
+    $this->createAcuteIllnessSymptoms('symptoms_general', $second_encounter->nid, $child_id, $date, 5);
+    $this->createAcuteIllnessVitals($second_encounter->nid, $child_id, $date);
   }
 
   /**
@@ -752,6 +796,10 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     ];
     node_save($encounter);
 
+    // Two readings, differing, so that the statistics are asked for one value
+    // rather than the list of them.
+    $this->createPrenatalNutrition($encounter->nid, $mother_id, 23.5, $date);
+    $this->createPrenatalNutrition($encounter->nid, $mother_id, 24.5, $date);
     $this->createPrenatalBreastfeeding($encounter->nid, $mother_id, $date);
     $this->createBreastExam($encounter->nid, $mother_id, $date);
     $this->createCoreExam('core_physical_exam', $encounter->nid, $mother_id, $date);

--- a/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
+++ b/server/hedley/modules/custom/hedley_stats/tests/HedleyStatsCalculation.test
@@ -257,6 +257,11 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->assertFalse(empty($stats['ncd_data']));
     $this->assertFalse(empty($stats['prenatal_data']));
     $this->assertFalse(empty($stats['acute_illness_data']));
+
+    // A temperature of 38.5 was recorded at the acute illness encounter,
+    // alongside a reading below the fever threshold.
+    $acute_illness_encounters = $stats['acute_illness_data'][0]['encounters'];
+    $this->assertTrue($acute_illness_encounters[0]['fever']);
     $this->assertFalse(empty($stats['child_scoreboard_data']));
     $this->assertFalse(empty($stats['spv_data']));
 
@@ -712,7 +717,10 @@ class HedleyStatsCalculation extends HedleyWebTestBase {
     $this->createAcuteIllnessSymptoms('symptoms_gi', $encounter->nid, $child_id, $date);
     $this->createAcuteIllnessSymptoms('symptoms_general', $encounter->nid, $child_id, $date);
     $this->createAcuteIllnessSymptoms('symptoms_respiratory', $encounter->nid, $child_id, $date);
+    // Two measurements, the second one feverish, so that the statistics are
+    // asked which of them decides.
     $this->createAcuteIllnessVitals($encounter->nid, $child_id, $date);
+    $this->createAcuteIllnessVitals($encounter->nid, $child_id, $date, 38.5);
     $this->createAcuteIllnessCoreExam($encounter->nid, $child_id, $date);
     $this->createAcuteFindings($encounter->nid, $child_id, $date);
   }


### PR DESCRIPTION
Fixes #2092

The statistics ask for the highest temperature and the longest fever period recorded at an acute illness encounter, so a fever counts wherever in the encounter it was recorded.

The prenatal MUAC, and the HIV test result and execution note on an NCD encounter, are read through `hedley_stats_extract_first_value()`, the same way every other single measurement in this file already is, so the dashboard receives one value rather than a list. A list fails the dashboard's decoder and takes the whole health center's dashboard with it.

Every `GROUP_CONCAT` in the file is now either read as a list by its consumer or reduced to one value before it is sent.

The statistics test records two of each measurement, so each of these reads is asked which one decides: two temperatures with only the second feverish, a second encounter reporting a fever only in the later of two fever periods and no temperature reaching the threshold, two MUAC readings at a prenatal encounter, and two HIV tests at an NCD encounter. `HedleyWebTestBase` gained a prenatal nutrition and an NCD HIV test entity, which it could not create before, and its acute illness symptoms accept a fever period.

Also here, since it is a one-line convention rather than a change worth its own branch: a title in `CLAUDE.md` now starts with the feature area, so the merge log says where a defect was as well as what it was.