### PR TITLE
Immunisation: stop a child holding extra doses reading as behind for good

### DIFF
--- a/client/src/elm/Measurement/Test.elm
+++ b/client/src/elm/Measurement/Test.elm
@@ -36,6 +36,7 @@ import Measurement.Utils
         , liverFunctionResultFormWithDefault
         , ncdaFormWithDefault
         , ncdaMeasurementsOutOfRange
+        , nextVaccinationDataForVaccine
         , outOfRangeAsEntered
         , setNCDAStep
         , showNCDAMeasurementOutOfRange
@@ -210,6 +211,39 @@ getAllDosesForVaccineTest =
                         [ VaccineDoseFirst
                         , VaccineDoseSecond
                         ]
+        ]
+
+
+nextVaccinationDataForVaccineTest : Test
+nextVaccinationDataForVaccineTest =
+    let
+        birthDate =
+            Date.fromCalendarDate 2026 Time.Jan 1
+
+        lastDoseDate =
+            Date.fromCalendarDate 2026 Time.Jun 1
+
+        -- Rwanda gives three doses of DTP, four weeks apart.
+        nextDTPDose dose =
+            nextVaccinationDataForVaccine SiteRwanda (Just birthDate) VaccineDTP False lastDoseDate dose
+    in
+    describe "nextVaccinationDataForVaccine (Rwanda, DTP)"
+        [ test "a dose is due while the doses given are short of the three expected" <|
+            \_ ->
+                nextDTPDose VaccineDoseSecond
+                    |> Expect.equal
+                        (Just ( VaccineDoseThird, Date.fromCalendarDate 2026 Time.Jun 29 ))
+        , test "no dose is due once the third has been given" <|
+            \_ ->
+                nextDTPDose VaccineDoseThird
+                    |> Expect.equal Nothing
+        , test "no dose is due when more doses are recorded than the three expected" <|
+            \_ ->
+                -- A record holding a fourth dose has no dose left to receive.
+                -- Read as still owing one, the child is behind from the day the
+                -- dose that does not exist falls due, and nothing clears it.
+                nextDTPDose VaccineDoseFourth
+                    |> Expect.equal Nothing
         ]
 
 
@@ -647,7 +681,8 @@ liverFunctionResultFormWithDefaultTest =
 all : Test
 all =
     describe "Measurement of children: form tests"
-        [ viewChildFormsTest
+        [ nextVaccinationDataForVaccineTest
+        , viewChildFormsTest
         , viewMotherFormsTest
         , viewColorAlertIndicationTest
         , getIntervalForVaccineTest

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -9645,10 +9645,16 @@ nextVaccinationDataForVaccine :
 nextVaccinationDataForVaccine site maybeBirthDate vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered =
     Maybe.andThen
         (\birthDate ->
-            if vaccineDoseToComparable (getLastDoseForVaccine site initialOpvAdministered vaccineType) <= vaccineDoseToComparable lastDoseAdministered then
-                -- The course is over once the doses reach the last the site
-                -- expects. A child holding more than that has no dose left to
-                -- receive either.
+            let
+                dosesGiven =
+                    vaccineDoseToComparable lastDoseAdministered
+
+                dosesTheSiteExpects =
+                    vaccineDoseToComparable (getLastDoseForVaccine site initialOpvAdministered vaccineType)
+            in
+            if dosesGiven >= dosesTheSiteExpects then
+                -- A child holding every dose the site expects, or more, has
+                -- none left to receive.
                 Nothing
 
             else

--- a/client/src/elm/Measurement/Utils.elm
+++ b/client/src/elm/Measurement/Utils.elm
@@ -9645,7 +9645,10 @@ nextVaccinationDataForVaccine :
 nextVaccinationDataForVaccine site maybeBirthDate vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered =
     Maybe.andThen
         (\birthDate ->
-            if getLastDoseForVaccine site initialOpvAdministered vaccineType == lastDoseAdministered then
+            if vaccineDoseToComparable (getLastDoseForVaccine site initialOpvAdministered vaccineType) <= vaccineDoseToComparable lastDoseAdministered then
+                -- The course is over once the doses reach the last the site
+                -- expects. A child holding more than that has no dose left to
+                -- receive either.
                 Nothing
 
             else

--- a/server/elm/src/Pages/Scoreboard/Utils.elm
+++ b/server/elm/src/Pages/Scoreboard/Utils.elm
@@ -73,7 +73,9 @@ latestVaccinationDataForVaccine vaccinationsData vaccineType =
 
 nextVaccinationDataForVaccine : Site -> NominalDate -> VaccineType -> Bool -> NominalDate -> VaccineDose -> Maybe ( VaccineDose, NominalDate )
 nextVaccinationDataForVaccine site birthDate vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered =
-    if getLastDoseForVaccine site initialOpvAdministered vaccineType == lastDoseAdministered then
+    if vaccineDoseToComparable (getLastDoseForVaccine site initialOpvAdministered vaccineType) <= vaccineDoseToComparable lastDoseAdministered then
+        -- The course is over once the doses reach the last the site expects. A
+        -- child holding more than that has no dose left to receive either.
         Nothing
 
     else

--- a/server/elm/src/Pages/Scoreboard/Utils.elm
+++ b/server/elm/src/Pages/Scoreboard/Utils.elm
@@ -73,9 +73,16 @@ latestVaccinationDataForVaccine vaccinationsData vaccineType =
 
 nextVaccinationDataForVaccine : Site -> NominalDate -> VaccineType -> Bool -> NominalDate -> VaccineDose -> Maybe ( VaccineDose, NominalDate )
 nextVaccinationDataForVaccine site birthDate vaccineType initialOpvAdministered lastDoseDate lastDoseAdministered =
-    if vaccineDoseToComparable (getLastDoseForVaccine site initialOpvAdministered vaccineType) <= vaccineDoseToComparable lastDoseAdministered then
-        -- The course is over once the doses reach the last the site expects. A
-        -- child holding more than that has no dose left to receive either.
+    let
+        dosesGiven =
+            vaccineDoseToComparable lastDoseAdministered
+
+        dosesTheSiteExpects =
+            vaccineDoseToComparable (getLastDoseForVaccine site initialOpvAdministered vaccineType)
+    in
+    if dosesGiven >= dosesTheSiteExpects then
+        -- A child holding every dose the site expects, or more, has none left
+        -- to receive.
         Nothing
 
     else

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -5843,8 +5843,10 @@ function hedley_reports_resolve_expected_immunisations(array $possible_immunisat
     sort($doses);
     $last_dose = array_reverse($doses)[0];
     $last_dose_for_immunisation = hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered, $site);
-    // If all doses we administered, skipping to next immunisation type.
-    if ($last_dose == $last_dose_for_immunisation) {
+    // The course is over once the doses reach the last the site expects. A
+    // child holding more than that has no dose left to receive either, so
+    // skipping to next immunisation type.
+    if ((int) explode('-', $last_dose)[1] >= (int) explode('-', $last_dose_for_immunisation)[1]) {
       continue;
     }
 

--- a/server/hedley/modules/custom/hedley_reports/hedley_reports.module
+++ b/server/hedley/modules/custom/hedley_reports/hedley_reports.module
@@ -5843,15 +5843,18 @@ function hedley_reports_resolve_expected_immunisations(array $possible_immunisat
     sort($doses);
     $last_dose = array_reverse($doses)[0];
     $last_dose_for_immunisation = hedley_reports_get_last_dose_for_vaccine($immunisation_type, $initial_opv_administered, $site);
+    $last_dose_as_number = (int) explode('-', $last_dose)[1];
+
     // The course is over once the doses reach the last the site expects. A
     // child holding more than that has no dose left to receive either, so
-    // skipping to next immunisation type.
-    if ((int) explode('-', $last_dose)[1] >= (int) explode('-', $last_dose_for_immunisation)[1]) {
+    // skipping to next immunisation type. An immunisation the site says nothing
+    // about is left to the dose after the last one recorded, as before.
+    if (!empty($last_dose_for_immunisation)
+      && $last_dose_as_number >= (int) explode('-', $last_dose_for_immunisation)[1]) {
       continue;
     }
 
     // Calculating when next dose is supposed to be administered.
-    $last_dose_as_number = (int) explode('-', $last_dose)[1];
     $next_dose_as_number = $last_dose_as_number + 1;
     $last_dose_date = $performed[$last_dose];
     $interval_between_dosed = hedley_reports_get_interval_for_vaccine($immunisation_type, $site);


### PR DESCRIPTION
Fixes #2096

A course of vaccine is over once the doses recorded reach the last dose the site expects. A child holding more than that has no dose left to receive, so none is worked out for them and they no longer read as behind.

A child short of the last dose still has one due, unchanged.

The three places that work this out say the same thing: the client's encounter pages, the scoreboard, and the reports, whose immunisation figures also raise health education and a referral. Saying it in one place alone would put them back out of step with each other.