### PR TITLE
Sync: stop listing a content type that does not exist

### DIFF
--- a/client/src/js/sw.js
+++ b/client/src/js/sw.js
@@ -90,7 +90,6 @@ var tableForType = {
     health_education: 'shards',
     height: 'shards',
     hiv_diagnostics: 'shards',
-    hiv_dot: 'shards',
     hiv_encounter: 'shards',
     hiv_follow_up: 'shards',
     hiv_health_education: 'shards',


### PR DESCRIPTION
Fixes #2098

The service worker's table of content types no longer names `hiv_dot`. Every type it still names is created, sent or read somewhere.